### PR TITLE
fix: enable JSON reflection for Qidian downloader

### DIFF
--- a/src/private/app/qidian-novel-downloader/QidianNovelDownloader.csproj
+++ b/src/private/app/qidian-novel-downloader/QidianNovelDownloader.csproj
@@ -9,6 +9,9 @@
 
     <AssemblyName>qidian-novel-downloader</AssemblyName>
     <RootNamespace>Hcoona.QidianNovelDownloader</RootNamespace>
+
+    <!-- Microsoft.Playwright requires reflection-based System.Text.Json at runtime. -->
+    <JsonSerializerIsReflectionEnabledByDefault>true</JsonSerializerIsReflectionEnabledByDefault>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- Enables reflection-based System.Text.Json for qidian-novel-downloader only
- Documents that Microsoft.Playwright requires JSON reflection at runtime

## Validation
- dotnet msbuild .\src\private\app\qidian-novel-downloader\QidianNovelDownloader.csproj -getProperty:JsonSerializerIsReflectionEnabledByDefault
- dotnet test .\tests\private\app\qidian-novel-downloader\Hcoona.QidianNovelDownloader.Tests.csproj --no-restore
- dotnet run --project .\src\private\app\qidian-novel-downloader\QidianNovelDownloader.csproj -- download https://www.qidian.com/book/1047182089/ --dry-run