### PR TITLE
Align Root Monorepo Source of Truth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -892,9 +892,6 @@ _version.py
 # Include C# app.manifest
 !app.manifest
 
-# Include OnePython packages
-!OnePython/packages/*
-
 # Include Ruby lib directories
 !lib/
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ This repository is designed to manage polyglot projects in a monorepo structure.
 2. Python: Managed by UV workspaces.
 3. JavaScript/TypeScript: Managed by PNPM workspaces.
 
-The current status of the repository is that we migrated the source code from separate repositories into this monorepo structure. But we have not yet moved the source code into specific subdirectories in `src/` for each project. Neither have we set up the release pipelines for each project.
+The current status of the repository is that most active projects now follow the canonical `src/` and `tests/` monorepo layout. `OneDotNet/` remains a preserved imported subtree with its own `srcs/` and `tests/` structure, and we have not yet set up the release pipelines for each project.
 
 The versioning of the projects is managed by NBGV (Nerdbank.GitVersioning). We write a hatching plugin (`nbgv-python`) to adapt NBGV for our Python projects.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,16 @@ Maintaining several language stacks across scattered repositories was slowing me
 
 ## What’s with the name?
 
-The first two pillars were **OnePython** and **OneDotNet**. Adding the rest of my “other” projects made it a trio, hence **Three = OnePython + OneDotNet + Others**. In Daoist philosophy, “三生万物” (“Three begets all things”) symbolizes how diversity emerges from a balanced trio—exactly how this monorepo grows.
+The name reflects the repo's original consolidation of **OnePython**, **OneDotNet**, and a growing set of other projects. Those historical roots still explain the branding, but they no longer map 1:1 to today's top-level directories.
+
+## Canonical repository layout
+
+The current repository contract is:
+
+- `src/` contains active monorepo projects, organized under `lab/`, `private/`, `public/`, and `sample/`.
+- `tests/` contains matching test projects for code that follows the root monorepo layout.
+- `OneDotNet/` remains a preserved imported subtree with its own `srcs/` and `tests/` layout.
+- There is no top-level `OnePython/` directory in this repository. Python workspace members now live under `src/` and are declared in the root `pyproject.toml`.
 
 ## Projects included
 
@@ -21,24 +30,35 @@ The first two pillars were **OnePython** and **OneDotNet**. Adding the rest of m
 | Asciidoctor LaTeXMath        | `src/public/lib/asciidoctor-latexmath/`        | [Repo][asciidoctor-upstream] | [514d685][asciidoctor-commit] |
 | ImageOcclusionEditor         | `src/public/app/ImageOcclusionEditor/`         | [Repo][ioe-upstream]         | [e08f834][ioe-commit]         |
 | OneDotNet                    | `OneDotNet/`                                   | [Repo][onedotnet-upstream]   | [17f2224][onedotnet-commit]   |
-| OnePython                    | `OnePython/`                                   | [Repo][onepython-upstream]   | [21ef6d5][onepython-commit]   |
 | Steam Account History to CSV | `src/public/lib/steam-account-history-to-csv/` | [Repo][steamhist-upstream]   | [b759a52][steamhist-commit]   |
 | Hexo Renderer AsciiDoc       | `src/public/lib/hexo-renderer-asciidoc/`       | [Repo][hexo-upstream]        | [d98f8d5][hexo-commit]        |
 
 ## JavaScript/pnpm workspace
 
-The `src/public/lib/hexo-renderer-asciidoc/` and `src/public/lib/steam-account-history-to-csv/` folders share a [pnpm workspace](https://pnpm.io/workspaces) that still lives at the repo root even though the projects moved under `src/public/lib/`. The nested layout keeps the repo top level tidy while preserving predictable dependency resolution (`sharedWorkspaceLockfile: true`) and automatic linking between workspace packages (`linkWorkspacePackages: true`). As before, the workspace does not pin a Node version—each package’s own `engines` entry (Hexo still wants Node ≥ 20.19) remains authoritative.
+The root [pnpm workspace](https://pnpm.io/workspaces) currently includes:
+
+- `src/public/lib/hexo-renderer-asciidoc/`
+- `src/public/lib/steam-account-history-to-csv/`
+- `src/private/app/im-acp-gateway/poc/*`
+
+The workspace stays at the repo root so these packages can share one lockfile (`sharedWorkspaceLockfile: true`) and workspace linking (`linkWorkspacePackages: true`) even though they live under different subtrees.
 
 Development flow:
 
-1. Enable Corepack (once per machine) so the `packageManager` setting can download pnpm for you.
+1. Install a compatible Node.js and pnpm toolchain. `mise.toml` is the repo-wide source of tool version intent; otherwise use a local toolchain that satisfies each package's `engines` constraints.
 2. From the repo root, run `pnpm install` to hydrate every workspace project and refresh the single `pnpm-lock.yaml`.
 3. Use the root scripts from `package.json`:
     - `pnpm run build` → runs `build` in every workspace package.
     - `pnpm run test` / `pnpm run lint` / `pnpm run format` → fan out with `--if-present`, so packages missing a script are skipped.
 4. When pnpm warns about blocked install scripts (for example `hexo-util`), review and allow them with `pnpm approve-builds` to stay compliant with pnpm 10’s hardened defaults.
 
-For publishing/versioning, follow pnpm’s [Changesets guide](https://pnpm.io/using-changesets) so both packages can share a single release workflow.
+## Python/uv workspace
+
+The root `pyproject.toml` is the source of truth for the repository's Python workspace membership. The current workspace is rooted under `src/`; there is no separate top-level `OnePython/` tree in this checkout.
+
+## .NET traversal
+
+The root `dirs.proj` treats `src/` and `tests/` as the canonical traversal roots for the main monorepo and references `OneDotNet/dirs.proj` separately so the preserved subtree can keep its internal `srcs/` layout for now.
 
 ## GitHub Copilot Telegram notifications
 
@@ -87,8 +107,6 @@ The runtime still honors `TG_BOT_TOKEN` and `TG_CHAT_ID` from the process enviro
 [ioe-commit]: https://github.com/hcoona/ImageOcclusionEditor/commit/e08f8348e58b83d04801212e55bace30a9126072
 [onedotnet-upstream]: https://dev.azure.com/zhangshuai89/Public/_git/OneDotNet
 [onedotnet-commit]: https://dev.azure.com/zhangshuai89/Public/_git/OneDotNet/commit/17f2224ab5f25c2149f7d5e9fd184c632afa0c3a
-[onepython-upstream]: https://dev.azure.com/zhangshuai89/Public/_git/OnePython
-[onepython-commit]: https://dev.azure.com/zhangshuai89/Public/_git/OnePython/commit/21ef6d519c5d35ac1c2e0694dd11f3c256c68756
 [steamhist-upstream]: https://github.com/hcoona/steam-account-history-to-csv
 [steamhist-commit]: https://github.com/hcoona/steam-account-history-to-csv/commit/b759a520b2d1edf8560a45cbcb70b403c77cecd1
 [hexo-upstream]: https://github.com/hcoona/hexo-renderer-asciidoc

--- a/dirs.proj
+++ b/dirs.proj
@@ -1,4 +1,5 @@
 <Project Sdk="Microsoft.Build.Traversal">
+  <!-- The main monorepo uses src/ and tests/; OneDotNet remains a preserved subtree. -->
   <ItemGroup Condition="'$(OS)' == 'Windows_NT'">
     <ProjectReference Include="OneDotNet\dirs.proj" />
     <ProjectReference Include="src\**\*.*proj" />

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hcoona/three-monorepo",
   "private": true,
-  "description": "Workspace root for pnpm-managed packages in this repository.",
+  "description": "Workspace root for pnpm-managed packages in the Three monorepo.",
   "license": "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception",
   "engines": {
     "node": ">=20.19.0"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 packages:
   - src/public/lib/hexo-renderer-asciidoc
   - src/public/lib/steam-account-history-to-csv
+  # These private POC packages intentionally share the root workspace and lockfile.
   - src/private/app/im-acp-gateway/poc/*
 
 linkWorkspacePackages: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
-name = "hcoona-one-python"
+name = "hcoona-three-monorepo"
 version = "0.0.0-dev"
-description = "This is the root mono-repository for HCOONa's One Python project."
+description = "Root uv workspace manifest for the Three monorepo."
 authors = [{ name = "Shuai Zhang", email = "zhangshuai.ustc@gmail.com" }]
 dependencies = []
 readme = "README.md"
-requires-python = ">= 3.12"
+requires-python = ">= 3.13"
 license = "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
 classifiers = ["Private :: Do Not Upload"]
 
@@ -13,6 +13,7 @@ classifiers = ["Private :: Do Not Upload"]
 dev = ["pyrefly>=0.25.0", "pytest>=8.3.4", "ruff>=0.11.8"]
 
 [tool.uv.workspace]
+# The current Python workspace is rooted under src/; legacy OnePython paths are retired.
 members = [
   "src/lab/azure-document-intelligence-lab",
   "src/private/app/factorio-cycle-calculator",
@@ -26,13 +27,13 @@ members = [
   "src/public/app/markdown-hybrid-search-mcp",
   "src/public/lib/nbgv-python",
   "src/sample/nbgv-hatch-demo",
-  "OnePython/packages/*",
 ]
 
 [tool.uv.sources]
 nbgv-python = { workspace = true }
 
 [tool.pyrefly]
+# Keep type-check coverage aligned with the root uv workspace membership.
 project-includes = [
   "src/lab/azure-document-intelligence-lab",
   "src/private/app/factorio-cycle-calculator",
@@ -46,12 +47,11 @@ project-includes = [
   "src/public/app/markdown-hybrid-search-mcp",
   "src/public/lib/nbgv-python",
   "src/sample/nbgv-hatch-demo",
-  "OnePython/packages/*",
 ]
 project-excludes = ['.venv/**', 'dist/**']
 
 [tool.ruff]
-target-version = "py312" # Enforce Python 3.12 syntax/stdlib expectations repository-wide.
+target-version = "py312" # Keep a conservative repo-wide lint target until package-level overrides are needed.
 line-length = 80         # Google Python Style Guide recommends an 80-character maximum line length.
 
 [tool.ruff.format]

--- a/uv.lock
+++ b/uv.lock
@@ -7,7 +7,7 @@ members = [
     "azure-document-intelligence-lab",
     "factorio-cycle-calculator",
     "git-commit-heatmap",
-    "hcoona-one-python",
+    "hcoona-three-monorepo",
     "html-sm-processor",
     "llm-text-splitter",
     "markdown-hybrid-search-mcp",
@@ -1035,7 +1035,7 @@ wheels = [
 ]
 
 [[package]]
-name = "hcoona-one-python"
+name = "hcoona-three-monorepo"
 version = "0.0.0.dev0"
 source = { virtual = "." }
 


### PR DESCRIPTION
## Summary
- align root docs and manifests with the current src/tests monorepo layout
- document OneDotNet as a preserved imported subtree and remove stale OnePython-era root metadata
- refresh root Python workspace metadata and lock state to match the current root contract

## Notes
- repeated Node engine feedback was reviewed and left out of this PR as out of scope for #184

close #184