### PR TITLE
fix: Remediate OpenMcdf vulnerability

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
   <ItemGroup Label="Direct">
     <PackageVersion Include="CommandLineParser" Version="2.9.1" />
     <PackageVersion Include="coverlet.collector" Version="8.0.1" />
-    <PackageVersion Include="FileSignatures" Version="5.3.0" />
+    <PackageVersion Include="FileSignatures" Version="7.1.0" />
     <PackageVersion Include="Google.OrTools" Version="9.15.6755" />
     <PackageVersion Include="Hjg.Pngcs" Version="1.1.4" />
     <PackageVersion Include="HtmlAgilityPack" Version="1.12.4" />
@@ -45,6 +45,7 @@
 
   <ItemGroup Label="Transitive">
     <PackageVersion Include="ExCSS" Version="4.3.1" />
+    <PackageVersion Include="OpenMcdf" Version="3.1.3" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
   </ItemGroup>

--- a/src/private/app/vscode-copilot-telegram-hook/packages.lock.json
+++ b/src/private/app/vscode-copilot-telegram-hook/packages.lock.json
@@ -10,9 +10,9 @@
       },
       "Microsoft.DotNet.ILCompiler": {
         "type": "Direct",
-        "requested": "[10.0.5, )",
-        "resolved": "10.0.5",
-        "contentHash": "yadTZIkStCVsG8nGwvfroSfBApPsgjQbodQyaIfp53dgayE0qhZpywixiCB6lx57JYQ+KVg1m1AFLrj54pxpZg=="
+        "requested": "[10.0.7, )",
+        "resolved": "10.0.7",
+        "contentHash": "2H7j1NltkQx04sPWBkUtFrZNBtro7vwsxRtdThP0oDj6Sn3ouGHCQlxATZ4Me2aJE67+KiXMX2V1IHDjt1uIpw=="
       },
       "Microsoft.Extensions.Hosting": {
         "type": "Direct",
@@ -71,9 +71,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.5, )",
-        "resolved": "10.0.5",
-        "contentHash": "A+5ZuQ0f449tM+MQrhf6R9ZX7lYpjk/ODEwLYKrnF6111rtARx8fVsm4YznUnQiKnnXfaXNBqgxmil6RW3L3SA=="
+        "requested": "[10.0.7, )",
+        "resolved": "10.0.7",
+        "contentHash": "AA/yhzFHNtQZXLdqjzujPy25G8EWwGWsAnxOE2zYSBoT/8QHP6ketN3CToD3DFreO653ipUwnKHo22B8AlBMCw=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
@@ -480,17 +480,17 @@
     "net10.0/linux-x64": {
       "Microsoft.DotNet.ILCompiler": {
         "type": "Direct",
-        "requested": "[10.0.5, )",
-        "resolved": "10.0.5",
-        "contentHash": "yadTZIkStCVsG8nGwvfroSfBApPsgjQbodQyaIfp53dgayE0qhZpywixiCB6lx57JYQ+KVg1m1AFLrj54pxpZg==",
+        "requested": "[10.0.7, )",
+        "resolved": "10.0.7",
+        "contentHash": "2H7j1NltkQx04sPWBkUtFrZNBtro7vwsxRtdThP0oDj6Sn3ouGHCQlxATZ4Me2aJE67+KiXMX2V1IHDjt1uIpw==",
         "dependencies": {
-          "runtime.linux-x64.Microsoft.DotNet.ILCompiler": "10.0.5"
+          "runtime.linux-x64.Microsoft.DotNet.ILCompiler": "10.0.7"
         }
       },
       "runtime.linux-x64.Microsoft.DotNet.ILCompiler": {
         "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "QYAggijHfk8FpLrPVhaESEOCYGWzEjA9JLapzg6XMFK5TGmwQ2HIqEprFv28MwvB5GdPGaZVLXE5icnkgLUfSA=="
+        "resolved": "10.0.7",
+        "contentHash": "bz+Di9NJXvaWTvoma5Pf9JrgFj6MGkbPo9dlWRo+jOHXDEme511jeWVEBWoPdoDe6BjDWRngGi9P9EUBCCgzgw=="
       },
       "System.Diagnostics.EventLog": {
         "type": "Transitive",
@@ -501,17 +501,17 @@
     "net10.0/win-x64": {
       "Microsoft.DotNet.ILCompiler": {
         "type": "Direct",
-        "requested": "[10.0.5, )",
-        "resolved": "10.0.5",
-        "contentHash": "yadTZIkStCVsG8nGwvfroSfBApPsgjQbodQyaIfp53dgayE0qhZpywixiCB6lx57JYQ+KVg1m1AFLrj54pxpZg==",
+        "requested": "[10.0.7, )",
+        "resolved": "10.0.7",
+        "contentHash": "2H7j1NltkQx04sPWBkUtFrZNBtro7vwsxRtdThP0oDj6Sn3ouGHCQlxATZ4Me2aJE67+KiXMX2V1IHDjt1uIpw==",
         "dependencies": {
-          "runtime.win-x64.Microsoft.DotNet.ILCompiler": "10.0.5"
+          "runtime.win-x64.Microsoft.DotNet.ILCompiler": "10.0.7"
         }
       },
       "runtime.win-x64.Microsoft.DotNet.ILCompiler": {
         "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "vblLkpVhSDYOmrEW0jypX7YVtLg7idU1QzUyx45ZdZ2sFUSSf3mYFCr0FW3+KZgXWpN1ve9ZPrxNywvHISF4bA=="
+        "resolved": "10.0.7",
+        "contentHash": "pdlgAPDgcAMCi1XMrgKTPcovBzM0IG9j8LbsIyXS8XXXIrPRyygByqJPJnPtTPDIHxXsLmd3tlMEDULglbBdKA=="
       },
       "System.Diagnostics.EventLog": {
         "type": "Transitive",

--- a/src/public/app/ImageOcclusionEditor/ImageOcclusionEditorWinUI3/packages.lock.json
+++ b/src/public/app/ImageOcclusionEditor/ImageOcclusionEditorWinUI3/packages.lock.json
@@ -10,11 +10,11 @@
       },
       "FileSignatures": {
         "type": "Direct",
-        "requested": "[5.3.0, )",
-        "resolved": "5.3.0",
-        "contentHash": "f1fUeIlNAXGMZFyu7trtCApfkIEzJpUC+05z1LefGt/d03iki6VUZTb+g/mSL+n1CKcTQpGVZNAovOevERmdcg==",
+        "requested": "[7.1.0, )",
+        "resolved": "7.1.0",
+        "contentHash": "w+RDtc1mo6nHjdeS4cbXs2MYrXZtHwTdAyVsOGcm/TYS7VIFjS6TCzKiqXrxQripyoBPM55aaoRUyOcn6yaj/Q==",
         "dependencies": {
-          "OpenMcdf": "2.3.1"
+          "OpenMcdf": "3.1.3"
         }
       },
       "IO.Github.Hcoona.Pngcs": {
@@ -25,15 +25,15 @@
       },
       "Microsoft.DotNet.ILCompiler": {
         "type": "Direct",
-        "requested": "[10.0.5, )",
-        "resolved": "10.0.5",
-        "contentHash": "yadTZIkStCVsG8nGwvfroSfBApPsgjQbodQyaIfp53dgayE0qhZpywixiCB6lx57JYQ+KVg1m1AFLrj54pxpZg=="
+        "requested": "[10.0.7, )",
+        "resolved": "10.0.7",
+        "contentHash": "2H7j1NltkQx04sPWBkUtFrZNBtro7vwsxRtdThP0oDj6Sn3ouGHCQlxATZ4Me2aJE67+KiXMX2V1IHDjt1uIpw=="
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.5, )",
-        "resolved": "10.0.5",
-        "contentHash": "A+5ZuQ0f449tM+MQrhf6R9ZX7lYpjk/ODEwLYKrnF6111rtARx8fVsm4YznUnQiKnnXfaXNBqgxmil6RW3L3SA=="
+        "requested": "[10.0.7, )",
+        "resolved": "10.0.7",
+        "contentHash": "AA/yhzFHNtQZXLdqjzujPy25G8EWwGWsAnxOE2zYSBoT/8QHP6ketN3CToD3DFreO653ipUwnKHo22B8AlBMCw=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
@@ -102,11 +102,6 @@
         "resolved": "8.0.0",
         "contentHash": "dk9JPxTCIevS75HyEQ0E4OVAFhB2N+V9ShCXf8Q6FkUQZDkgLI12y679Nym1YqsiSysuQskT7Z+6nUf3yab6Vw=="
       },
-      "OpenMcdf": {
-        "type": "Transitive",
-        "resolved": "2.3.1",
-        "contentHash": "2Otbtp5FsIkdtWn4904oftoyOigllM/Auz2V7qIpxNaK+MC1C2ENjNXL3/ZdKWFLOs24/Bi/lYOE254C7s3Pgw=="
-      },
       "ShimSkiaSharp": {
         "type": "Transitive",
         "resolved": "3.0.4",
@@ -162,16 +157,22 @@
         "requested": "[1.0.3351.48, )",
         "resolved": "1.0.3351.48",
         "contentHash": "UIzXdl3x3H2MX2es7+BHYT3pLkLoT7090omqla9S3MQQCma0slwiY+CXBM6x0LmdLTpksoQ6XUqOAXrtxjtklQ=="
+      },
+      "OpenMcdf": {
+        "type": "CentralTransitive",
+        "requested": "[3.1.3, )",
+        "resolved": "3.1.3",
+        "contentHash": "TJTdAIhyqx8LUfF2PnrhXCjuUiKVi19zUNe7FzO1skd0zyJFur44KGxLFEosl1KrKQzsFCxTMTQE8VFkXIHMZQ=="
       }
     },
     "net10.0-windows10.0.22000/win-x64": {
       "Microsoft.DotNet.ILCompiler": {
         "type": "Direct",
-        "requested": "[10.0.5, )",
-        "resolved": "10.0.5",
-        "contentHash": "yadTZIkStCVsG8nGwvfroSfBApPsgjQbodQyaIfp53dgayE0qhZpywixiCB6lx57JYQ+KVg1m1AFLrj54pxpZg==",
+        "requested": "[10.0.7, )",
+        "resolved": "10.0.7",
+        "contentHash": "2H7j1NltkQx04sPWBkUtFrZNBtro7vwsxRtdThP0oDj6Sn3ouGHCQlxATZ4Me2aJE67+KiXMX2V1IHDjt1uIpw==",
         "dependencies": {
-          "runtime.win-x64.Microsoft.DotNet.ILCompiler": "10.0.5"
+          "runtime.win-x64.Microsoft.DotNet.ILCompiler": "10.0.7"
         }
       },
       "Microsoft.WindowsAppSDK": {
@@ -191,8 +192,8 @@
       },
       "runtime.win-x64.Microsoft.DotNet.ILCompiler": {
         "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "vblLkpVhSDYOmrEW0jypX7YVtLg7idU1QzUyx45ZdZ2sFUSSf3mYFCr0FW3+KZgXWpN1ve9ZPrxNywvHISF4bA=="
+        "resolved": "10.0.7",
+        "contentHash": "pdlgAPDgcAMCi1XMrgKTPcovBzM0IG9j8LbsIyXS8XXXIrPRyygByqJPJnPtTPDIHxXsLmd3tlMEDULglbBdKA=="
       },
       "SkiaSharp.NativeAssets.Win32": {
         "type": "Transitive",

--- a/src/public/app/ImageOcclusionEditor/THIRD-PARTY-NOTICES.TXT
+++ b/src/public/app/ImageOcclusionEditor/THIRD-PARTY-NOTICES.TXT
@@ -1,6 +1,6 @@
 THIRD-PARTY NOTICES
 ====================
-Generated on: 2026-05-19 03:22:02 +00:00
+Generated on: 2026-05-19 17:14:32 +00:00
 
 This file lists third-party components used by this project with their license names.
 
@@ -1271,7 +1271,7 @@ REQUIREMENTS AND/OR USE RIGHTS.
 
  a.
  DISTRIBUTABLE
-CODE.  T he software is
+CODE.  The software is
 comprised of Distributable Code. “Distributable Code” is code that you are
 permitted to distribute in applications you develop if you comply with the
 terms below.
@@ -1323,7 +1323,7 @@ form; or (ii) others have the right to modify it.
 information about you and your use of the software, and send that to Microsoft.
 Microsoft may use this information to provide services and improve our products
 and services.  You may opt-out of many of these scenarios, but not all, as
-described in the software documentation.  There are also s ome features in the software that may enable you and
+described in the software documentation.  There are also some features in the software that may enable you and
 Microsoft to collect data from users of your applications. If you use
 these features, you must comply with applicable law, including providing
 appropriate notices to users of your applications together with Microsoft’s

--- a/src/public/app/ImageOcclusionEditor/THIRD-PARTY-NOTICES.TXT
+++ b/src/public/app/ImageOcclusionEditor/THIRD-PARTY-NOTICES.TXT
@@ -1,6 +1,6 @@
 THIRD-PARTY NOTICES
 ====================
-Generated on: 2025-08-15 00:00:52 -07:00
+Generated on: 2026-05-19 03:22:02 +00:00
 
 This file lists third-party components used by this project with their license names.
 
@@ -21,7 +21,7 @@ License: GPL-3.0-or-later
 License: MIT
 ------------
 - ExCSS@4.3.1
-- FileSignatures@5.3.0
+- FileSignatures@7.1.0
 - HarfBuzzSharp@8.3.0.1
 - HarfBuzzSharp.NativeAssets.Win32@8.3.0.1
 - ShimSkiaSharp@3.0.4
@@ -34,34 +34,17 @@ License: MIT
 License: MIT AND .NET Library License
 -------------------------------------
 - Microsoft.Build.Tasks.Git@8.0.0
-- Microsoft.NETCore.Platforms@1.1.1
-- Microsoft.NETCore.Targets@1.1.3
 - Microsoft.SourceLink.Common@8.0.0
 - Microsoft.Web.WebView2@1.0.3351.48
 - Microsoft.Windows.SDK.BuildTools@10.0.26100.4654
 - Microsoft.WindowsAppSDK@1.7.250606001
-- runtime.any.System.IO@4.3.0
-- runtime.any.System.Reflection@4.3.0
-- runtime.any.System.Reflection.Primitives@4.3.0
-- runtime.any.System.Runtime@4.3.0
-- runtime.any.System.Text.Encoding@4.3.0
-- runtime.any.System.Threading.Tasks@4.3.0
-- runtime.win-x64.Microsoft.DotNet.ILCompiler@9.0.8
-- System.IO@4.3.0
-- System.Private.Uri@4.3.2
-- System.Reflection@4.3.0
-- System.Reflection.Primitives@4.3.0
-- System.Reflection.TypeExtensions@4.3.0
-- System.Runtime@4.3.0
-- System.Text.Encoding@4.3.0
-- System.Text.Json@9.0.7
-- System.Threading.Tasks@4.3.0
+- runtime.win-x64.Microsoft.DotNet.ILCompiler@10.0.7
   Note: Microsoft official .NET libraries are treated as dual-licensed under MIT and the .NET Library License.
         See: https://dotnet.microsoft.com/dotnet_library_license.htm
 
 License: MPL-2.0
 ----------------
-- OpenMcdf@2.3.1
+- OpenMcdf@3.1.3
 
 License: MS-PL
 --------------
@@ -77,7 +60,8 @@ License notice for ExCSS
 https://github.com/TylerBrinks/ExCSS
 
 Available at
-https://github.com/TylerBrinks/ExCSS/raw/master/license.txt
+https://licenses.nuget.org/MIT
+https://github.com/TylerBrinks/ExCSS/raw/c97e84d6126bb2e42658cf5af627d52e697c8779/license.txt
 
 The MIT License (MIT)
 
@@ -106,10 +90,11 @@ SOFTWARE.
 License notice for FileSignatures
 -------------------------------
 
-https://github.com/neilharvey/FileSignatures
+https://github.com/neilharvey/FileSignatures/
 
 Available at
-https://github.com/neilharvey/FileSignatures/raw/master/LICENCE
+https://licenses.nuget.org/MIT
+https://github.com/neilharvey/FileSignatures/raw/e17f6540c4ab9b2b435de3d51c4e1a2b86c6d1a1/LICENCE
 
 MIT License
 
@@ -141,7 +126,28 @@ License notice for HarfBuzzSharp
 https://go.microsoft.com/fwlink/?linkid=868515
 
 Available at
+NuGet package HarfBuzzSharp@8.3.0.1: LICENSE.txt
 https://licenses.nuget.org/MIT
+
+Copyright (c) 2015-2016 Xamarin, Inc.
+Copyright (c) 2017-2018 Microsoft Corporation.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 
@@ -151,7 +157,28 @@ License notice for HarfBuzzSharp.NativeAssets.Win32
 https://go.microsoft.com/fwlink/?linkid=868515
 
 Available at
+NuGet package HarfBuzzSharp.NativeAssets.Win32@8.3.0.1: LICENSE.txt
 https://licenses.nuget.org/MIT
+
+Copyright (c) 2015-2016 Xamarin, Inc.
+Copyright (c) 2017-2018 Microsoft Corporation.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 
@@ -161,7 +188,8 @@ License notice for IO.Github.Hcoona.Pngcs
 https://github.com/hcoona/pngcs
 
 Available at
-https://github.com/hcoona/pngcs/raw/main/LICENSE
+NuGet package IO.Github.Hcoona.Pngcs@1.2.1: LICENSE
+https://licenses.nuget.org/GPL-3.0-or-later
 
 # LICENSE
 
@@ -201,384 +229,635 @@ limitations under the License.
 License notice for OpenMcdf
 -------------------------------
 
-https://github.com/ironfede/openmcdf
+https://openmcdf.github.io/openmcdf/
 
 Available at
-https://github.com/ironfede/openmcdf/raw/master/License.txt
-
-Mozilla Public License Version 2.0
-==================================
-
-1. Definitions
---------------
+https://licenses.nuget.org/MPL-2.0
 
-1.1. "Contributor"
-    means each individual or legal entity that creates, contributes to
-    the creation of, or owns Covered Software.
+'MPL-2.0' reference
 
-1.2. "Contributor Version"
-    means the combination of the Contributions of others (if any) used
-    by a Contributor and that particular Contributor's Contribution.
 
-1.3. "Contribution"
-    means Covered Software of a particular Contributor.
-
-1.4. "Covered Software"
-    means Source Code Form to which the initial Contributor has attached
-    the notice in Exhibit A, the Executable Form of such Source Code
-    Form, and Modifications of such Source Code Form, in each case
-    including portions thereof.
 
-1.5. "Incompatible With Secondary Licenses"
-    means
 
-    (a) that the initial Contributor has attached the notice described
-        in Exhibit B to the Covered Software; or
 
-    (b) that the Covered Software was made available under the terms of
-        version 1.1 or earlier of the License, but not also under the
-        terms of a Secondary License.
 
-1.6. "Executable Form"
-    means any form of the work other than Source Code Form.
+ Mozilla Public License 2.0
 
-1.7. "Larger Work"
-    means a work that combines Covered Software with other material, in
-    a separate file or files, that is not Covered Software.
+ SPDX identifier
+ MPL-2.0
 
-1.8. "License"
-    means this document.
+ License text
 
-1.9. "Licensable"
-    means having the right to grant, to the maximum extent possible,
-    whether at the time of the initial grant or subsequently, any and
-    all of the rights conveyed by this License.
 
-1.10. "Modifications"
-    means any of the following:
+ Mozilla Public License Version 2.0
 
-    (a) any file in Source Code Form that results from an addition to,
-        deletion from, or modification of the contents of Covered
-        Software; or
+     ==================================
 
-    (b) any new file in Source Code Form that contains any Covered
-        Software.
 
-1.11. "Patent Claims" of a Contributor
-    means any patent claim(s), including without limitation, method,
-    process, and apparatus claims, in any patent Licensable by such
-    Contributor that would be infringed, but for the grant of the
-    License, by the making, using, selling, offering for sale, having
-    made, import, or transfer of either its Contributions or its
-    Contributor Version.
 
-1.12. "Secondary License"
-    means either the GNU General Public License, Version 2.0, the GNU
-    Lesser General Public License, Version 2.1, the GNU Affero General
-    Public License, Version 3.0, or any later versions of those
-    licenses.
 
-1.13. "Source Code Form"
-    means the form of the work preferred for making modifications.
 
-1.14. "You" (or "Your")
-    means an individual or a legal entity exercising rights under this
-    License. For legal entities, "You" includes any entity that
-    controls, is controlled by, or is under common control with You. For
-    purposes of this definition, "control" means (a) the power, direct
-    or indirect, to cause the direction or management of such entity,
-    whether by contract or otherwise, or (b) ownership of more than
-    fifty percent (50%) of the outstanding shares or beneficial
-    ownership of such entity.
 
-2. License Grants and Conditions
---------------------------------
 
-2.1. Grants
+             1.
+            Definitions
 
-Each Contributor hereby grants You a world-wide, royalty-free,
-non-exclusive license:
 
-(a) under intellectual property rights (other than patent or trademark)
-    Licensable by such Contributor to use, reproduce, make available,
-    modify, display, perform, distribute, and otherwise exploit its
-    Contributions, either on an unmodified basis, with Modifications, or
-    as part of a Larger Work; and
+         --------------
 
-(b) under Patent Claims of such Contributor to make, use, sell, offer
-    for sale, have made, import, and otherwise transfer either its
-    Contributions or its Contributor Version.
 
-2.2. Effective Date
 
-The licenses granted in Section 2.1 with respect to any Contribution
-become effective for each Contribution on the date the Contributor first
-distributes such Contribution.
 
-2.3. Limitations on Grant Scope
 
-The licenses granted in this Section 2 are the only rights granted under
-this License. No additional rights or licenses will be implied from the
-distribution or licensing of Covered Software under this License.
-Notwithstanding Section 2.1(b) above, no patent license is granted by a
-Contributor:
+ 1.1.
+ "Contributor" means each individual or legal entity that creates, contributes to
+ the creation of, or owns Covered Software.
 
-(a) for any code that a Contributor has removed from Covered Software;
-    or
 
-(b) for infringements caused by: (i) Your and any other third party's
-    modifications of Covered Software, or (ii) the combination of its
-    Contributions with other software (except as part of its Contributor
-    Version); or
 
-(c) under Patent Claims infringed by Covered Software in the absence of
-    its Contributions.
-
-This License does not grant any rights in the trademarks, service marks,
-or logos of any Contributor (except as may be necessary to comply with
-the notice requirements in Section 3.4).
-
-2.4. Subsequent Licenses
-
-No Contributor makes additional grants as a result of Your choice to
-distribute the Covered Software under a subsequent version of this
-License (see Section 10.2) or under the terms of a Secondary License (if
-permitted under the terms of Section 3.3).
-
-2.5. Representation
-
-Each Contributor represents that the Contributor believes its
-Contributions are its original creation(s) or it has sufficient rights
-to grant the rights to its Contributions conveyed by this License.
-
-2.6. Fair Use
-
-This License is not intended to limit any rights You have under
-applicable copyright doctrines of fair use, fair dealing, or other
-equivalents.
-
-2.7. Conditions
-
-Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
-in Section 2.1.
-
-3. Responsibilities
--------------------
-
-3.1. Distribution of Source Form
-
-All distribution of Covered Software in Source Code Form, including any
-Modifications that You create or to which You contribute, must be under
-the terms of this License. You must inform recipients that the Source
-Code Form of the Covered Software is governed by the terms of this
-License, and how they can obtain a copy of this License. You may not
-attempt to alter or restrict the recipients' rights in the Source Code
-Form.
-
-3.2. Distribution of Executable Form
-
-If You distribute Covered Software in Executable Form then:
-
-(a) such Covered Software must also be made available in Source Code
-    Form, as described in Section 3.1, and You must inform recipients of
-    the Executable Form how they can obtain a copy of such Source Code
-    Form by reasonable means in a timely manner, at a charge no more
-    than the cost of distribution to the recipient; and
-
-(b) You may distribute such Executable Form under the terms of this
-    License, or sublicense it under different terms, provided that the
-    license for the Executable Form does not attempt to limit or alter
-    the recipients' rights in the Source Code Form under this License.
-
-3.3. Distribution of a Larger Work
-
-You may create and distribute a Larger Work under terms of Your choice,
-provided that You also comply with the requirements of this License for
-the Covered Software. If the Larger Work is a combination of Covered
-Software with a work governed by one or more Secondary Licenses, and the
-Covered Software is not Incompatible With Secondary Licenses, this
-License permits You to additionally distribute such Covered Software
-under the terms of such Secondary License(s), so that the recipient of
-the Larger Work may, at their option, further distribute the Covered
-Software under the terms of either this License or such Secondary
-License(s).
-
-3.4. Notices
-
-You may not remove or alter the substance of any license notices
-(including copyright notices, patent notices, disclaimers of warranty,
-or limitations of liability) contained within the Source Code Form of
-the Covered Software, except that You may alter any license notices to
-the extent required to remedy known factual inaccuracies.
-
-3.5. Application of Additional Terms
-
-You may choose to offer, and to charge a fee for, warranty, support,
-indemnity or liability obligations to one or more recipients of Covered
-Software. However, You may do so only on Your own behalf, and not on
-behalf of any Contributor. You must make it absolutely clear that any
-such warranty, support, indemnity, or liability obligation is offered by
-You alone, and You hereby agree to indemnify every Contributor for any
-liability incurred by such Contributor as a result of warranty, support,
-indemnity or liability terms You offer. You may include additional
-disclaimers of warranty and limitations of liability specific to any
-jurisdiction.
-
-4. Inability to Comply Due to Statute or Regulation
----------------------------------------------------
-
-If it is impossible for You to comply with any of the terms of this
-License with respect to some or all of the Covered Software due to
-statute, judicial order, or regulation then You must: (a) comply with
-the terms of this License to the maximum extent possible; and (b)
-describe the limitations and the code they affect. Such description must
-be placed in a text file included with all distributions of the Covered
-Software under this License. Except to the extent prohibited by statute
-or regulation, such description must be sufficiently detailed for a
-recipient of ordinary skill to be able to understand it.
-
-5. Termination
---------------
-
-5.1. The rights granted under this License will terminate automatically
-if You fail to comply with any of its terms. However, if You become
-compliant, then the rights granted under this License from a particular
-Contributor are reinstated (a) provisionally, unless and until such
-Contributor explicitly and finally terminates Your grants, and (b) on an
-ongoing basis, if such Contributor fails to notify You of the
-non-compliance by some reasonable means prior to 60 days after You have
-come back into compliance. Moreover, Your grants from a particular
-Contributor are reinstated on an ongoing basis if such Contributor
-notifies You of the non-compliance by some reasonable means, this is the
-first time You have received notice of non-compliance with this License
-from such Contributor, and You become compliant prior to 30 days after
-Your receipt of the notice.
-
-5.2. If You initiate litigation against any entity by asserting a patent
-infringement claim (excluding declaratory judgment actions,
-counter-claims, and cross-claims) alleging that a Contributor Version
-directly or indirectly infringes any patent, then the rights granted to
-You by any and all Contributors for the Covered Software under Section
-2.1 of this License shall terminate.
-
-5.3. In the event of termination under Sections 5.1 or 5.2 above, all
-end user license agreements (excluding distributors and resellers) which
-have been validly granted by You or Your distributors under this License
-prior to termination shall survive termination.
-
-************************************************************************
-*                                                                      *
-*  6. Disclaimer of Warranty                                           *
-*  -------------------------                                           *
-*                                                                      *
-*  Covered Software is provided under this License on an "as is"       *
-*  basis, without warranty of any kind, either expressed, implied, or  *
-*  statutory, including, without limitation, warranties that the       *
-*  Covered Software is free of defects, merchantable, fit for a        *
-*  particular purpose or non-infringing. The entire risk as to the     *
-*  quality and performance of the Covered Software is with You.        *
-*  Should any Covered Software prove defective in any respect, You     *
-*  (not any Contributor) assume the cost of any necessary servicing,   *
-*  repair, or correction. This disclaimer of warranty constitutes an   *
-*  essential part of this License. No use of any Covered Software is   *
-*  authorized under this License except under this disclaimer.         *
-*                                                                      *
-************************************************************************
-
-************************************************************************
-*                                                                      *
-*  7. Limitation of Liability                                          *
-*  --------------------------                                          *
-*                                                                      *
-*  Under no circumstances and under no legal theory, whether tort      *
-*  (including negligence), contract, or otherwise, shall any           *
-*  Contributor, or anyone who distributes Covered Software as          *
-*  permitted above, be liable to You for any direct, indirect,         *
-*  special, incidental, or consequential damages of any character      *
-*  including, without limitation, damages for lost profits, loss of    *
-*  goodwill, work stoppage, computer failure or malfunction, or any    *
-*  and all other commercial damages or losses, even if such party      *
-*  shall have been informed of the possibility of such damages. This   *
-*  limitation of liability shall not apply to liability for death or   *
-*  personal injury resulting from such party's negligence to the       *
-*  extent applicable law prohibits such limitation. Some               *
-*  jurisdictions do not allow the exclusion or limitation of           *
-*  incidental or consequential damages, so this exclusion and          *
-*  limitation may not apply to You.                                    *
-*                                                                      *
-************************************************************************
-
-8. Litigation
--------------
-
-Any litigation relating to this License may be brought only in the
-courts of a jurisdiction where the defendant maintains its principal
-place of business and such litigation shall be governed by laws of that
-jurisdiction, without reference to its conflict-of-law provisions.
-Nothing in this Section shall prevent a party's ability to bring
-cross-claims or counter-claims.
-
-9. Miscellaneous
-----------------
-
-This License represents the complete agreement concerning the subject
-matter hereof. If any provision of this License is held to be
-unenforceable, such provision shall be reformed only to the extent
-necessary to make it enforceable. Any law or regulation which provides
-that the language of a contract shall be construed against the drafter
-shall not be used to construe this License against a Contributor.
-
-10. Versions of the License
----------------------------
-
-10.1. New Versions
-
-Mozilla Foundation is the license steward. Except as provided in Section
-10.3, no one other than the license steward has the right to modify or
-publish new versions of this License. Each version will be given a
-distinguishing version number.
-
-10.2. Effect of New Versions
-
-You may distribute the Covered Software under the terms of the version
-of the License under which You originally received the Covered Software,
-or under the terms of any subsequent version published by the license
-steward.
-
-10.3. Modified Versions
-
-If you create software not governed by this License, and you want to
-create a new license for such software, you may create and use a
-modified version of this License if you rename the license and remove
-any references to the name of the license steward (except to note that
-such modified license differs from this License).
-
-10.4. Distributing Source Code Form that is Incompatible With Secondary
-Licenses
-
-If You choose to distribute Source Code Form that is Incompatible With
-Secondary Licenses under the terms of this version of the License, the
-notice described in Exhibit B of this License must be attached.
-
-Exhibit A - Source Code Form License Notice
--------------------------------------------
-
-  This Source Code Form is subject to the terms of the Mozilla Public
-  License, v. 2.0. If a copy of the MPL was not distributed with this
-  file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-If it is not possible or desirable to put the notice in a particular
-file, then You may include the notice in a location (such as a LICENSE
-file in a relevant directory) where a recipient would be likely to look
-for such a notice.
-
-You may add additional accurate notices of copyright ownership.
-
-Exhibit B - "Incompatible With Secondary Licenses" Notice
----------------------------------------------------------
-
-  This Source Code Form is "Incompatible With Secondary Licenses", as
-  defined by the Mozilla Public License, v. 2.0.
+ 1.2.
+ "Contributor Version" means the combination of the Contributions of others (if any)
+ used by a Contributor and that particular Contributor's Contribution.
+
+
+
+ 1.3.
+ "Contribution" means Covered Software of a particular Contributor.
+
+
+
+ 1.4.
+ "Covered Software" means Source Code Form to which the initial Contributor has
+ attached the notice in Exhibit A, the Executable Form of such Source Code Form, and
+ Modifications of such Source Code Form, in each case including portions thereof.
+
+
+
+ 1.5.
+ "Incompatible With Secondary Licenses" means
+
+
+
+
+ (a)
+ that the initial Contributor has attached the notice described in Exhibit B to the
+ Covered Software; or
+
+
+
+ (b)
+ that the Covered Software was made available under the terms of version 1.1 or earlier of
+ the License, but not also under the terms of a Secondary License.
+
+
+
+
+
+
+ 1.6.
+ "Executable Form" means any form of the work other than Source Code Form.
+
+
+
+ 1.7.
+ "Larger Work" means a work that combines Covered Software with other material, in a
+ separate file or files, that is not Covered Software.
+
+
+
+ 1.8.
+ "License" means this document.
+
+
+
+ 1.9.
+ "Licensable" means having the right to grant, to the maximum extent possible,
+ whether at the time of the initial grant or subsequently, any and all of the rights
+ conveyed by this License.
+
+
+
+ 1.10.
+ "Modifications" means any of the following:
+
+
+
+
+ (a)
+ any file in Source Code Form that results from an addition to, deletion from, or
+ modification of the contents of Covered Software; or
+
+
+
+ (b)
+ any new file in Source Code Form that contains any Covered Software.
+
+
+
+
+
+
+ 1.11.
+ "Patent Claims" of a Contributor means any patent claim(s), including without
+ limitation, method, process, and apparatus claims, in any patent Licensable by such
+ Contributor that would be infringed, but for the grant of the License, by the making,
+ using, selling, offering for sale, having made, import, or transfer of either its
+ Contributions or its Contributor Version.
+
+
+
+ 1.12.
+ "Secondary License" means either the GNU General Public License, Version 2.0, the
+ GNU Lesser General Public License, Version 2.1, the GNU Affero General Public License,
+ Version 3.0, or any later versions of those licenses.
+
+
+
+ 1.13.
+ "Source Code Form" means the form of the work preferred for making modifications.
+
+
+
+ 1.14.
+ "You" (or "Your") means an individual or a legal entity exercising rights
+ under this License. For legal entities, "You" includes any entity that controls,
+ is controlled by, or is under common control with You. For purposes of this definition,
+ "control" means (a) the power, direct or indirect, to cause the direction or
+ management of such entity, whether by contract or otherwise, or (b) ownership of more than
+ fifty percent (50%) of the outstanding shares or beneficial ownership of such entity.
+
+
+
+
+
+
+
+          2.
+            License Grants and Conditions
+
+
+         --------------------------------
+
+
+
+
+
+ 2.1.
+ Grants
+ Each Contributor hereby grants You a world-wide, royalty-free, non-exclusive license:
+
+
+
+
+
+ (a)
+ under intellectual property rights (other than patent or trademark) Licensable by such
+ Contributor to use, reproduce, make available, modify, display, perform, distribute,
+ and otherwise exploit its Contributions, either on an unmodified basis, with
+ Modifications, or as part of a Larger Work; and
+
+
+
+ (b)
+ under Patent Claims of such Contributor to make, use, sell, offer for sale, have made,
+ import, and otherwise transfer either its Contributions or its Contributor
+ Version.
+
+
+
+
+
+
+ 2.2.
+ Effective Date
+ The licenses granted in Section 2.1 with respect to any Contribution become effective
+ for each Contribution on the date the Contributor first distributes such
+ Contribution.
+
+
+
+
+
+ 2.3.
+ Limitations on Grant Scope
+ The licenses granted in this Section 2 are the only rights granted under this License.
+ No additional rights or licenses will be implied from the distribution or
+ licensing of Covered Software under this License. Notwithstanding Section 2.1(b)
+ above, no patent license is granted by a Contributor:
+
+
+
+
+
+ (a)
+ for any code that a Contributor has removed from Covered Software; or
+
+
+
+ (b)
+ for infringements caused by: (i) Your and any other third party's modifications of
+ Covered Software, or (ii) the combination of its Contributions with other software
+ (except as part of its Contributor Version); or
+
+
+
+ (c)
+ under Patent Claims infringed by Covered Software in the absence of its Contributions.
+
+
+
+ This License does not grant any rights in the trademarks, service marks, or logos of any
+ Contributor (except as may be necessary to comply with the notice requirements in
+ Section 3.4).
+
+
+
+
+ 2.4.
+ Subsequent Licenses
+ No Contributor makes additional grants as a result of Your choice to distribute the
+ Covered Software under a subsequent version of this License (see Section 10.2) or
+ under the terms of a Secondary License (if permitted under the terms of Section
+ 3.3).
+
+
+
+
+ 2.5.
+ Representation
+ Each Contributor represents that the Contributor believes its Contributions are its
+ original creation(s) or it has sufficient rights to grant the rights to its
+ Contributions conveyed by this License.
+
+
+
+
+
+ 2.6.
+ Fair Use
+ This License is not intended to limit any rights You have under applicable copyright
+ doctrines of fair use, fair dealing, or other equivalents.
+
+
+
+
+
+ 2.7.
+ Conditions
+ Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted in Section 2.1.
+
+
+
+
+
+
+
+
+          3.
+         Responsibilities
+
+
+         -------------------
+
+
+
+
+
+ 3.1.
+ Distribution of Source Form
+ All distribution of Covered Software in Source Code Form, including any Modifications
+ that You create or to which You contribute, must be under the terms of this
+ License. You must inform recipients that the Source Code Form of the Covered
+ Software is governed by the terms of this License, and how they can obtain a copy
+ of this License. You may not attempt to alter or restrict the recipients'
+ rights in the Source Code Form.
+
+
+
+
+
+ 3.2.
+ Distribution of Executable Form
+ If You distribute Covered Software in Executable Form then:
+
+
+
+
+ (a)
+ such Covered Software must also be made available in Source Code Form, as described in
+ Section 3.1, and You must inform recipients of the Executable Form how they can obtain
+ a copy of such Source Code Form by reasonable means in a timely manner, at a charge no
+ more than the cost of distribution to the recipient; and
+
+
+
+ (b)
+ You may distribute such Executable Form under the terms of this License, or sublicense it
+ under different terms, provided that the license for the Executable Form does not
+ attempt to limit or alter the recipients' rights in the Source Code Form under
+ this License.
+
+
+
+
+
+
+ 3.3.
+ Distribution of a Larger Work
+ You may create and distribute a Larger Work under terms of Your choice, provided that
+ You also comply with the requirements of this License for the Covered Software. If
+ the Larger Work is a combination of Covered Software with a work governed by one
+ or more Secondary Licenses, and the Covered Software is not Incompatible With
+ Secondary Licenses, this License permits You to additionally distribute such
+ Covered Software under the terms of such Secondary License(s), so that the
+ recipient of the Larger Work may, at their option, further distribute the Covered
+ Software under the terms of either this License or such Secondary License(s).
+
+
+
+
+
+ 3.4.
+ Notices
+ You may not remove or alter the substance of any license notices (including copyright
+ notices, patent notices, disclaimers of warranty, or limitations of liability)
+ contained within the Source Code Form of the Covered Software, except that You may
+ alter any license notices to the extent required to remedy known factual
+ inaccuracies.
+
+
+
+
+
+ 3.5.
+ Application of Additional Terms
+ You may choose to offer, and to charge a fee for, warranty, support, indemnity or
+ liability obligations to one or more recipients of Covered Software. However, You
+ may do so only on Your own behalf, and not on behalf of any Contributor. You must
+ make it absolutely clear that any such warranty, support, indemnity, or liability
+ obligation is offered by You alone, and You hereby agree to indemnify every
+ Contributor for any liability incurred by such Contributor as a result of
+ warranty, support, indemnity or liability terms You offer. You may include
+ additional disclaimers of warranty and limitations of liability specific to any
+ jurisdiction.
+
+
+
+
+
+
+
+
+
+          4.
+         Inability to Comply Due to Statute or Regulation
+
+
+         ---------------------------------------------------
+
+ If it is impossible for You to comply with any of the terms of this License with respect to
+ some or all of the Covered Software due to statute, judicial order, or regulation then
+ You must: (a) comply with the terms of this License to the maximum extent possible;
+ and (b) describe the limitations and the code they affect. Such description must be
+ placed in a text file included with all distributions of the Covered Software under
+ this License. Except to the extent prohibited by statute or regulation, such
+ description must be sufficiently detailed for a recipient of ordinary skill to be able
+ to understand it.
+
+
+
+
+
+
+             5.
+         Termination
+
+
+         --------------
+
+
+
+
+
+ 5.1.
+ The rights granted under this License will terminate automatically if You fail to comply with
+ any of its terms. However, if You become compliant, then the rights granted under this
+ License from a particular Contributor are reinstated (a) provisionally, unless and until
+ such Contributor explicitly and finally terminates Your grants, and (b) on an ongoing
+ basis, if such Contributor fails to notify You of the non-compliance by some reasonable
+ means prior to 60 days after You have come back into compliance. Moreover, Your grants
+ from a particular Contributor are reinstated on an ongoing basis if such Contributor
+ notifies You of the non-compliance by some reasonable means, this is the first time You
+ have received notice of non-compliance with this License from such Contributor, and You
+ become compliant prior to 30 days after Your receipt of the notice.
+
+
+
+ 5.2.
+ If You initiate litigation against any entity by asserting a patent infringement claim
+ (excluding declaratory judgment actions, counter-claims, and cross-claims) alleging that a
+ Contributor Version directly or indirectly infringes any patent, then the rights granted
+ to You by any and all Contributors for the Covered Software under Section 2.1 of this
+ License shall terminate.
+
+
+
+ 5.3.
+ In the event of termination under Sections 5.1 or 5.2 above, all end user license agreements
+ (excluding distributors and resellers) which have been validly granted by You or Your
+ distributors under this License prior to termination shall survive termination.
+
+
+
+
+
+
+         ************************************************************************
+
+
+          6.
+         Disclaimer of Warranty
+
+
+         * ------------------------- *
+
+ Covered Software is provided under this License on an "as is" basis, without
+ warranty of any kind, either expressed, implied, or statutory, including, without
+ limitation, warranties that the Covered Software is free of defects, merchantable, fit
+ for a particular purpose or non-infringing. The entire risk as to the quality and
+ performance of the Covered Software is with You. Should any Covered Software prove
+ defective in any respect, You (not any Contributor) assume the cost of any necessary
+ servicing, repair, or correction. This disclaimer of warranty constitutes an essential
+ part of this License. No use of any Covered Software is authorized under this License
+ except under this disclaimer.
+
+
+         ************************************************************************
+
+
+
+
+         ************************************************************************
+
+
+          7.
+         Limitation of Liability
+
+
+         * -------------------------- *
+
+ Under no circumstances and under no legal theory, whether tort (including negligence),
+ contract, or otherwise, shall any Contributor, or anyone who distributes Covered
+ Software as permitted above, be liable to You for any direct, indirect, special,
+ incidental, or consequential damages of any character including, without limitation,
+ damages for lost profits, loss of goodwill, work stoppage, computer failure or
+ malfunction, or any and all other commercial damages or losses, even if such party
+ shall have been informed of the possibility of such damages. This limitation of
+ liability shall not apply to liability for death or personal injury resulting from
+ such party's negligence to the extent applicable law prohibits such limitation.
+ Some jurisdictions do not allow the exclusion or limitation of incidental or
+ consequential damages, so this exclusion and limitation may not apply to You.
+
+
+         ************************************************************************
+
+
+
+
+
+          8.
+         Litigation
+
+
+         -------------
+
+ Any litigation relating to this License may be brought only in the courts of a jurisdiction
+ where the defendant maintains its principal place of business and such litigation
+ shall be governed by laws of that jurisdiction, without reference to its
+ conflict-of-law provisions. Nothing in this Section shall prevent a party's
+ ability to bring cross-claims or counter-claims.
+
+
+
+
+
+
+          9.
+         Miscellaneous
+
+
+         ----------------
+
+ This License represents the complete agreement concerning the subject matter hereof. If any
+ provision of this License is held to be unenforceable, such provision shall be
+ reformed only to the extent necessary to make it enforceable. Any law or regulation
+ which provides that the language of a contract shall be construed against the drafter
+ shall not be used to construe this License against a Contributor.
+
+
+
+
+
+
+          10.
+         Versions of the License
+
+
+         ---------------------------
+
+
+
+
+
+ 10.1.
+ New Versions
+ Mozilla Foundation is the license steward. Except as provided in Section 10.3, no one
+ other than the license steward has the right to modify or publish new versions of
+ this License. Each version will be given a distinguishing version number.
+
+
+
+
+
+ 10.2.
+ Effect of New Versions
+ You may distribute the Covered Software under the terms of the version of the License
+ under which You originally received the Covered Software, or under the terms of
+ any subsequent version published by the license steward.
+
+
+
+
+
+ 10.3.
+ Modified Versions
+ If you create software not governed by this License, and you want to create a new
+ license for such software, you may create and use a modified version of this
+ License if you rename the license and remove any references to the name of the
+ license steward (except to note that such modified license differs from this
+ License).
+
+
+
+
+
+ 10.4.
+ Distributing Source Code Form that is Incompatible With Secondary Licenses
+ If You choose to distribute Source Code Form that is Incompatible With Secondary Licenses under the terms
+ of this version of the License, the notice described in Exhibit B of this License must be
+ attached.
+
+
+
+
+
+
+
+
+
+ Exhibit A - Source Code Form License Notice
+
+ -------------------------------------------
+
+
+ This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL
+ was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+ If it is not possible or desirable to put the notice in a particular file, then You may include the
+ notice in a location (such as a LICENSE file in a relevant directory) where a recipient would be
+ likely to look for such a notice.
+
+ You may add additional accurate notices of copyright ownership.
+
+ Exhibit B - "Incompatible With Secondary Licenses" Notice
+
+ ---------------------------------------------------------
+
+     This Source Code Form is "Incompatible With Secondary Licenses", as defined by the Mozilla
+ Public License, v. 2.0.
+
+
+
+
+ Standard License Header
+
+ This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL
+ was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+
+
+ Notes
+ This license was released in January 2012. This license list entry is for use when the standard MPL 2.0 is used, as indicated by the standard header (Exhibit A but no Exhibit B).
+
+ SPDX web page
+
+ https://spdx.org/licenses/MPL-2.0.html
+
+
+ Notice
+ This license content is provided by the SPDX project . For more information about licenses.nuget.org , see our documentation .
+
+ Data pulled from spdx/license-list-data on November 6, 2024.
 
 
 
@@ -588,7 +867,8 @@ License notice for ShimSkiaSharp
 https://github.com/wieslawsoltes/Svg.Skia
 
 Available at
-https://github.com/wieslawsoltes/Svg.Skia/raw/master/LICENSE.TXT
+https://licenses.nuget.org/MIT
+https://github.com/wieslawsoltes/Svg.Skia/raw/db9461b33b819aa3df283bd07b5cf264836cd130/LICENSE.TXT
 
 MIT License
 
@@ -620,7 +900,28 @@ License notice for SkiaSharp
 https://go.microsoft.com/fwlink/?linkid=868515
 
 Available at
+NuGet package SkiaSharp@3.116.1: LICENSE.txt
 https://licenses.nuget.org/MIT
+
+Copyright (c) 2015-2016 Xamarin, Inc.
+Copyright (c) 2017-2018 Microsoft Corporation.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 
@@ -630,7 +931,28 @@ License notice for SkiaSharp.HarfBuzz
 https://go.microsoft.com/fwlink/?linkid=868515
 
 Available at
+NuGet package SkiaSharp.HarfBuzz@3.116.1: LICENSE.txt
 https://licenses.nuget.org/MIT
+
+Copyright (c) 2015-2016 Xamarin, Inc.
+Copyright (c) 2017-2018 Microsoft Corporation.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 
@@ -640,7 +962,28 @@ License notice for SkiaSharp.NativeAssets.Win32
 https://go.microsoft.com/fwlink/?linkid=868515
 
 Available at
+NuGet package SkiaSharp.NativeAssets.Win32@3.116.1: LICENSE.txt
 https://licenses.nuget.org/MIT
+
+Copyright (c) 2015-2016 Xamarin, Inc.
+Copyright (c) 2017-2018 Microsoft Corporation.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 
@@ -650,29 +993,133 @@ License notice for Svg.Custom
 https://github.com/wieslawsoltes/Svg.Skia
 
 Available at
-https://github.com/wieslawsoltes/Svg.Skia/raw/master/LICENSE.TXT
+https://licenses.nuget.org/MS-PL
 
-MIT License
+'MS-PL' reference
 
-Copyright (c) 2020 Wiesław Šoltés
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+
+
+ Microsoft Public License
+
+ SPDX identifier
+ MS-PL
+
+ License text
+
+
+ Microsoft Public License (Ms-PL)
+
+
+
+ This license governs use of the accompanying software. If you use the software, you accept this license.
+ If you do not accept the license, do not use the software.
+
+
+
+
+ 1.
+ Definitions
+
+
+ The terms "reproduce," "reproduction," "derivative works,"
+ and "distribution" have the same meaning here as under U.S. copyright law. A
+ "contribution" is the original software, or any additions or changes to the
+ software. A "contributor" is any person that distributes its contribution
+ under this license. "Licensed patents" are a contributor's patent
+ claims that read directly on its contribution.
+
+
+
+
+ 2.
+ Grant of Rights
+
+
+
+
+ (A)
+ Copyright Grant- Subject to the terms of this license, including the license conditions and
+ limitations in section 3, each contributor grants you a non-exclusive, worldwide,
+ royalty-free copyright license to reproduce its contribution, prepare derivative works of
+ its contribution, and distribute its contribution or any derivative works that you
+ create.
+
+
+
+ (B)
+ Patent Grant- Subject to the terms of this license, including the license conditions and
+ limitations in section 3, each contributor grants you a non-exclusive, worldwide,
+ royalty-free license under its licensed patents to make, have made, use, sell, offer for
+ sale, import, and/or otherwise dispose of its contribution in the software or derivative
+ works of the contribution in the software.
+
+
+
+
+
+
+ 3.
+ Conditions and Limitations
+
+
+
+
+ (A)
+ No Trademark License- This license does not grant you rights to use any contributors'
+ name, logo, or trademarks.
+
+
+
+ (B)
+ If you bring a patent claim against any contributor over patents that you claim are infringed
+ by the software, your patent license from such contributor to the software ends
+ automatically.
+
+
+
+ (C)
+ If you distribute any portion of the software, you must retain all copyright, patent,
+ trademark, and attribution notices that are present in the software.
+
+
+
+ (D)
+ If you distribute any portion of the software in source code form, you may do so only under
+ this license by including a complete copy of this license with your distribution. If you
+ distribute any portion of the software in compiled or object code form, you may only do so
+ under a license that complies with this license.
+
+
+
+ (E)
+ The software is licensed "as-is." You bear the risk of using it. The contributors
+ give no express warranties, guarantees, or conditions. You may have additional consumer
+ rights under your local laws which this license cannot change. To the extent permitted
+ under your local laws, the contributors exclude the implied warranties of merchantability,
+ fitness for a particular purpose and non-infringement.
+
+
+
+
+
+
+
+
+
+
+
+ SPDX web page
+
+ https://spdx.org/licenses/MS-PL.html
+
+
+ Notice
+ This license content is provided by the SPDX project . For more information about licenses.nuget.org , see our documentation .
+
+ Data pulled from spdx/license-list-data on November 6, 2024.
 
 
 
@@ -682,7 +1129,8 @@ License notice for Svg.Model
 https://github.com/wieslawsoltes/Svg.Skia
 
 Available at
-https://github.com/wieslawsoltes/Svg.Skia/raw/master/LICENSE.TXT
+https://licenses.nuget.org/MIT
+https://github.com/wieslawsoltes/Svg.Skia/raw/db9461b33b819aa3df283bd07b5cf264836cd130/LICENSE.TXT
 
 MIT License
 
@@ -714,7 +1162,8 @@ License notice for Svg.Skia
 https://github.com/wieslawsoltes/Svg.Skia
 
 Available at
-https://github.com/wieslawsoltes/Svg.Skia/raw/master/LICENSE.TXT
+https://licenses.nuget.org/MIT
+https://github.com/wieslawsoltes/Svg.Skia/raw/db9461b33b819aa3df283bd07b5cf264836cd130/LICENSE.TXT
 
 MIT License
 
@@ -808,19 +1257,19 @@ you comply with these license terms, you have the rights below.
  1.     INSTALLATION AND USE RIGHTS.
 
  You may
-install and use any number of copies of the software to develop and test your applications. 
+install and use any number of copies of the software to develop and test your applications.
 
 
- 2.    
+ 2.
  THIRD PARTY COMPONENTS. The software may include third party components with
 separate legal notices or governed by other agreements, as may be described in
 the ThirdPartyNotices file(s) accompanying the software.
 
- 3.    
+ 3.
  ADDITIONAL LICENSING
 REQUIREMENTS AND/OR USE RIGHTS.
 
- a.     
+ a.
  DISTRIBUTABLE
 CODE.  T he software is
 comprised of Distributable Code. “Distributable Code” is code that you are
@@ -829,25 +1278,25 @@ terms below.
 
  i.       Right to Use and Distribute.
 
- ·        
+ ·
  You may copy and distribute the object code form of the software.
 
- ·        
+ ·
  Third Party Distribution. You may permit distributors of your applications
 to copy and distribute the Distributable Code as part of those applications.
 
  ii.      Distribution Requirements. For any
 Distributable Code you distribute, you must
 
- ·        
+ ·
  use the Distributable Code in your applications and not as a
 standalone distribution;
 
- ·        
+ ·
  require distributors and external end users to agree to terms that
 protect it at least as much as this agreement; and
 
- ·        
+ ·
  indemnify, defend, and hold harmless Microsoft from any claims,
 including attorneys’ fees, related to the distribution or use of your applications,
 except to the extent that any claim is based solely on the unmodified Distributable
@@ -855,26 +1304,26 @@ Code.
 
  iii.    Distribution Restrictions. You may not
 
- ·        
+ ·
  use Microsoft’s trademarks in your applications’ names or in a way
 that suggests your applications come from or are endorsed by Microsoft; or
 
- ·        
+ ·
  modify or distribute the source code of any Distributable Code so
 that any part of it becomes subject to an Excluded License. An “Excluded
 License” is one that requires, as a condition of use, modification or
 distribution of code, that (i) it be disclosed or distributed in source code
 form; or (ii) others have the right to modify it.
 
- 4.    
+ 4.
  DATA.
 
- a.     
+ a.
  Data Collection. The software may collect
 information about you and your use of the software, and send that to Microsoft.
 Microsoft may use this information to provide services and improve our products
 and services.  You may opt-out of many of these scenarios, but not all, as
-described in the software documentation.  There are also s some features in the software that may enable you and
+described in the software documentation.  There are also s ome features in the software that may enable you and
 Microsoft to collect data from users of your applications. If you use
 these features, you must comply with applicable law, including providing
 appropriate notices to users of your applications together with Microsoft’s
@@ -883,14 +1332,14 @@ collection and its use from the software documentation and our privacy
 statement. Your use of the software operates as your consent to these
 practices.
 
- b.    
+ b.
  Processing of Personal Data. To the extent Microsoft is a
 processor or subprocessor of personal data in connection with the software,
 Microsoft makes the commitments in the European Union General Data Protection
 Regulation Terms of the Online Services Terms to all customers effective May
 25, 2018, at https://learn.microsoft.com/en-us/legal/gdpr .
 
- 5.    
+ 5.
  Scope of
 License . The software is licensed, not sold. This agreement
 only gives you some rights to use the software. Microsoft reserves all other
@@ -899,43 +1348,43 @@ you may use the software only as expressly permitted in this agreement. In
 doing so, you must comply with any technical limitations in the software that
 only allow you to use it in certain ways. You may not
 
- ·        
+ ·
  work around any technical
 limitations in the software ;
 
- ·        
+ ·
  reverse engineer, decompile or
 disassemble the software, or otherwise attempt to derive the source code for
 the software, except and to the extent required by third party licensing terms
 governing use of certain open source components that may be included in the
 software;
 
- ·        
+ ·
  remove, minimize, block or modify
 any notices of Microsoft or its suppliers in the software;
 
- ·        
+ ·
  use the software in any way that
 is against the law; or
 
- ·        
+ ·
  share, publish, rent or lease the
 software, provide the software as a stand-alone offering for others to use, or
 transfer the software or this agreement to any third party.
 
- 6.    
+ 6.
  Export
 Restrictions . You must comply with all domestic and international
 export laws and regulations that apply to the software, which include
 restrictions on destinations, end users, and end use. For further information
 on export restrictions, visit www.microsoft.com/exporting.
 
- 7.    
+ 7.
  SUPPORT
 SERVICES. Because this software is “as is,” we may not provide
 support services for it.
 
- 8.    
+ 8.
  Entire
 Agreement. This
 agreement, and the terms for supplements, updates, Internet-based services and

--- a/src/public/app/ImageOcclusionEditor/script/Helpers.ps1
+++ b/src/public/app/ImageOcclusionEditor/script/Helpers.ps1
@@ -147,7 +147,10 @@ function Invoke-CycloneDX {
     #>
     param(
         [Parameter(Mandatory)][string]$ProjectPath,
-        [Parameter(Mandatory)][string]$OutDir
+        [Parameter(Mandatory)][string]$OutDir,
+        [string]$TargetFramework,
+        [string]$RuntimeIdentifier,
+        [switch]$DisablePackageRestore
     )
     # Ensure output directory exists
     if (-not (Test-Path -LiteralPath $OutDir)) {
@@ -161,6 +164,9 @@ function Invoke-CycloneDX {
         '--exclude-test-projects',
         '--output-format', 'Json'
     )
+    if ($TargetFramework) { $cdxArguments += @('--framework', $TargetFramework) }
+    if ($RuntimeIdentifier) { $cdxArguments += @('--runtime', $RuntimeIdentifier) }
+    if ($DisablePackageRestore) { $cdxArguments += '--disable-package-restore' }
 
     $cmds = @(
         @{ File = 'dotnet-CycloneDX'; Arguments = $cdxArguments },

--- a/src/public/app/ImageOcclusionEditor/script/New-ThirdPartyNotices.ps1
+++ b/src/public/app/ImageOcclusionEditor/script/New-ThirdPartyNotices.ps1
@@ -137,6 +137,7 @@ function Convert-HtmlToText {
     param([Parameter(Mandatory = $true)][string]$Html)
     try {
         $text = ($Html -replace '(?s)<script.*?</script>', '') -replace '(?s)<style.*?</style>', ''
+        $text = $text -replace '(?<=[\p{L}\p{N}])(?:<[^>]+>)+(?=[\p{L}\p{N}])', ''
         $text = ($text -replace '<[^>]+>', ' ')
         $text = [System.Net.WebUtility]::HtmlDecode($text)
         # Normalize whitespace
@@ -179,7 +180,7 @@ function Get-NuGetLocalPackageDirectory {
     return $null
 }
 
-function ConvertFrom-NuGetNuspecMetadata {
+function ConvertFrom-NuGetNuspecMetadatum {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)][string]$Content,
@@ -228,7 +229,7 @@ function Get-NuGetPackageInfo {
         $nuspec = Get-ChildItem -LiteralPath $packageDir -Filter '*.nuspec' -File | Select-Object -First 1
         if ($nuspec) {
             try {
-                return ConvertFrom-NuGetNuspecMetadata -Content ([System.IO.File]::ReadAllText($nuspec.FullName)) -PackageDirectory $packageDir
+                return ConvertFrom-NuGetNuspecMetadatum -Content ([System.IO.File]::ReadAllText($nuspec.FullName)) -PackageDirectory $packageDir
             }
             catch {
                 Write-Verbose "[NuGet] Failed to parse local nuspec for $($Id)@$($Version): $($_.Exception.Message)"
@@ -280,7 +281,7 @@ function Get-NuGetPackageInfo {
     $resp2 = Invoke-WebRequestSafe -Uri $nuspecUrl
     if ($resp2 -and $resp2.Content) {
         try {
-            return ConvertFrom-NuGetNuspecMetadata -Content $resp2.Content -PackageDirectory $packageDir
+            return ConvertFrom-NuGetNuspecMetadatum -Content $resp2.Content -PackageDirectory $packageDir
         }
         catch {
             Write-Verbose "[NuGet] Failed to parse nuspec XML for $($Id)@$($Version): $($_.Exception.Message)"
@@ -378,6 +379,7 @@ function Test-LicenseContentMatchesExpression {
 
 function Test-StandardizedLicenseTextNeedsPackageCopyright {
     [CmdletBinding()]
+    [OutputType([bool])]
     param(
         [Parameter(Mandatory = $true)][string]$Content,
         [Parameter(Mandatory = $true)][string]$Expression
@@ -563,7 +565,7 @@ function Write-Notice([string]$OutputPath, $components) {
         }
         if ($isGitHubRepo -and $repositoryCommit -and
             (-not $licenseExpression -or -not $licenseContent -or
-                (Test-StandardizedLicenseTextNeedsPackageCopyright -Content $licenseContent -Expression $licenseExpression))) {
+            (Test-StandardizedLicenseTextNeedsPackageCopyright -Content $licenseContent -Expression $licenseExpression))) {
             $licenseGuess = Get-GitHubLicenseContent -RepoUrl $githubRepoUrl -Ref $repositoryCommit
             if ($licenseGuess) {
                 $githubLicenseContent = [string]$licenseGuess.Content

--- a/src/public/app/ImageOcclusionEditor/script/New-ThirdPartyNotices.ps1
+++ b/src/public/app/ImageOcclusionEditor/script/New-ThirdPartyNotices.ps1
@@ -141,9 +141,78 @@ function Convert-HtmlToText {
         $text = [System.Net.WebUtility]::HtmlDecode($text)
         # Normalize whitespace
         $text = ($text -replace "\r\n|\r|\n", "`n") -replace ' +', ' '
-        return $text.Trim()
+        $lines = $text -split "`n" | ForEach-Object { $_.TrimEnd() }
+        return (($lines -join "`n").Trim())
     }
     catch { return $Html }
+}
+
+function Format-NoticeContent {
+    [CmdletBinding()]
+    param([Parameter(Mandatory = $true)][string]$Text)
+
+    $normalized = ($Text.Trim() -replace "\r\n|\r|\n", "`n") -replace "`t", '    '
+    $lines = $normalized -split "`n" | ForEach-Object { $_.TrimEnd() }
+    return ($lines -join [Environment]::NewLine)
+}
+
+function Get-NuGetLocalPackageDirectory {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)][string]$Id,
+        [Parameter(Mandatory = $true)][string]$Version
+    )
+
+    $roots = @()
+    if ($env:NUGET_PACKAGES) { $roots += $env:NUGET_PACKAGES }
+    $userProfile = [Environment]::GetFolderPath([Environment+SpecialFolder]::UserProfile)
+    if ($userProfile) { $roots += (Join-Path $userProfile '.nuget/packages') }
+
+    $lowerId = $Id.ToLowerInvariant()
+    $lowerVer = $Version.ToLowerInvariant()
+    foreach ($root in ($roots | Select-Object -Unique)) {
+        $path = Join-Path (Join-Path $root $lowerId) $lowerVer
+        if (Test-Path -LiteralPath $path -PathType Container) {
+            return (Resolve-Path -LiteralPath $path).Path
+        }
+    }
+    return $null
+}
+
+function ConvertFrom-NuGetNuspecMetadata {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)][string]$Content,
+        [string]$PackageDirectory
+    )
+
+    [xml]$xml = $Content
+    $meta = $xml.package.metadata
+    $repoUrl = $null
+    $repoCommit = $null
+    $repoNode = $meta.repository
+    if ($repoNode) {
+        $repoUrl = $repoNode.GetAttribute('url')
+        $repoCommit = $repoNode.GetAttribute('commit')
+        if ([string]::IsNullOrWhiteSpace($repoUrl)) { $repoUrl = $null }
+        if ([string]::IsNullOrWhiteSpace($repoCommit)) { $repoCommit = $null }
+    }
+
+    $licenseNode = $meta.license
+    $licenseText = if ($licenseNode) { [string]$licenseNode.InnerText } else { $null }
+    $licenseType = if ($licenseNode) { $licenseNode.GetAttribute('type') } else { $null }
+    if ([string]::IsNullOrWhiteSpace($licenseType)) { $licenseType = $null }
+
+    return [pscustomobject]@{
+        ProjectUrl        = [string]$meta.projectUrl
+        RepositoryUrl     = $repoUrl
+        RepositoryCommit  = $repoCommit
+        LicenseUrl        = [string]$meta.licenseUrl
+        LicenseExpression = if ($licenseType -eq 'file') { $null } else { $licenseText }
+        LicenseFile       = if ($licenseType -eq 'file') { $licenseText } else { $null }
+        LicenseType       = $licenseType
+        PackageDirectory  = $PackageDirectory
+    }
 }
 
 function Get-NuGetPackageInfo {
@@ -152,6 +221,21 @@ function Get-NuGetPackageInfo {
         [Parameter(Mandatory = $true)][string]$Id,
         [Parameter(Mandatory = $true)][string]$Version
     )
+    # Prefer the locally restored package because it is the exact versioned
+    # package content used by this project, including embedded license files.
+    $packageDir = Get-NuGetLocalPackageDirectory -Id $Id -Version $Version
+    if ($packageDir) {
+        $nuspec = Get-ChildItem -LiteralPath $packageDir -Filter '*.nuspec' -File | Select-Object -First 1
+        if ($nuspec) {
+            try {
+                return ConvertFrom-NuGetNuspecMetadata -Content ([System.IO.File]::ReadAllText($nuspec.FullName)) -PackageDirectory $packageDir
+            }
+            catch {
+                Write-Verbose "[NuGet] Failed to parse local nuspec for $($Id)@$($Version): $($_.Exception.Message)"
+            }
+        }
+    }
+
     # Try the NuGet registration API first.
     $lowerId = $Id.ToLowerInvariant()
     $lowerVer = $Version.ToLowerInvariant()
@@ -162,11 +246,27 @@ function Get-NuGetPackageInfo {
             $json = $resp.Content | ConvertFrom-Json
             if ($json -and $json.catalogEntry) {
                 $entry = $json.catalogEntry
+                $repositoryUrl = $null
+                $repositoryCommit = $null
+                if ($entry.PSObject.Properties.Match('repositoryUrl').Count -gt 0 -and $entry.repositoryUrl) {
+                    $repositoryUrl = $entry.repositoryUrl
+                }
+                elseif ($entry.PSObject.Properties.Match('repository').Count -gt 0 -and $entry.repository) {
+                    if ($entry.repository.PSObject.Properties.Match('url').Count -gt 0 -and $entry.repository.url) { $repositoryUrl = $entry.repository.url }
+                    if ($entry.repository.PSObject.Properties.Match('commit').Count -gt 0 -and $entry.repository.commit) { $repositoryCommit = $entry.repository.commit }
+                }
+                $projectUrl = if ($entry.PSObject.Properties.Match('projectUrl').Count -gt 0) { $entry.projectUrl } else { $null }
+                $licenseUrl = if ($entry.PSObject.Properties.Match('licenseUrl').Count -gt 0) { $entry.licenseUrl } else { $null }
+                $licenseExpression = if ($entry.PSObject.Properties.Match('licenseExpression').Count -gt 0) { $entry.licenseExpression } else { $null }
                 return [pscustomobject]@{
-                    ProjectUrl        = $entry.projectUrl
-                    RepositoryUrl     = if ($entry.repositoryUrl) { $entry.repositoryUrl } elseif ($entry.repository -and $entry.repository.url) { $entry.repository.url } else { $null }
-                    LicenseUrl        = $entry.licenseUrl
-                    LicenseExpression = $entry.licenseExpression
+                    ProjectUrl        = $projectUrl
+                    RepositoryUrl     = $repositoryUrl
+                    RepositoryCommit  = $repositoryCommit
+                    LicenseUrl        = $licenseUrl
+                    LicenseExpression = $licenseExpression
+                    LicenseFile       = $null
+                    LicenseType       = if ($licenseExpression) { 'expression' } else { $null }
+                    PackageDirectory  = $packageDir
                 }
             }
         }
@@ -180,16 +280,7 @@ function Get-NuGetPackageInfo {
     $resp2 = Invoke-WebRequestSafe -Uri $nuspecUrl
     if ($resp2 -and $resp2.Content) {
         try {
-            [xml]$xml = $resp2.Content
-            $meta = $xml.package.metadata
-            $repoUrl = $null
-            if ($meta.repository -and $meta.repository.url) { $repoUrl = [string]$meta.repository.url }
-            return [pscustomobject]@{
-                ProjectUrl        = [string]$meta.projectUrl
-                RepositoryUrl     = $repoUrl
-                LicenseUrl        = [string]$meta.licenseUrl
-                LicenseExpression = [string]$meta.license
-            }
+            return ConvertFrom-NuGetNuspecMetadata -Content $resp2.Content -PackageDirectory $packageDir
         }
         catch {
             Write-Verbose "[NuGet] Failed to parse nuspec XML for $($Id)@$($Version): $($_.Exception.Message)"
@@ -198,15 +289,114 @@ function Get-NuGetPackageInfo {
     return $null
 }
 
+function Get-NuGetPackageLicenseNotice {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)][string]$Id,
+        [Parameter(Mandatory = $true)][string]$Version,
+        $PackageInfo
+    )
+
+    if (-not $PackageInfo) { return $null }
+
+    $availableAt = New-Object System.Collections.Generic.List[string]
+    $content = $null
+
+    if ($PackageInfo.PackageDirectory) {
+        $licenseFileNames = New-Object System.Collections.Generic.List[string]
+        if ($PackageInfo.LicenseFile) { $licenseFileNames.Add([string]$PackageInfo.LicenseFile) | Out-Null }
+        @(
+            'LICENSE', 'LICENSE.txt', 'LICENSE.md', 'LICENSE.TXT', 'License.txt',
+            'license', 'license.txt', 'license.md',
+            'LICENCE', 'LICENCE.txt', 'LICENCE.md', 'Licence', 'Licence.txt', 'Licence.md',
+            'licence', 'licence.txt', 'licence.md',
+            'NOTICE', 'NOTICE.txt', 'NOTICE.md'
+        ) | ForEach-Object { $licenseFileNames.Add($_) | Out-Null }
+
+        foreach ($licenseFileName in ($licenseFileNames | Select-Object -Unique)) {
+            $candidate = Join-Path ([string]$PackageInfo.PackageDirectory) $licenseFileName
+            if (Test-Path -LiteralPath $candidate -PathType Leaf) {
+                $relativeName = $licenseFileName -replace '\\', '/'
+                $availableAt.Add("NuGet package $Id@$Version`: $relativeName") | Out-Null
+                $content = [System.IO.File]::ReadAllText((Resolve-Path -LiteralPath $candidate))
+                break
+            }
+        }
+    }
+
+    if ($PackageInfo.LicenseUrl) {
+        $licenseUrl = [string]$PackageInfo.LicenseUrl
+        if ($licenseUrl -like 'https://go.microsoft.com/fwlink*') { $licenseUrl = Get-FinalUrl -Uri $licenseUrl }
+        if ($licenseUrl -match 'https?://github.com/.+') { $licenseUrl = Convert-GitHubBlobToRaw -Url $licenseUrl }
+        $availableAt.Add($licenseUrl) | Out-Null
+    }
+    elseif ($PackageInfo.LicenseExpression) {
+        $availableAt.Add("https://licenses.nuget.org/$($PackageInfo.LicenseExpression)") | Out-Null
+    }
+
+    if ($content -or $availableAt.Count -gt 0) {
+        return [pscustomobject]@{
+            AvailableAt = @($availableAt)
+            Content     = $content
+        }
+    }
+    return $null
+}
+
+function Test-LicenseContentMatchesExpression {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)][string]$Content,
+        [Parameter(Mandatory = $true)][string]$Expression
+    )
+
+    $normalizedExpression = $Expression.Trim()
+    $normalizedContent = ($Content -replace "\r\n|\r|\n", "`n").Trim()
+
+    switch -Regex ($normalizedExpression) {
+        '^MIT$' {
+            return ($normalizedContent -match '(?im)^\s*(The\s+)?MIT License(\s*\(MIT\))?\s*$' -and
+                $normalizedContent -match 'Permission is hereby granted, free of charge' -and
+                $normalizedContent -notmatch 'Microsoft Public License')
+        }
+        '^MS-PL$' {
+            return ($normalizedContent -match 'Microsoft Public License' -and
+                $normalizedContent -match 'This license governs use of the accompanying software')
+        }
+        '^MPL-2\.0$' {
+            return ($normalizedContent -match 'Mozilla Public License Version 2\.0')
+        }
+        '^GPL-3\.0-or-later$' {
+            return ($normalizedContent -match 'GNU GENERAL PUBLIC LICENSE' -and
+                $normalizedContent -match 'Version 3')
+        }
+        default {
+            return $false
+        }
+    }
+}
+
+function Test-StandardizedLicenseTextNeedsPackageCopyright {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)][string]$Content,
+        [Parameter(Mandatory = $true)][string]$Expression
+    )
+
+    if ($Expression -ne 'MIT') { return $false }
+    return ($Content -match '<year>\s+<copyright holders>')
+}
+
 function Get-GitHubLicenseContent {
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory = $true)][string]$RepoUrl
+        [Parameter(Mandatory = $true)][string]$RepoUrl,
+        [string]$Ref
     )
     # Normalize repo URL to https://github.com/owner/name
     if ($RepoUrl -notmatch '^https?://github.com/[^/]+/[^/]+') { return $null }
     $prefix = ($RepoUrl -replace '/+$', '')
-    $branches = @('main', 'master')
+    $branches = if ($Ref) { @($Ref) } else { @('main', 'master') }
     $files = @(
         # Common US spelling
         'LICENSE', 'LICENSE.txt', 'LICENSE.md', 'LICENSE.TXT', 'License.txt',
@@ -224,6 +414,21 @@ function Get-GitHubLicenseContent {
                     return [pscustomobject]@{ Url = $raw; Content = $resp.Content }
                 }
             }
+        }
+    }
+    return $null
+}
+
+function Get-NuGetLicenseExpressionContent {
+    [CmdletBinding()]
+    param([Parameter(Mandatory = $true)][string]$Expression)
+
+    $licenseUrl = "https://licenses.nuget.org/$Expression"
+    $resp = Invoke-WebRequestSafe -Uri $licenseUrl
+    if ($resp -and $resp.Content) {
+        return [pscustomobject]@{
+            Url     = $licenseUrl
+            Content = (Convert-HtmlToText -Html $resp.Content)
         }
     }
     return $null
@@ -342,17 +547,38 @@ function Write-Notice([string]$OutputPath, $components) {
         $ghFromProject = if ($projectUrl) { ConvertTo-GitHubRepoUrl -Url $projectUrl } else { $null }
         $githubRepoUrl = if ($ghFromRepo) { $ghFromRepo } elseif ($ghFromProject) { $ghFromProject } else { $null }
         $isGitHubRepo = [string]::IsNullOrEmpty($githubRepoUrl) -eq $false
-        # Only consider NuGet's licenseUrl when repo is not GitHub; for GitHub we want raw LICENSE content.
-        $licenseUrl = if (-not $isGitHubRepo -and $meta -and $meta.LicenseUrl) { $meta.LicenseUrl } else { $null }
-        if ($licenseUrl -and $licenseUrl -like 'https://go.microsoft.com/fwlink*') { $licenseUrl = Get-FinalUrl -Uri $licenseUrl }
-        if ($licenseUrl -and $licenseUrl -match 'https?://github.com/.+') { $licenseUrl = Convert-GitHubBlobToRaw -Url $licenseUrl }
-        if (-not $isGitHubRepo -and -not $licenseUrl -and $meta -and $meta.LicenseExpression) {
-            $licenseUrl = "https://licenses.nuget.org/" + ([string]$meta.LicenseExpression)
-        }
+        $packageLicense = Get-NuGetPackageLicenseNotice -Id $id -Version $ver -PackageInfo $meta
+        $licenseUrls = @()
+        if ($packageLicense) { $licenseUrls += @($packageLicense.AvailableAt) }
+        $licenseContent = if ($packageLicense -and $packageLicense.Content) { [string]$packageLicense.Content } else { $null }
+        $repositoryCommit = if ($meta -and $meta.RepositoryCommit) { [string]$meta.RepositoryCommit } else { $null }
         $licenseGuess = $null
-        if ($isGitHubRepo) {
+        $licenseExpression = if ($meta -and $meta.LicenseExpression) { [string]$meta.LicenseExpression } else { $null }
+        if (-not $licenseContent -and $meta -and $meta.LicenseExpression) {
+            $licenseGuess = Get-NuGetLicenseExpressionContent -Expression $licenseExpression
+            if ($licenseGuess) {
+                $licenseUrls += $licenseGuess.Url
+                $licenseContent = [string]$licenseGuess.Content
+            }
+        }
+        if ($isGitHubRepo -and $repositoryCommit -and
+            (-not $licenseExpression -or -not $licenseContent -or
+                (Test-StandardizedLicenseTextNeedsPackageCopyright -Content $licenseContent -Expression $licenseExpression))) {
+            $licenseGuess = Get-GitHubLicenseContent -RepoUrl $githubRepoUrl -Ref $repositoryCommit
+            if ($licenseGuess) {
+                $githubLicenseContent = [string]$licenseGuess.Content
+                if (-not $licenseExpression -or (Test-LicenseContentMatchesExpression -Content $githubLicenseContent -Expression $licenseExpression)) {
+                    $licenseUrls += $licenseGuess.Url
+                    $licenseContent = $githubLicenseContent
+                }
+            }
+        }
+        if (-not $licenseContent -and $isGitHubRepo -and -not $repositoryCommit -and -not $licenseExpression) {
             $licenseGuess = Get-GitHubLicenseContent -RepoUrl $githubRepoUrl
-            if (-not $licenseUrl -and $licenseGuess) { $licenseUrl = $licenseGuess.Url }
+            if ($licenseGuess) {
+                $licenseUrls += $licenseGuess.Url
+                $licenseContent = [string]$licenseGuess.Content
+            }
         }
 
         $section = @()
@@ -361,14 +587,14 @@ function Write-Notice([string]$OutputPath, $components) {
         $section += "-------------------------------"
         if ($projectUrl) { $section += ""; $section += $projectUrl }
         elseif ($repoUrl) { $section += ""; $section += $repoUrl }
-        if ($licenseUrl) {
+        if (@($licenseUrls).Count -gt 0) {
             $section += ""
             $section += "Available at"
-            $section += $licenseUrl
+            $section += ($licenseUrls | Select-Object -Unique)
         }
-        if ($licenseGuess -and $licenseGuess.Content) {
+        if ($licenseContent) {
             $section += ""
-            $section += $licenseGuess.Content.Trim()
+            $section += (Format-NoticeContent -Text $licenseContent)
         }
         $sectionText = ($section -join [Environment]::NewLine)
         Add-Content -LiteralPath $OutputPath -Value $sectionText -Encoding UTF8
@@ -393,7 +619,7 @@ function Write-Notice([string]$OutputPath, $components) {
             $resp = Invoke-WebRequestSafe -Uri $runtimeRaw
             if ($resp -and $resp.Content) {
                 $msSection += ""
-                $msSection += $resp.Content.Trim()
+                $msSection += (Format-NoticeContent -Text $resp.Content)
             }
         }
     }
@@ -424,10 +650,21 @@ try {
     $manifestPath = Join-Path $repoRoot $ManifestDir
     New-DirectoryIfMissing -Path $manifestPath
 
-    $bomPath = Invoke-CycloneDX -ProjectPath $projectPath -OutDir $manifestPath
+    $projectInfo = Get-ProjectInfo -CsprojPath $projectPath
+    if ($projectInfo.TargetFramework -match '-windows' -and -not $IsWindows -and -not $env:EnableWindowsTargeting) {
+        $env:EnableWindowsTargeting = 'true'
+    }
+
+    $restoreArgs = @('restore', $projectPath, '--locked-mode')
+    if ($projectInfo.TargetFramework -match '-windows') { $restoreArgs += '-p:EnableWindowsTargeting=true' }
+    if ($projectInfo.RuntimeIdentifier) { $restoreArgs += "-p:RuntimeIdentifier=$($projectInfo.RuntimeIdentifier)" }
+    & dotnet @restoreArgs
+    if ($LASTEXITCODE -ne 0) { throw "dotnet restore failed with exit code $LASTEXITCODE." }
+
+    $bomPath = Invoke-CycloneDX -ProjectPath $projectPath -OutDir $manifestPath -TargetFramework $projectInfo.TargetFramework -RuntimeIdentifier $projectInfo.RuntimeIdentifier -DisablePackageRestore
     Write-Information "[CycloneDX] SBOM generated at: $bomPath"
 
-    $components = Read-Component -BomPath $bomPath
+    $components = @(Read-Component -BomPath $bomPath)
     Write-Information ("[Info] Components loaded: {0}" -f $components.Count)
 
     $outputPath = if ([IO.Path]::IsPathRooted($Output)) { $Output } else { Join-Path $repoRoot $Output }

--- a/src/public/app/PhiFailureDetector.Console/packages.lock.json
+++ b/src/public/app/PhiFailureDetector.Console/packages.lock.json
@@ -10,9 +10,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.5, )",
-        "resolved": "10.0.5",
-        "contentHash": "A+5ZuQ0f449tM+MQrhf6R9ZX7lYpjk/ODEwLYKrnF6111rtARx8fVsm4YznUnQiKnnXfaXNBqgxmil6RW3L3SA=="
+        "requested": "[10.0.7, )",
+        "resolved": "10.0.7",
+        "contentHash": "AA/yhzFHNtQZXLdqjzujPy25G8EWwGWsAnxOE2zYSBoT/8QHP6ketN3CToD3DFreO653ipUwnKHo22B8AlBMCw=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",

--- a/src/public/lib/CircularList/packages.lock.json
+++ b/src/public/lib/CircularList/packages.lock.json
@@ -236,9 +236,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.25, )",
-        "resolved": "8.0.25",
-        "contentHash": "sqX4nmBft05ivqKvUT4nxaN8rT3apCLt9SWFkfRrQPwra1zPwFknQAw1lleuMCKOCLvVmOWwrC2iPSm9RiXZUg=="
+        "requested": "[8.0.26, )",
+        "resolved": "8.0.26",
+        "contentHash": "o7/yVssM2r9Wyln2s9edBd5ANZXqdSdBI+g7JqXkyJmXrhs2WsJp25K5yPnYrTgdKBCjKB8bg+O2oew4sgzFaA=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
@@ -290,9 +290,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[9.0.14, )",
-        "resolved": "9.0.14",
-        "contentHash": "+MeWjj5sGq6Oj/l0E9RPMgXDyCIPxczzCbGuvuVTZFEGiy2S/atsfoAoKUnkEin/GeGpN+HenCzRmiQKSc99eQ=="
+        "requested": "[9.0.15, )",
+        "resolved": "9.0.15",
+        "contentHash": "EejcbfCMR77Dthy77qxRbEShmzLApHZUPqXMBVQK+A0pNrRThkaHoGGMGvbq/gTkC/waKcDEgjBkbaejB58Wtw=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",

--- a/src/public/lib/Hjg.Pngcs/packages.lock.json
+++ b/src/public/lib/Hjg.Pngcs/packages.lock.json
@@ -92,9 +92,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.25, )",
-        "resolved": "8.0.25",
-        "contentHash": "sqX4nmBft05ivqKvUT4nxaN8rT3apCLt9SWFkfRrQPwra1zPwFknQAw1lleuMCKOCLvVmOWwrC2iPSm9RiXZUg=="
+        "requested": "[8.0.26, )",
+        "resolved": "8.0.26",
+        "contentHash": "o7/yVssM2r9Wyln2s9edBd5ANZXqdSdBI+g7JqXkyJmXrhs2WsJp25K5yPnYrTgdKBCjKB8bg+O2oew4sgzFaA=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
@@ -132,9 +132,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[9.0.14, )",
-        "resolved": "9.0.14",
-        "contentHash": "+MeWjj5sGq6Oj/l0E9RPMgXDyCIPxczzCbGuvuVTZFEGiy2S/atsfoAoKUnkEin/GeGpN+HenCzRmiQKSc99eQ=="
+        "requested": "[9.0.15, )",
+        "resolved": "9.0.15",
+        "contentHash": "EejcbfCMR77Dthy77qxRbEShmzLApHZUPqXMBVQK+A0pNrRThkaHoGGMGvbq/gTkC/waKcDEgjBkbaejB58Wtw=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",

--- a/src/public/lib/Memoization/packages.lock.json
+++ b/src/public/lib/Memoization/packages.lock.json
@@ -310,9 +310,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.25, )",
-        "resolved": "8.0.25",
-        "contentHash": "sqX4nmBft05ivqKvUT4nxaN8rT3apCLt9SWFkfRrQPwra1zPwFknQAw1lleuMCKOCLvVmOWwrC2iPSm9RiXZUg=="
+        "requested": "[8.0.26, )",
+        "resolved": "8.0.26",
+        "contentHash": "o7/yVssM2r9Wyln2s9edBd5ANZXqdSdBI+g7JqXkyJmXrhs2WsJp25K5yPnYrTgdKBCjKB8bg+O2oew4sgzFaA=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
@@ -378,9 +378,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[9.0.14, )",
-        "resolved": "9.0.14",
-        "contentHash": "+MeWjj5sGq6Oj/l0E9RPMgXDyCIPxczzCbGuvuVTZFEGiy2S/atsfoAoKUnkEin/GeGpN+HenCzRmiQKSc99eQ=="
+        "requested": "[9.0.15, )",
+        "resolved": "9.0.15",
+        "contentHash": "EejcbfCMR77Dthy77qxRbEShmzLApHZUPqXMBVQK+A0pNrRThkaHoGGMGvbq/gTkC/waKcDEgjBkbaejB58Wtw=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",

--- a/src/public/lib/MicrosoftExtensions.Logging.MSTest/packages.lock.json
+++ b/src/public/lib/MicrosoftExtensions.Logging.MSTest/packages.lock.json
@@ -567,9 +567,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.25, )",
-        "resolved": "8.0.25",
-        "contentHash": "sqX4nmBft05ivqKvUT4nxaN8rT3apCLt9SWFkfRrQPwra1zPwFknQAw1lleuMCKOCLvVmOWwrC2iPSm9RiXZUg=="
+        "requested": "[8.0.26, )",
+        "resolved": "8.0.26",
+        "contentHash": "o7/yVssM2r9Wyln2s9edBd5ANZXqdSdBI+g7JqXkyJmXrhs2WsJp25K5yPnYrTgdKBCjKB8bg+O2oew4sgzFaA=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
@@ -658,9 +658,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[9.0.14, )",
-        "resolved": "9.0.14",
-        "contentHash": "+MeWjj5sGq6Oj/l0E9RPMgXDyCIPxczzCbGuvuVTZFEGiy2S/atsfoAoKUnkEin/GeGpN+HenCzRmiQKSc99eQ=="
+        "requested": "[9.0.15, )",
+        "resolved": "9.0.15",
+        "contentHash": "EejcbfCMR77Dthy77qxRbEShmzLApHZUPqXMBVQK+A0pNrRThkaHoGGMGvbq/gTkC/waKcDEgjBkbaejB58Wtw=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",

--- a/src/public/lib/MicrosoftExtensions.Logging.Xunit/packages.lock.json
+++ b/src/public/lib/MicrosoftExtensions.Logging.Xunit/packages.lock.json
@@ -243,9 +243,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.25, )",
-        "resolved": "8.0.25",
-        "contentHash": "sqX4nmBft05ivqKvUT4nxaN8rT3apCLt9SWFkfRrQPwra1zPwFknQAw1lleuMCKOCLvVmOWwrC2iPSm9RiXZUg=="
+        "requested": "[8.0.26, )",
+        "resolved": "8.0.26",
+        "contentHash": "o7/yVssM2r9Wyln2s9edBd5ANZXqdSdBI+g7JqXkyJmXrhs2WsJp25K5yPnYrTgdKBCjKB8bg+O2oew4sgzFaA=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
@@ -325,9 +325,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[9.0.14, )",
-        "resolved": "9.0.14",
-        "contentHash": "+MeWjj5sGq6Oj/l0E9RPMgXDyCIPxczzCbGuvuVTZFEGiy2S/atsfoAoKUnkEin/GeGpN+HenCzRmiQKSc99eQ=="
+        "requested": "[9.0.15, )",
+        "resolved": "9.0.15",
+        "contentHash": "EejcbfCMR77Dthy77qxRbEShmzLApHZUPqXMBVQK+A0pNrRThkaHoGGMGvbq/gTkC/waKcDEgjBkbaejB58Wtw=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",

--- a/src/public/lib/PhiFailureDetector/packages.lock.json
+++ b/src/public/lib/PhiFailureDetector/packages.lock.json
@@ -265,9 +265,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.25, )",
-        "resolved": "8.0.25",
-        "contentHash": "sqX4nmBft05ivqKvUT4nxaN8rT3apCLt9SWFkfRrQPwra1zPwFknQAw1lleuMCKOCLvVmOWwrC2iPSm9RiXZUg=="
+        "requested": "[8.0.26, )",
+        "resolved": "8.0.26",
+        "contentHash": "o7/yVssM2r9Wyln2s9edBd5ANZXqdSdBI+g7JqXkyJmXrhs2WsJp25K5yPnYrTgdKBCjKB8bg+O2oew4sgzFaA=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
@@ -319,9 +319,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[9.0.14, )",
-        "resolved": "9.0.14",
-        "contentHash": "+MeWjj5sGq6Oj/l0E9RPMgXDyCIPxczzCbGuvuVTZFEGiy2S/atsfoAoKUnkEin/GeGpN+HenCzRmiQKSc99eQ=="
+        "requested": "[9.0.15, )",
+        "resolved": "9.0.15",
+        "contentHash": "EejcbfCMR77Dthy77qxRbEShmzLApHZUPqXMBVQK+A0pNrRThkaHoGGMGvbq/gTkC/waKcDEgjBkbaejB58Wtw=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",


### PR DESCRIPTION
## Summary
- remediate GHSA-jxpf-xq2m-q525 by upgrading FileSignatures to a version compatible with OpenMcdf 3.1.3
- refresh .NET lock files required for locked restore under the current SDK/workload inputs
- regenerate ImageOcclusionEditor third-party notices and make notice generation prefer versioned NuGet license data

## Validation
- `dotnet restore dirs.proj --locked-mode`
- `dotnet restore dirs.proj --locked-mode -p:EnableWindowsTargeting=true`
- `dotnet restore src/public/app/ImageOcclusionEditor/ImageOcclusionEditorWinUI3/ImageOcclusionEditorWinUI3.csproj --locked-mode -p:EnableWindowsTargeting=true -p:RuntimeIdentifier=win-x64 -p:RuntimeIdentifiers=win-x64`
- `git --no-pager diff --check`
