### PR TITLE
fix: Prefer Chinese in Telegram Summary Assignment

### DIFF
--- a/src/private/app/vscode-copilot-telegram-hook/Commands/HookCommandService.cs
+++ b/src/private/app/vscode-copilot-telegram-hook/Commands/HookCommandService.cs
@@ -860,7 +860,8 @@ internal sealed class HookCommandService(
                 $"notification_turn_id='{turn.NotificationTurnId}',",
                 $"notification_nonce='{turn.NotificationNonce}'.",
                 "updated_at must be a UTC timestamp in yyyy-MM-ddTHH:mm:ss.fffZ format.",
-                "summary must be a non-empty concise human-readable sentence.",
+                "summary must be a non-empty concise human-readable sentence;",
+                "prefer Chinese when practical, but a usable non-Chinese summary is allowed.",
                 "details, changed_files, and next_steps must be JSON arrays.",
                 "Do not write legacy singleton notification files.",
             ]);

--- a/src/private/app/vscode-copilot-telegram-hook/Commands/HookCommandService.cs
+++ b/src/private/app/vscode-copilot-telegram-hook/Commands/HookCommandService.cs
@@ -691,6 +691,7 @@ internal sealed class HookCommandService(
 
         string trimmed = prompt.TrimStart();
         if (trimmed.StartsWith("<system_reminder>", StringComparison.OrdinalIgnoreCase)
+            || trimmed.StartsWith("<system_notification>", StringComparison.OrdinalIgnoreCase)
             || trimmed.StartsWith("Contents of AGENTS.md", StringComparison.OrdinalIgnoreCase)
             || IsExplicitSubagentHandoff(trimmed)
             || trimmed.Contains("Coder subagent", StringComparison.OrdinalIgnoreCase)
@@ -861,7 +862,8 @@ internal sealed class HookCommandService(
                 $"notification_nonce='{turn.NotificationNonce}'.",
                 "updated_at must be a UTC timestamp in yyyy-MM-ddTHH:mm:ss.fffZ format.",
                 "summary must be a non-empty concise human-readable sentence;",
-                "prefer Chinese when practical, but a usable non-Chinese summary is allowed.",
+                "write summary in Chinese when practical,",
+                "but a usable non-Chinese summary is allowed.",
                 "details, changed_files, and next_steps must be JSON arrays.",
                 "Do not write legacy singleton notification files.",
             ]);

--- a/src/private/app/vscode-copilot-telegram-hook/README.md
+++ b/src/private/app/vscode-copilot-telegram-hook/README.md
@@ -222,8 +222,9 @@ For summary generation, the hook emits a Notification Assignment for
 high-confidence main user prompts. Only that assignment authorizes writing a
 summary, and the agent must write only the exact per-turn `summary.json` path
 with matching `session_id`, `notification_turn_id`, `notification_nonce`,
-`updated_at`, and non-empty `summary`; prefer Chinese when practical, but a
-usable non-Chinese summary is allowed. The default `Stop` behavior never blocks:
+`updated_at`, and non-empty `summary`; write the summary in Chinese when
+practical, but a usable non-Chinese summary is allowed. The default `Stop`
+behavior never blocks:
 valid summaries are sent normally, while missing, stale, ambiguous, or invalid
 handoffs produce a degraded fallback notification with durable duplicate
 suppression.

--- a/src/private/app/vscode-copilot-telegram-hook/README.md
+++ b/src/private/app/vscode-copilot-telegram-hook/README.md
@@ -222,8 +222,8 @@ For summary generation, the hook emits a Notification Assignment for
 high-confidence main user prompts. Only that assignment authorizes writing a
 summary, and the agent must write only the exact per-turn `summary.json` path
 with matching `session_id`, `notification_turn_id`, `notification_nonce`,
-`updated_at`, and non-empty `summary`, preferring Chinese when practical. The
-default `Stop` behavior never blocks:
+`updated_at`, and non-empty `summary`; prefer Chinese when practical, but a
+usable non-Chinese summary is allowed. The default `Stop` behavior never blocks:
 valid summaries are sent normally, while missing, stale, ambiguous, or invalid
 handoffs produce a degraded fallback notification with durable duplicate
 suppression.

--- a/src/private/app/vscode-copilot-telegram-hook/README.md
+++ b/src/private/app/vscode-copilot-telegram-hook/README.md
@@ -222,7 +222,8 @@ For summary generation, the hook emits a Notification Assignment for
 high-confidence main user prompts. Only that assignment authorizes writing a
 summary, and the agent must write only the exact per-turn `summary.json` path
 with matching `session_id`, `notification_turn_id`, `notification_nonce`,
-`updated_at`, and non-empty `summary`. The default `Stop` behavior never blocks:
+`updated_at`, and non-empty `summary`, preferring Chinese when practical. The
+default `Stop` behavior never blocks:
 valid summaries are sent normally, while missing, stale, ambiguous, or invalid
 handoffs produce a degraded fallback notification with durable duplicate
 suppression.

--- a/tests/private/app/vscode-copilot-telegram-hook/HookCommandServiceTests.cs
+++ b/tests/private/app/vscode-copilot-telegram-hook/HookCommandServiceTests.cs
@@ -371,6 +371,7 @@ public sealed class HookCommandServiceTests
                 "session-123",
                 turn.NotificationTurnId), assignment, StringComparison.Ordinal);
             Assert.Contains(turn.NotificationNonce, assignment, StringComparison.Ordinal);
+            Assert.Contains("prefer Chinese when practical", assignment, StringComparison.Ordinal);
         }
         finally
         {

--- a/tests/private/app/vscode-copilot-telegram-hook/HookCommandServiceTests.cs
+++ b/tests/private/app/vscode-copilot-telegram-hook/HookCommandServiceTests.cs
@@ -444,6 +444,7 @@ public sealed class HookCommandServiceTests
                 "session-123",
                 turn.NotificationTurnId), assignment, StringComparison.Ordinal);
             Assert.Contains(turn.NotificationNonce, assignment, StringComparison.Ordinal);
+            Assert.Contains("prefer Chinese when practical", assignment, StringComparison.Ordinal);
         }
         finally
         {

--- a/tests/private/app/vscode-copilot-telegram-hook/HookCommandServiceTests.cs
+++ b/tests/private/app/vscode-copilot-telegram-hook/HookCommandServiceTests.cs
@@ -169,6 +169,55 @@ public sealed class HookCommandServiceTests
     }
 
     [Fact]
+    public async Task HandleUserPromptSubmitAsyncTreatsSystemNotificationAsObservationOnly()
+    {
+        DirectoryInfo tempDirectory = Directory.CreateTempSubdirectory();
+
+        try
+        {
+            WorkspaceStateStore stateStore = new(
+                TimeProvider.System,
+                NullLogger<WorkspaceStateStore>.Instance);
+            HookCommandService service = CreateHookCommandService(
+                new RecordingHttpMessageHandler(),
+                stateStore: stateStore);
+            UserPromptSubmitHookInput promptInput = new()
+            {
+                Cwd = tempDirectory.FullName,
+                SessionId = "session-123",
+                Timestamp = "2026-03-14T15:51:45.783Z",
+                TranscriptPath = "/workspace/transcript.json",
+                Prompt = string.Join(
+                    '\n',
+                    [
+                        "<system_notification>",
+                        "Agent finished processing.",
+                        "</system_notification>",
+                    ]),
+            };
+            await using MemoryStream output = new();
+
+            int exitCode = await service.HandleUserPromptSubmitAsync(
+                CreateJsonStream(
+                    promptInput,
+                    AppJsonSerializerContext.Default.UserPromptSubmitHookInput),
+                output,
+                CancellationToken.None);
+
+            Assert.Equal(0, exitCode);
+            Assert.Equal(0, output.Length);
+            Assert.Empty(await stateStore.ListOpenTurnsAsync(
+                tempDirectory.FullName,
+                "session-123",
+                CancellationToken.None));
+        }
+        finally
+        {
+            tempDirectory.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task ReviewerSubagentStopDoesNotCloseMainTurnAndLaterMainStopCanNotify()
     {
         DirectoryInfo tempDirectory = Directory.CreateTempSubdirectory();
@@ -371,7 +420,10 @@ public sealed class HookCommandServiceTests
                 "session-123",
                 turn.NotificationTurnId), assignment, StringComparison.Ordinal);
             Assert.Contains(turn.NotificationNonce, assignment, StringComparison.Ordinal);
-            Assert.Contains("prefer Chinese when practical", assignment, StringComparison.Ordinal);
+            Assert.Contains(
+                "write summary in Chinese when practical",
+                assignment,
+                StringComparison.Ordinal);
         }
         finally
         {
@@ -444,7 +496,10 @@ public sealed class HookCommandServiceTests
                 "session-123",
                 turn.NotificationTurnId), assignment, StringComparison.Ordinal);
             Assert.Contains(turn.NotificationNonce, assignment, StringComparison.Ordinal);
-            Assert.Contains("prefer Chinese when practical", assignment, StringComparison.Ordinal);
+            Assert.Contains(
+                "write summary in Chinese when practical",
+                assignment,
+                StringComparison.Ordinal);
         }
         finally
         {


### PR DESCRIPTION
## Summary
- Restore the Chinese-preferred hint in the Telegram hook Notification Assignment
- Document the runtime summary language preference in the app README
- Cover the assignment text with a regression assertion

## Validation
- dotnet test tests/private/app/vscode-copilot-telegram-hook/Hcoona.VsCodeCopilotTelegramHook.Tests.csproj --no-restore --nologo
- hk check --pr