### PR TITLE
fix(nbgv-python)!: Fix SemVer Parsing and Prerelease Mapping Logic

### DIFF
--- a/src/public/lib/nbgv-python/CHANGELOG.md
+++ b/src/public/lib/nbgv-python/CHANGELOG.md
@@ -10,12 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **BREAKING**: The `version` template field now contains the raw NBGV version string instead of the PEP 440 normalized version. Use `normalized_version` for the PEP 440 compliant string.
+- **BREAKING**: Map unrecognized prerelease labels to `.dev` suffixes to preserve version ordering (e.g., `1.0.0-ci` becomes `1.0.0.dev0+ci`, `1.0.0-ci.1` becomes `1.0.0.dev1+ci`). Complex prerelease tags that cannot be mapped will now raise an error.
 
 ### Fixed
 
 - Fix `GitVersion` mapping protocol behavior (missing keys now raise `KeyError`; iteration/length reflect all supported keys)
 - Ensure single-element version tuples are rendered with a trailing comma
 - Fix documentation links in project metadata
+- Use strict SemVer 2.0 regex for version parsing
 
 ## [1.1.0] - 2025-12-17
 

--- a/src/public/lib/nbgv-python/src/nbgv_python/runner.py
+++ b/src/public/lib/nbgv-python/src/nbgv_python/runner.py
@@ -89,20 +89,20 @@ class NbgvRunner:
     ) -> subprocess.CompletedProcess[str]:
         """Run the command and raise `NbgvCommandError` on failure."""
         full_command = (*self._command, *args)
-        process = subprocess.run(  # noqa: S603 (intentional invocation)
-            full_command,
-            cwd=_coerce_path(cwd),
-            check=False,
-            capture_output=capture_output,
-            text=True,
-        )
-        if process.returncode != 0:
-            stdout = process.stdout if capture_output else None
-            stderr = process.stderr if capture_output else None
-            raise NbgvCommandError(
-                full_command, process.returncode, stdout, stderr
+        try:
+            return subprocess.run(  # noqa: S603 (intentional invocation)
+                full_command,
+                cwd=_coerce_path(cwd),
+                check=True,
+                capture_output=capture_output,
+                text=True,
             )
-        return process
+        except subprocess.CalledProcessError as exc:
+            stdout = exc.stdout if capture_output else None
+            stderr = exc.stderr if capture_output else None
+            raise NbgvCommandError(
+                full_command, exc.returncode, stdout, stderr
+            ) from exc
 
 
 __all__ = [

--- a/src/public/lib/nbgv-python/src/nbgv_python/versioning.py
+++ b/src/public/lib/nbgv-python/src/nbgv_python/versioning.py
@@ -19,7 +19,10 @@ _LABEL_MAP = {
 }
 
 _SEMVER_PATTERN = re.compile(
-    r"^(?P<core>\d+(?:\.\d+)*)(?:-(?P<pre>[^+]+))?(?:\+(?P<local>.+))?$"
+    r"^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)"
+    r"(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)"
+    r"(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?"
+    r"(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"
 )
 
 _SPLIT_PATTERN = re.compile(r"[.\-]")
@@ -53,9 +56,12 @@ def _convert_semver_to_pep440(candidate: str) -> str | None:
     match = _SEMVER_PATTERN.match(candidate)
     if not match:
         return None
-    core = match.group("core")
-    prerelease = match.group("pre")
-    local = match.group("local")
+    major = match.group("major")
+    minor = match.group("minor")
+    patch = match.group("patch")
+    core = f"{major}.{minor}.{patch}"
+    prerelease = match.group("prerelease")
+    local = match.group("buildmetadata")
     result = core
     local_parts: list[str] = []
     if local:
@@ -78,7 +84,27 @@ def _convert_prerelease(text: str) -> tuple[str, list[str]] | None:
     tokens = [token for token in _SPLIT_PATTERN.split(text) if token]
     if not tokens:
         return None
-    label_token = tokens[0]
+
+    label, number, extra_tokens = _parse_label_token(tokens[0])
+    remainder_tokens = extra_tokens + tokens[1:]
+
+    if label not in _LABEL_MAP:
+        return _handle_unrecognized_prerelease(
+            text, label, number, remainder_tokens
+        )
+
+    if not number:
+        number_index = _first_numeric_index(remainder_tokens)
+        if number_index is not None:
+            number = str(int(remainder_tokens.pop(number_index)))
+    if not number:
+        number = "0"
+    mapped = _LABEL_MAP[label]
+    suffix = f"{mapped}{number}"
+    return suffix, remainder_tokens
+
+
+def _parse_label_token(label_token: str) -> tuple[str, str, list[str]]:
     match = re.match(r"(?P<label>[A-Za-z]+)(?P<number>\d*)$", label_token)
     if match:
         label = match.group("label").lower()
@@ -94,18 +120,29 @@ def _convert_prerelease(text: str) -> tuple[str, list[str]] | None:
             )
             if chunk
         ]
-    remainder_tokens.extend(tokens[1:])
-    if label not in _LABEL_MAP:
-        return None
-    if not number:
-        number_index = _first_numeric_index(remainder_tokens)
-        if number_index is not None:
-            number = str(int(remainder_tokens.pop(number_index)))
-    if not number:
-        number = "0"
-    mapped = _LABEL_MAP[label]
-    suffix = f"{mapped}{number}"
-    return suffix, remainder_tokens
+    return label, number, remainder_tokens
+
+
+def _handle_unrecognized_prerelease(
+    text: str, label: str, number: str, remainder_tokens: list[str]
+) -> tuple[str, list[str]]:
+    dev_number = "0"
+    if number:
+        dev_number = number
+        if remainder_tokens:
+            _raise_complex_prerelease_error(text)
+    elif remainder_tokens:
+        if not remainder_tokens[0].isdigit():
+            _raise_complex_prerelease_error(text)
+        dev_number = remainder_tokens[0]
+        if len(remainder_tokens) > 1:
+            _raise_complex_prerelease_error(text)
+    return f".dev{dev_number}", [label]
+
+
+def _raise_complex_prerelease_error(text: str) -> None:
+    msg = f"Cannot map complex prerelease tag '{text}' to PEP 440 dev version."
+    raise RuntimeError(msg)
 
 
 def _first_numeric_index(parts: list[str]) -> int | None:

--- a/src/public/lib/nbgv-python/tests/test_versioning.py
+++ b/src/public/lib/nbgv-python/tests/test_versioning.py
@@ -15,7 +15,7 @@ from nbgv_python.versioning import normalize_version_field
         ("1.2.3-rc.4", "1.2.3rc4"),
         ("1.2.3-pre.2+sha", "1.2.3rc2+sha"),
         ("1.2.3-dev.5", "1.2.3.dev5"),
-        ("1.2.3-gabcdef", "1.2.3+gabcdef"),
+        ("1.2.3-gabcdef", "1.2.3.dev0+gabcdef"),
         ("1.2.3-alpha.1.gabcdef", "1.2.3a1+gabcdef"),
     ],
 )
@@ -28,3 +28,23 @@ def test_normalize_version_field_rejects_invalid() -> None:
     """Invalid values raise a runtime error with context."""
     with pytest.raises(RuntimeError):
         normalize_version_field("not-a-version", field="simple_version")
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        # Unrecognized prerelease label with numeric token and extra tokens.
+        "1.2.3-ci.1.extra",
+        # Unrecognized prerelease label with non-numeric remainder.
+        "1.2.3-unknown.extra",
+        # Unrecognized prerelease label with an embedded number and extra
+        # tokens.
+        "1.2.3-ci1.extra",
+    ],
+)
+def test_normalize_version_field_rejects_complex_unrecognized_prerelease(
+    value: str,
+) -> None:
+    """Complex unrecognized prerelease tags should raise a runtime error."""
+    with pytest.raises(RuntimeError):
+        normalize_version_field(value, field="simple_version")


### PR DESCRIPTION
This commit addresses several issues in the `nbgv-python` library regarding version parsing
and code quality.

BREAKING CHANGE: Unrecognized prerelease labels are now mapped to `.devN` suffixes to preserve
version ordering (e.g., `1.0.0-ci` becomes `1.0.0.dev0+ci`). Complex prerelease tags that cannot
be mapped will now raise a `RuntimeError`.

Changes:
- Update `_SEMVER_PATTERN` to strictly adhere to the SemVer 2.0 regular expression.
- Refactor `_convert_prerelease` in `versioning.py` to reduce complexity by extracting
    `_parse_label_token` and `_handle_unrecognized_prerelease` helper functions.
- Update `NbgvRunner._execute` to use `check=True` with  for more idiomatic error handling.
- Update `CHANGELOG.md` with the breaking changes and fixes.