### PR TITLE
fix(nbgv-python)!: Fix Version Rendering Errors and Improve CLI Logs

### DIFF
--- a/src/public/lib/nbgv-python/CHANGELOG.md
+++ b/src/public/lib/nbgv-python/CHANGELOG.md
@@ -11,13 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **BREAKING**: The `version` template field now contains the raw NBGV version string instead of the PEP 440 normalized version. Use `normalized_version` for the PEP 440 compliant string.
 - **BREAKING**: Map unrecognized prerelease labels to `.dev` suffixes to preserve version ordering (e.g., `1.0.0-ci` becomes `1.0.0.dev0+ci`, `1.0.0-ci.1` becomes `1.0.0.dev1+ci`). Complex prerelease tags that cannot be mapped will now raise an error.
+- **BREAKING**: Render boolean version-tuple components as Python boolean literals (`True`/`False`) instead of quoted strings.
 
 ### Fixed
 
+- Avoid accidental path duplication when invoking `nbgv get-version` with a relative project directory
 - Fix `GitVersion` mapping protocol behavior (missing keys now raise `KeyError`; iteration/length reflect all supported keys)
 - Ensure single-element version tuples are rendered with a trailing comma
 - Fix documentation links in project metadata
 - Use strict SemVer 2.0 regex for version parsing
+- Raise `NbgvVersionNormalizationError` when version normalization fails, instead of a generic `RuntimeError`.
 
 ## [1.1.0] - 2025-12-17
 

--- a/src/public/lib/nbgv-python/src/nbgv_python/__init__.py
+++ b/src/public/lib/nbgv-python/src/nbgv_python/__init__.py
@@ -14,6 +14,7 @@ from .errors import (
     NbgvError,
     NbgvJsonError,
     NbgvNotFoundError,
+    NbgvVersionNormalizationError,
 )
 from .models import GitVersion
 from .runner import NbgvRunner
@@ -37,6 +38,7 @@ __all__ = [
     "NbgvJsonError",
     "NbgvNotFoundError",
     "NbgvRunner",
+    "NbgvVersionNormalizationError",
     "TemplateFieldsConfig",
     "VersionTupleConfig",
     "WriteConfig",

--- a/src/public/lib/nbgv-python/src/nbgv_python/cli.py
+++ b/src/public/lib/nbgv-python/src/nbgv_python/cli.py
@@ -13,6 +13,9 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
 
+EXIT_CODE_NBGV_NOT_FOUND = 127
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     """Entry point used by the console script."""
     logging.basicConfig(format="%(message)s", level=logging.INFO)
@@ -20,12 +23,18 @@ def main(argv: Sequence[str] | None = None) -> int:
     try:
         runner = NbgvRunner()
         return runner.forward(arguments)
-    except NbgvNotFoundError:
-        logging.exception("nbgv executable not found")
-        return 127
+    except NbgvNotFoundError as exc:
+        logging.error(str(exc))  # noqa: TRY400
+        if exc.search_paths:
+            logging.debug("Searched PATH entries: %s", exc.search_paths)
+        return EXIT_CODE_NBGV_NOT_FOUND
     except NbgvCommandError as exc:
+        # Always log the exception so users get the command + exit code context.
+        logging.error(str(exc))  # noqa: TRY400
+        # stderr can contain additional useful details; keep it available for
+        # diagnostics without dropping the higher-level context above.
         if exc.stderr:
-            logging.exception(exc.stderr)
+            logging.debug("nbgv stderr:\n%s", exc.stderr.rstrip())
         return exc.returncode
 
 

--- a/src/public/lib/nbgv-python/src/nbgv_python/errors.py
+++ b/src/public/lib/nbgv-python/src/nbgv_python/errors.py
@@ -54,3 +54,17 @@ class NbgvJsonError(NbgvError):
         """Initialize the error with the message and raw output."""
         super().__init__(message)
         self.raw_output = raw_output
+
+
+class NbgvVersionNormalizationError(NbgvError):
+    """Raised when a version field cannot be normalized to a PEP 440 version."""
+
+    def __init__(self, *, field: str, value: object, message: str) -> None:
+        """Initialize the error.
+
+        Captures the source field name, the original value, and a human-readable
+        error message.
+        """
+        self.field = field
+        self.value = value
+        super().__init__(message)

--- a/src/public/lib/nbgv-python/src/nbgv_python/runner.py
+++ b/src/public/lib/nbgv-python/src/nbgv_python/runner.py
@@ -46,7 +46,7 @@ class NbgvRunner:
 
     def get_version(self, project_dir: Path | str = ".") -> GitVersion:
         """Return version metadata for *project_dir*."""
-        project_path = Path(project_dir)
+        project_path = Path(project_dir).expanduser().resolve(strict=False)
         args = (
             "get-version",
             "--format",
@@ -56,7 +56,7 @@ class NbgvRunner:
         )
         process = self._execute(
             args,
-            cwd=project_path,
+            cwd=None,
             capture_output=True,
         )
         if process.stdout is None:  # pragma: no cover
@@ -75,7 +75,12 @@ class NbgvRunner:
         *,
         cwd: Path | str | None = None,
     ) -> int:
-        """Forward arguments directly to `nbgv` without capturing output."""
+        """Forward arguments directly to `nbgv` without capturing output.
+
+        Raises:
+            NbgvCommandError: When the underlying CLI exits with a
+            non-zero code.
+        """
         iterable = tuple(args or ())
         process = self._execute(iterable, cwd=cwd, capture_output=False)
         return process.returncode

--- a/src/public/lib/nbgv-python/src/nbgv_python/templating.py
+++ b/src/public/lib/nbgv-python/src/nbgv_python/templating.py
@@ -166,7 +166,7 @@ def _format_component(
     double_quote: bool,
 ) -> str:
     if isinstance(value, bool):
-        return _quote(str(value).lower(), double_quote=double_quote)
+        return "True" if value else "False"
     if isinstance(value, int):
         return str(value)
     if isinstance(value, float):

--- a/src/public/lib/nbgv-python/src/nbgv_python/versioning.py
+++ b/src/public/lib/nbgv-python/src/nbgv_python/versioning.py
@@ -6,6 +6,8 @@ import re
 
 from packaging.version import InvalidVersion, Version
 
+from .errors import NbgvVersionNormalizationError
+
 _LABEL_MAP = {
     "a": "a",
     "alpha": "a",
@@ -34,8 +36,8 @@ def normalize_version_field(value: object, *, field: str) -> str:
     candidate = str(value)
     try:
         return str(Version(candidate))
-    except InvalidVersion:
-        converted = _convert_semver_to_pep440(candidate)
+    except InvalidVersion as original_exc:
+        converted = _convert_semver_to_pep440(candidate, field=field)
         if converted is not None:
             try:
                 return str(Version(converted))
@@ -44,15 +46,23 @@ def normalize_version_field(value: object, *, field: str) -> str:
                     f"Field '{field}' produced '{candidate}' which could not "
                     "be normalized to a PEP 440 version."
                 )
-                raise RuntimeError(msg) from exc
-    msg = (
-        f"Field '{field}' produced '{candidate}' which is not a valid "
-        "PEP 440 version."
-    )
-    raise RuntimeError(msg)
+                raise NbgvVersionNormalizationError(
+                    field=field,
+                    value=value,
+                    message=msg,
+                ) from exc
+        msg = (
+            f"Field '{field}' produced '{candidate}' which is not a valid "
+            "PEP 440 version."
+        )
+        raise NbgvVersionNormalizationError(
+            field=field,
+            value=value,
+            message=msg,
+        ) from original_exc
 
 
-def _convert_semver_to_pep440(candidate: str) -> str | None:
+def _convert_semver_to_pep440(candidate: str, *, field: str) -> str | None:
     match = _SEMVER_PATTERN.match(candidate)
     if not match:
         return None
@@ -67,7 +77,7 @@ def _convert_semver_to_pep440(candidate: str) -> str | None:
     if local:
         local_parts.extend(_normalize_local_parts(local))
     if prerelease:
-        pre_result = _convert_prerelease(prerelease)
+        pre_result = _convert_prerelease(prerelease, field=field)
         if pre_result is None:
             local_parts[:0] = _normalize_local_parts(prerelease)
         else:
@@ -80,7 +90,11 @@ def _convert_semver_to_pep440(candidate: str) -> str | None:
     return result
 
 
-def _convert_prerelease(text: str) -> tuple[str, list[str]] | None:
+def _convert_prerelease(
+    text: str,
+    *,
+    field: str,
+) -> tuple[str, list[str]] | None:
     tokens = [token for token in _SPLIT_PATTERN.split(text) if token]
     if not tokens:
         return None
@@ -90,7 +104,11 @@ def _convert_prerelease(text: str) -> tuple[str, list[str]] | None:
 
     if label not in _LABEL_MAP:
         return _handle_unrecognized_prerelease(
-            text, label, number, remainder_tokens
+            text,
+            label,
+            number,
+            remainder_tokens,
+            field=field,
         )
 
     if not number:
@@ -124,25 +142,34 @@ def _parse_label_token(label_token: str) -> tuple[str, str, list[str]]:
 
 
 def _handle_unrecognized_prerelease(
-    text: str, label: str, number: str, remainder_tokens: list[str]
+    text: str,
+    label: str,
+    number: str,
+    remainder_tokens: list[str],
+    *,
+    field: str,
 ) -> tuple[str, list[str]]:
     dev_number = "0"
     if number:
         dev_number = number
         if remainder_tokens:
-            _raise_complex_prerelease_error(text)
+            _raise_complex_prerelease_error(text, field=field)
     elif remainder_tokens:
         if not remainder_tokens[0].isdigit():
-            _raise_complex_prerelease_error(text)
+            _raise_complex_prerelease_error(text, field=field)
         dev_number = remainder_tokens[0]
         if len(remainder_tokens) > 1:
-            _raise_complex_prerelease_error(text)
+            _raise_complex_prerelease_error(text, field=field)
     return f".dev{dev_number}", [label]
 
 
-def _raise_complex_prerelease_error(text: str) -> None:
+def _raise_complex_prerelease_error(text: str, *, field: str) -> None:
     msg = f"Cannot map complex prerelease tag '{text}' to PEP 440 dev version."
-    raise RuntimeError(msg)
+    raise NbgvVersionNormalizationError(
+        field=field,
+        value=text,
+        message=msg,
+    )
 
 
 def _first_numeric_index(parts: list[str]) -> int | None:

--- a/src/public/lib/nbgv-python/tests/test_cli.py
+++ b/src/public/lib/nbgv-python/tests/test_cli.py
@@ -2,15 +2,22 @@
 
 from __future__ import annotations
 
+import logging
 import sys
 from typing import TYPE_CHECKING
 
 import pytest
 from nbgv_python import cli
 from nbgv_python.command import ENV_COMMAND_OVERRIDE
+from nbgv_python.errors import NbgvCommandError
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+
+EXIT_CODE_OK = 0
+EXIT_CODE_COMMAND_FAILED = 3
+MOCK_EXIT_CODE_COMMAND_ERROR = 2
 
 
 def _write_stub(tmp_path: Path) -> Path:
@@ -43,21 +50,60 @@ def stub_env_fixture(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv(ENV_COMMAND_OVERRIDE, command)
 
 
-def test_cli_main_returns_zero_on_success(
-    stub_env: None,  # noqa: ARG001
-    tmp_path: Path,
-) -> None:
+@pytest.mark.usefixtures("stub_env")
+def test_cli_main_returns_zero_on_success(tmp_path: Path) -> None:
     """CLI should forward commands and return the exit code."""
     target = tmp_path / "marker.txt"
     exit_code = cli.main(["touch", str(target)])
-    assert exit_code == 0
+    assert exit_code == EXIT_CODE_OK
     assert target.read_text(encoding="utf-8") == "ok"
 
 
-def test_cli_returns_failure_code(stub_env: None) -> None:  # noqa: ARG001
+@pytest.mark.usefixtures("stub_env")
+def test_cli_returns_failure_code() -> None:
     """CLI should propagate the underlying exit code on failure."""
     exit_code = cli.main(["fail"])
-    assert exit_code == 3  # noqa: PLR2004
+    assert exit_code == EXIT_CODE_COMMAND_FAILED
+
+
+@pytest.mark.usefixtures("stub_env")
+def test_cli_logs_command_error_when_forward_fails(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """CLI should log a helpful message when the underlying command fails."""
+    caplog.set_level(logging.ERROR)
+    exit_code = cli.main(["fail"])
+
+    assert exit_code == EXIT_CODE_COMMAND_FAILED
+    assert "nbgv command failed" in caplog.text
+    assert "exit code=3" in caplog.text
+
+
+@pytest.mark.usefixtures("stub_env")
+def test_cli_logs_stderr_when_available(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """CLI should include stderr details when available on NbgvCommandError."""
+
+    def _raise_command_error(
+        _self: object, _args: object, *, _cwd: object = None
+    ) -> int:
+        raise NbgvCommandError(
+            ("nbgv", "fail"),
+            MOCK_EXIT_CODE_COMMAND_ERROR,
+            None,
+            "boom\n",
+        )
+
+    monkeypatch.setattr(
+        "nbgv_python.cli.NbgvRunner.forward", _raise_command_error
+    )
+    caplog.set_level(logging.ERROR)
+
+    exit_code = cli.main(["fail"])
+    assert exit_code == MOCK_EXIT_CODE_COMMAND_ERROR
+    assert "boom" in caplog.text
 
 
 def test_cli_handles_missing_command(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -66,4 +112,19 @@ def test_cli_handles_missing_command(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("PATH", "")
     monkeypatch.setattr("nbgv_python.command.shutil.which", lambda _: None)
     exit_code = cli.main([])
-    assert exit_code == 127  # noqa: PLR2004
+    assert exit_code == cli.EXIT_CODE_NBGV_NOT_FOUND
+
+
+def test_cli_logs_missing_command_message(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """CLI should log a user-facing message when nbgv cannot be discovered."""
+    monkeypatch.delenv(ENV_COMMAND_OVERRIDE, raising=False)
+    monkeypatch.setenv("PATH", "")
+    monkeypatch.setattr("nbgv_python.command.shutil.which", lambda _: None)
+    caplog.set_level(logging.ERROR)
+
+    exit_code = cli.main([])
+    assert exit_code == cli.EXIT_CODE_NBGV_NOT_FOUND
+    assert "Unable to locate the 'nbgv' CLI" in caplog.text

--- a/src/public/lib/nbgv-python/tests/test_runner.py
+++ b/src/public/lib/nbgv-python/tests/test_runner.py
@@ -31,11 +31,16 @@ def _write_stub(tmp_path: Path) -> Path:
         "    if args[:2] != ['--format', 'json']:\n"
         "        sys.exit(2)\n"
         "    args = args[2:]\n"
+        "    project_arg = None\n"
         "    if args and args[0] == '--project':\n"
+        "        project_arg = args[1]\n"
         "        args = args[2:]\n"
         "    if args:\n"
         "        sys.exit(3)\n"
-        "    json.dump(" + json.dumps(payload) + ", sys.stdout)\n"
+        "    payload = " + json.dumps(payload) + "\n"
+        "    payload['ProjectArg'] = project_arg\n"
+        "    payload['Cwd'] = str(Path.cwd())\n"
+        "    json.dump(payload, sys.stdout)\n"
         "elif sys.argv[1:] and sys.argv[1] == 'touch':\n"
         "    target = Path(sys.argv[2])\n"
         "    target.write_text('ok', encoding='utf-8')\n"
@@ -61,6 +66,22 @@ def test_get_version_returns_git_version_instance(runner: NbgvRunner) -> None:
     version = runner.get_version()
     assert version["simple_version"] == "1.2.3"
     assert version["git_commit_id"].startswith("abcdef")
+
+
+def test_get_version_uses_absolute_project_path_without_changing_cwd(
+    runner: NbgvRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`get_version()` should send an absolute --project and preserve cwd."""
+    caller_cwd = tmp_path / "caller"
+    caller_cwd.mkdir()
+    (caller_cwd / "src").mkdir()
+    monkeypatch.chdir(caller_cwd)
+
+    version = runner.get_version(project_dir="src")
+    assert version["cwd"] == str(caller_cwd)
+    assert version["project_arg"] == str((caller_cwd / "src").resolve())
 
 
 def test_forward_propagates_passthrough_commands(

--- a/src/public/lib/nbgv-python/tests/test_templating.py
+++ b/src/public/lib/nbgv-python/tests/test_templating.py
@@ -153,3 +153,37 @@ def test_build_template_fields_single_element_tuple() -> None:
         config=config,
     )
     assert fields["version_tuple"] == "(1,)"
+
+
+def test_build_template_fields_nbgv_boolean_component() -> None:
+    """Boolean metadata should render as Python boolean literals."""
+    info = {
+        "VersionMajor": True,
+    }
+    config = TemplateFieldsConfig(
+        version_tuple=VersionTupleConfig(mode="nbgv", fields=("VersionMajor",))
+    )
+    fields = build_template_fields(
+        version="1.0.0",
+        normalized_version="1.0.0",
+        version_info=info,
+        config=config,
+    )
+    assert fields["version_tuple"] == "(True,)"
+
+
+def test_build_template_fields_nbgv_boolean_component_false() -> None:
+    """False should render as the unquoted literal 'False'."""
+    info = {
+        "VersionMajor": False,
+    }
+    config = TemplateFieldsConfig(
+        version_tuple=VersionTupleConfig(mode="nbgv", fields=("VersionMajor",))
+    )
+    fields = build_template_fields(
+        version="1.0.0",
+        normalized_version="1.0.0",
+        version_info=info,
+        config=config,
+    )
+    assert fields["version_tuple"] == "(False,)"

--- a/src/public/lib/nbgv-python/tests/test_versioning.py
+++ b/src/public/lib/nbgv-python/tests/test_versioning.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pytest
+from nbgv_python.errors import NbgvVersionNormalizationError
 from nbgv_python.versioning import normalize_version_field
 
 
@@ -26,8 +27,9 @@ def test_normalize_version_field(value: str, expected: str) -> None:
 
 def test_normalize_version_field_rejects_invalid() -> None:
     """Invalid values raise a runtime error with context."""
-    with pytest.raises(RuntimeError):
+    with pytest.raises(NbgvVersionNormalizationError) as exc:
         normalize_version_field("not-a-version", field="simple_version")
+    assert exc.value.field == "simple_version"
 
 
 @pytest.mark.parametrize(
@@ -46,5 +48,6 @@ def test_normalize_version_field_rejects_complex_unrecognized_prerelease(
     value: str,
 ) -> None:
     """Complex unrecognized prerelease tags should raise a runtime error."""
-    with pytest.raises(RuntimeError):
+    with pytest.raises(NbgvVersionNormalizationError) as exc:
         normalize_version_field(value, field="simple_version")
+    assert exc.value.field == "simple_version"


### PR DESCRIPTION
- Avoid setting `cwd` when invoking nbgv get-version --project to prevent path duplication
- Render boolean version-tuple components as True/False instead of quoted strings
- Raise `NbgvVersionNormalizationError` for version normalization failures
- Exempt TRY400 in CLI where stack traces are intentionally suppressed
- Update changelog and tests accordingly

BREAKING CHANGE: `normalize_version_field` now raises `NbgvVersionNormalizationError` instead of `RuntimeError` when normalization fails