### PR TITLE
Fix Hook Surface Output Per Client

### DIFF
--- a/src/private/app/vscode-copilot-telegram-hook/Commands/HookCommandService.cs
+++ b/src/private/app/vscode-copilot-telegram-hook/Commands/HookCommandService.cs
@@ -20,6 +20,10 @@ internal sealed class HookCommandService(
     ILogger<HookCommandService> logger)
 {
     private const string UtcTimestampFormat = "yyyy-MM-ddTHH:mm:ss.fff'Z'";
+    private static readonly HookOutputAdapter VsCodeAdapter =
+        new HookSpecificOutputAdapter();
+    private static readonly HookOutputAdapter CopilotCliAdapter =
+        new CopilotCliOutputAdapter();
 
     public async Task<int> HandleSessionStartAsync(
         Stream standardInput,
@@ -127,9 +131,9 @@ internal sealed class HookCommandService(
                 hookInput,
                 observation,
                 cancellationToken);
-            await WriteAdditionalContextResponseAsync(
+            await WriteUserPromptSubmitResponseAsync(
                 standardOutput,
-                "UserPromptSubmit",
+                hookInput.Prompt ?? string.Empty,
                 BuildNotificationAssignmentContext(workspacePath, turn),
                 cancellationToken);
         }
@@ -1149,19 +1153,38 @@ internal sealed class HookCommandService(
         string hookEventName,
         string additionalContext,
         CancellationToken cancellationToken)
-    {
-        if (hookExecutionContext.GetSurface() == HookSurface.CopilotCli)
-        {
-            await WriteCopilotCliHookOutputAsync(
-                standardOutput,
-                new CopilotCliHookOutput
-                {
-                    AdditionalContext = additionalContext,
-                },
-                cancellationToken);
-            return;
-        }
+        => await GetHookOutputAdapter().WriteAdditionalContextResponseAsync(
+            standardOutput,
+            hookEventName,
+            additionalContext,
+            cancellationToken);
 
+    private async Task WriteUserPromptSubmitResponseAsync(
+        Stream standardOutput,
+        string prompt,
+        string additionalContext,
+        CancellationToken cancellationToken)
+        => await GetHookOutputAdapter().WriteUserPromptSubmitResponseAsync(
+            standardOutput,
+            prompt,
+            additionalContext,
+            cancellationToken);
+
+    private HookOutputAdapter GetHookOutputAdapter()
+        => hookExecutionContext.GetSurface() switch
+        {
+            HookSurface.CopilotCli => CopilotCliAdapter,
+            HookSurface.VsCode => VsCodeAdapter,
+            _ => throw new InvalidOperationException(
+                $"Unsupported hook surface '{hookExecutionContext.GetSurface()}'."),
+        };
+
+    private static async Task WriteHookSpecificOutputResponseAsync(
+        Stream standardOutput,
+        string hookEventName,
+        string additionalContext,
+        CancellationToken cancellationToken)
+    {
         await WriteVsCodeHookResponseAsync(
             standardOutput,
             new HookResponse
@@ -1174,6 +1197,11 @@ internal sealed class HookCommandService(
             },
             cancellationToken);
     }
+
+    private static string BuildCopilotCliUserPromptSubmitModifiedPrompt(
+        string prompt,
+        string additionalContext)
+        => $"{prompt}\n\n<system_reminder>\n{additionalContext}\n</system_reminder>";
 
     private static async Task WriteVsCodeHookResponseAsync(
         Stream standardOutput,
@@ -1197,6 +1225,77 @@ internal sealed class HookCommandService(
             output,
             AppJsonSerializerContext.Default.CopilotCliHookOutput,
             cancellationToken);
+    }
+
+    private abstract class HookOutputAdapter
+    {
+        public abstract Task WriteAdditionalContextResponseAsync(
+            Stream standardOutput,
+            string hookEventName,
+            string additionalContext,
+            CancellationToken cancellationToken);
+
+        public abstract Task WriteUserPromptSubmitResponseAsync(
+            Stream standardOutput,
+            string prompt,
+            string additionalContext,
+            CancellationToken cancellationToken);
+    }
+
+    private sealed class HookSpecificOutputAdapter : HookOutputAdapter
+    {
+        public override Task WriteAdditionalContextResponseAsync(
+            Stream standardOutput,
+            string hookEventName,
+            string additionalContext,
+            CancellationToken cancellationToken)
+            => WriteHookSpecificOutputResponseAsync(
+                standardOutput,
+                hookEventName,
+                additionalContext,
+                cancellationToken);
+
+        public override Task WriteUserPromptSubmitResponseAsync(
+            Stream standardOutput,
+            string prompt,
+            string additionalContext,
+            CancellationToken cancellationToken)
+            => WriteHookSpecificOutputResponseAsync(
+                standardOutput,
+                "UserPromptSubmit",
+                additionalContext,
+                cancellationToken);
+    }
+
+    private sealed class CopilotCliOutputAdapter : HookOutputAdapter
+    {
+        public override Task WriteAdditionalContextResponseAsync(
+            Stream standardOutput,
+            string hookEventName,
+            string additionalContext,
+            CancellationToken cancellationToken)
+            => WriteCopilotCliHookOutputAsync(
+                standardOutput,
+                new CopilotCliHookOutput
+                {
+                    AdditionalContext = additionalContext,
+                },
+                cancellationToken);
+
+        public override Task WriteUserPromptSubmitResponseAsync(
+            Stream standardOutput,
+            string prompt,
+            string additionalContext,
+            CancellationToken cancellationToken)
+            => WriteCopilotCliHookOutputAsync(
+                standardOutput,
+                new CopilotCliHookOutput
+                {
+                    ModifiedPrompt = BuildCopilotCliUserPromptSubmitModifiedPrompt(
+                        prompt,
+                        additionalContext),
+                },
+                cancellationToken);
     }
 
     private sealed record SummaryValidationResult(

--- a/src/private/app/vscode-copilot-telegram-hook/Models/AppModels.cs
+++ b/src/private/app/vscode-copilot-telegram-hook/Models/AppModels.cs
@@ -75,8 +75,14 @@ internal sealed class HookResponse
 
 internal sealed class CopilotCliHookOutput
 {
+    [JsonPropertyName("modifiedPrompt")]
+    public string? ModifiedPrompt { get; init; }
+
     [JsonPropertyName("additionalContext")]
     public string? AdditionalContext { get; init; }
+
+    [JsonPropertyName("suppressOutput")]
+    public bool? SuppressOutput { get; init; }
 
     [JsonPropertyName("decision")]
     public string? Decision { get; init; }

--- a/src/private/app/vscode-copilot-telegram-hook/UserHookConfigurationManager.cs
+++ b/src/private/app/vscode-copilot-telegram-hook/UserHookConfigurationManager.cs
@@ -587,13 +587,8 @@ internal static class UserHookConfigurationManager
     private static bool IsManagedCopilotCliHookEntryForRemoval(UserHookEntry? entry)
     {
         return IsManagedHookEntry(entry)
-            && entry?.Env.TryGetValue(
-                AppConstants.ManagedHookSurfaceEnvironmentVariable,
-                out string? surfaceValue) == true
-            && string.Equals(
-                surfaceValue,
-                AppConstants.ManagedHookCopilotCliSurfaceValue,
-                StringComparison.Ordinal);
+            && (IsManagedCopilotCliSurfaceEntry(entry)
+                || IsLegacyManagedCopilotCliEntry(entry));
     }
 
     private static bool IsStrictManagedCopilotCliHookEntry(
@@ -611,6 +606,25 @@ internal static class UserHookConfigurationManager
                 AppConstants.ManagedHookEventEnvironmentVariable,
                 out string? entryEventName)
             && string.Equals(entryEventName, eventName, StringComparison.Ordinal);
+    }
+
+    private static bool IsManagedCopilotCliSurfaceEntry(UserHookEntry? entry)
+    {
+        return entry?.Env.TryGetValue(
+            AppConstants.ManagedHookSurfaceEnvironmentVariable,
+            out string? surfaceValue) == true
+            && string.Equals(
+                surfaceValue,
+                AppConstants.ManagedHookCopilotCliSurfaceValue,
+                StringComparison.Ordinal);
+    }
+
+    private static bool IsLegacyManagedCopilotCliEntry(UserHookEntry? entry)
+    {
+        return entry is not null
+            && entry.TimeoutSec is not null
+            && !entry.TimeoutPropertyPresent
+            && !entry.Env.ContainsKey(AppConstants.ManagedHookSurfaceEnvironmentVariable);
     }
 
     private static bool CanDeleteManagedHookFile(

--- a/tests/private/app/vscode-copilot-telegram-hook/HookCommandServiceTests.cs
+++ b/tests/private/app/vscode-copilot-telegram-hook/HookCommandServiceTests.cs
@@ -298,6 +298,7 @@ public sealed class HookCommandServiceTests
                 "session-123",
                 CancellationToken.None));
             HookResponse response = await DeserializeHookResponseAsync(output);
+            Assert.Equal("UserPromptSubmit", response.HookSpecificOutput?.HookEventName);
             string assignment = Assert.IsType<string>(
                 response.HookSpecificOutput?.AdditionalContext);
             Assert.Contains(AppPaths.GetSummaryStatePath(
@@ -306,6 +307,140 @@ public sealed class HookCommandServiceTests
                 turn.NotificationTurnId), assignment, StringComparison.Ordinal);
             Assert.Contains(turn.NotificationNonce, assignment, StringComparison.Ordinal);
             Assert.DoesNotContain("notify-summary.json", assignment, StringComparison.Ordinal);
+        }
+        finally
+        {
+            tempDirectory.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task HandleUserPromptSubmitAsyncUsesHookSpecificContextForVsCodeSurface()
+    {
+        DirectoryInfo tempDirectory = Directory.CreateTempSubdirectory();
+
+        try
+        {
+            WorkspaceStateStore stateStore = new(
+                TimeProvider.System,
+                NullLogger<WorkspaceStateStore>.Instance);
+            HookCommandService service = CreateHookCommandService(
+                new RecordingHttpMessageHandler(),
+                stateStore: stateStore,
+                surface: HookSurface.VsCode);
+            UserPromptSubmitHookInput promptInput = new()
+            {
+                Cwd = tempDirectory.FullName,
+                SessionId = "session-123",
+                Timestamp = "2026-03-14T15:51:50.783Z",
+                TranscriptPath = "/workspace/transcript.json",
+                Prompt = "Ship the notification redesign.",
+            };
+            await using MemoryStream output = new();
+
+            int exitCode = await service.HandleUserPromptSubmitAsync(
+                CreateJsonStream(
+                    promptInput,
+                    AppJsonSerializerContext.Default.UserPromptSubmitHookInput),
+                output,
+                CancellationToken.None);
+
+            Assert.Equal(0, exitCode);
+            NotificationTurn turn = Assert.Single(await stateStore.ListOpenTurnsAsync(
+                tempDirectory.FullName,
+                "session-123",
+                CancellationToken.None));
+            JsonElement root = ReadJsonRootElement(output);
+            AssertJsonProperties(root, "hookSpecificOutput");
+            JsonElement hookSpecificOutput = root.GetProperty("hookSpecificOutput");
+            AssertJsonProperties(
+                hookSpecificOutput,
+                "hookEventName",
+                "additionalContext");
+            Assert.Equal(
+                "UserPromptSubmit",
+                hookSpecificOutput.GetProperty("hookEventName").GetString());
+            Assert.False(root.TryGetProperty("modifiedPrompt", out _));
+            Assert.False(root.TryGetProperty("additionalContext", out _));
+            HookResponse response = await DeserializeHookResponseAsync(output);
+            Assert.Equal("UserPromptSubmit", response.HookSpecificOutput?.HookEventName);
+            string assignment = Assert.IsType<string>(
+                response.HookSpecificOutput?.AdditionalContext);
+            Assert.Contains(AppPaths.GetSummaryStatePath(
+                tempDirectory.FullName,
+                "session-123",
+                turn.NotificationTurnId), assignment, StringComparison.Ordinal);
+            Assert.Contains(turn.NotificationNonce, assignment, StringComparison.Ordinal);
+        }
+        finally
+        {
+            tempDirectory.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task HandleUserPromptSubmitAsyncUsesModifiedPromptForCopilotCliAssignment()
+    {
+        DirectoryInfo tempDirectory = Directory.CreateTempSubdirectory();
+
+        try
+        {
+            WorkspaceStateStore stateStore = new(
+                TimeProvider.System,
+                NullLogger<WorkspaceStateStore>.Instance);
+            HookCommandService service = CreateHookCommandService(
+                new RecordingHttpMessageHandler(),
+                stateStore: stateStore,
+                surface: HookSurface.CopilotCli);
+            UserPromptSubmitHookInput promptInput = new()
+            {
+                Cwd = tempDirectory.FullName,
+                SessionId = "session-123",
+                Timestamp = "2026-03-14T15:51:50.783Z",
+                TranscriptPath = "/workspace/transcript.json",
+                Prompt = "Ship the notification redesign.",
+            };
+            await using MemoryStream output = new();
+
+            int exitCode = await service.HandleUserPromptSubmitAsync(
+                CreateJsonStream(
+                    promptInput,
+                    AppJsonSerializerContext.Default.UserPromptSubmitHookInput),
+                output,
+                CancellationToken.None);
+
+            Assert.Equal(0, exitCode);
+            NotificationTurn turn = Assert.Single(await stateStore.ListOpenTurnsAsync(
+                tempDirectory.FullName,
+                "session-123",
+                CancellationToken.None));
+            JsonElement root = ReadJsonRootElement(output);
+            AssertJsonProperties(root, "modifiedPrompt");
+            Assert.False(root.TryGetProperty("hookSpecificOutput", out _));
+            Assert.False(root.TryGetProperty("additionalContext", out _));
+            CopilotCliHookOutput response = await DeserializeCopilotCliHookOutputAsync(output);
+            Assert.Null(response.AdditionalContext);
+            string modifiedPrompt = Assert.IsType<string>(response.ModifiedPrompt);
+            const string reminderStart = "\n\n<system_reminder>\n";
+            const string reminderEnd = "\n</system_reminder>";
+            Assert.StartsWith(
+                promptInput.Prompt + reminderStart,
+                modifiedPrompt,
+                StringComparison.Ordinal);
+            Assert.EndsWith(reminderEnd, modifiedPrompt, StringComparison.Ordinal);
+            string assignment = modifiedPrompt.Substring(
+                promptInput.Prompt.Length + reminderStart.Length,
+                modifiedPrompt.Length
+                    - promptInput.Prompt.Length
+                    - reminderStart.Length
+                    - reminderEnd.Length);
+            Assert.Equal(promptInput.Prompt + reminderStart + assignment + reminderEnd, modifiedPrompt);
+            Assert.StartsWith("Notification Assignment", assignment, StringComparison.Ordinal);
+            Assert.Contains(AppPaths.GetSummaryStatePath(
+                tempDirectory.FullName,
+                "session-123",
+                turn.NotificationTurnId), assignment, StringComparison.Ordinal);
+            Assert.Contains(turn.NotificationNonce, assignment, StringComparison.Ordinal);
         }
         finally
         {
@@ -1762,6 +1897,34 @@ public sealed class HookCommandServiceTests
                 AppJsonSerializerContext.Default.HookResponse,
                 CancellationToken.None)
             ?? throw new InvalidOperationException("Expected a valid hook response.");
+    }
+
+    private static async Task<CopilotCliHookOutput> DeserializeCopilotCliHookOutputAsync(
+        MemoryStream output)
+    {
+        output.Position = 0;
+        return await JsonSerializer.DeserializeAsync(
+                output,
+                AppJsonSerializerContext.Default.CopilotCliHookOutput,
+                CancellationToken.None)
+            ?? throw new InvalidOperationException("Expected a valid Copilot CLI hook output.");
+    }
+
+    private static JsonElement ReadJsonRootElement(MemoryStream output)
+    {
+        using JsonDocument document = JsonDocument.Parse(output.ToArray());
+        return document.RootElement.Clone();
+    }
+
+    private static void AssertJsonProperties(JsonElement element, params string[] expectedNames)
+    {
+        string[] actualNames = element.EnumerateObject()
+            .Select(static property => property.Name)
+            .OrderBy(static name => name, StringComparer.Ordinal)
+            .ToArray();
+        Assert.Equal(
+            expectedNames.Order(StringComparer.Ordinal).ToArray(),
+            actualNames);
     }
 
     private static async Task WriteSummaryAsync(

--- a/tests/private/app/vscode-copilot-telegram-hook/HookCommandServiceTests.cs
+++ b/tests/private/app/vscode-copilot-telegram-hook/HookCommandServiceTests.cs
@@ -434,7 +434,9 @@ public sealed class HookCommandServiceTests
                     - promptInput.Prompt.Length
                     - reminderStart.Length
                     - reminderEnd.Length);
-            Assert.Equal(promptInput.Prompt + reminderStart + assignment + reminderEnd, modifiedPrompt);
+            Assert.Equal(
+                promptInput.Prompt + reminderStart + assignment + reminderEnd,
+                modifiedPrompt);
             Assert.StartsWith("Notification Assignment", assignment, StringComparison.Ordinal);
             Assert.Contains(AppPaths.GetSummaryStatePath(
                 tempDirectory.FullName,

--- a/tests/private/app/vscode-copilot-telegram-hook/HookExecutionContextTests.cs
+++ b/tests/private/app/vscode-copilot-telegram-hook/HookExecutionContextTests.cs
@@ -37,4 +37,16 @@ public sealed class HookExecutionContextTests : IDisposable
 
         Assert.Equal(HookSurface.CopilotCli, context.GetSurface());
     }
+
+    [Fact]
+    public void GetSurfaceDefaultsToVsCodeForUnknownSurfaceEnvironmentVariable()
+    {
+        Environment.SetEnvironmentVariable(
+            AppConstants.ManagedHookSurfaceEnvironmentVariable,
+            "unknown-surface");
+
+        HookExecutionContext context = new();
+
+        Assert.Equal(HookSurface.VsCode, context.GetSurface());
+    }
 }

--- a/tests/private/app/vscode-copilot-telegram-hook/UserHookConfigurationManagerTests.cs
+++ b/tests/private/app/vscode-copilot-telegram-hook/UserHookConfigurationManagerTests.cs
@@ -222,6 +222,104 @@ public sealed class UserHookConfigurationManagerTests
     }
 
     [Fact]
+    public void InstallManagedCopilotCliHookFileMigratesLegacyManagedTimeoutSecEntries()
+    {
+        DirectoryInfo tempDirectory = Directory.CreateTempSubdirectory();
+
+        try
+        {
+            string hookFilePath = Path.Combine(
+                tempDirectory.FullName,
+                AppConstants.CopilotCliHookFileName);
+            File.WriteAllText(
+                hookFilePath,
+                """
+                {
+                  "version": 1,
+                  "hooks": {
+                    "SessionStart": [
+                      {
+                        "type": "command",
+                        "command": "custom session-start",
+                        "timeoutSec": 10,
+                        "env": {
+                          "CUSTOM_FLAG": "1"
+                        }
+                      },
+                      {
+                        "type": "command",
+                        "command": "legacy managed session-start",
+                        "timeoutSec": 10,
+                        "env": {
+                          "HCOONA_VSCODE_COPILOT_TELEGRAM_HOOK": "1"
+                        }
+                      }
+                    ],
+                    "UserPromptSubmit": [
+                      {
+                        "type": "command",
+                        "command": "legacy managed user-prompt-submit",
+                        "timeoutSec": 10,
+                        "env": {
+                          "HCOONA_VSCODE_COPILOT_TELEGRAM_HOOK": "1"
+                        }
+                      }
+                    ],
+                    "Stop": [
+                      {
+                        "type": "command",
+                        "command": "legacy managed stop",
+                        "timeoutSec": 20,
+                        "env": {
+                          "HCOONA_VSCODE_COPILOT_TELEGRAM_HOOK": "1"
+                        }
+                      }
+                    ]
+                  }
+                }
+                """);
+
+            ConfigurationApplyResult installResult =
+                UserHookConfigurationManager.InstallManagedCopilotCliHookFile(
+                    hookFilePath,
+                    "managed session-start",
+                    "managed user-prompt-submit",
+                    "managed stop",
+                    "2026-03-13T12:34:56.789Z");
+
+            Assert.True(installResult.Applied);
+            UserHookSettingsDocument installedSettings = ReadSettings(hookFilePath);
+            Assert.True(
+                UserHookConfigurationManager.IsManagedCopilotCliHookFileInstalled(hookFilePath));
+            Assert.DoesNotContain(
+                installedSettings.Hooks.SelectMany(static pair => pair.Value),
+                static entry => entry.Command?.StartsWith(
+                    "legacy managed ",
+                    StringComparison.Ordinal) == true);
+            Assert.Contains(
+                installedSettings.Hooks["SessionStart"],
+                static entry => entry.Command == "custom session-start");
+
+            foreach (string eventName in new[] { "SessionStart", "UserPromptSubmit", "Stop" })
+            {
+                UserHookEntry managedEntry = Assert.Single(
+                    installedSettings.Hooks[eventName],
+                    entry => entry.Env.TryGetValue(
+                        AppConstants.ManagedHookSurfaceEnvironmentVariable,
+                        out string? surface)
+                        && surface == AppConstants.ManagedHookCopilotCliSurfaceValue);
+                Assert.Equal(
+                    eventName,
+                    managedEntry.Env[AppConstants.ManagedHookEventEnvironmentVariable]);
+            }
+        }
+        finally
+        {
+            tempDirectory.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
     public void InstallManagedCopilotCliHookFilePreservesExplicitNullTimeoutOnUnrelatedEntries()
     {
         DirectoryInfo tempDirectory = Directory.CreateTempSubdirectory();


### PR DESCRIPTION
## Summary
- Preserve VS Code UserPromptSubmit output through hookSpecificOutput.additionalContext
- Use Copilot CLI modifiedPrompt for current-turn notification summary assignments
- Migrate legacy managed Copilot CLI hook entries without surface markers

## Validation
- dotnet test tests/private/app/vscode-copilot-telegram-hook/Hcoona.VsCodeCopilotTelegramHook.Tests.csproj --no-restore
- dotnet format tests/private/app/vscode-copilot-telegram-hook/Hcoona.VsCodeCopilotTelegramHook.Tests.csproj --verify-no-changes --no-restore
- hk check --pr