### PR TITLE
fix: enable JSON reflection for Oxford learners processor

### DIFF
--- a/src/private/app/OxfordLearnersDictionaryProcessor/OxfordLearnersDictionaryProcessor.csproj
+++ b/src/private/app/OxfordLearnersDictionaryProcessor/OxfordLearnersDictionaryProcessor.csproj
@@ -8,6 +8,9 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
+    <!-- This app uses reflection-based System.Text.Json directly and via AI SDK dependencies. -->
+    <JsonSerializerIsReflectionEnabledByDefault>true</JsonSerializerIsReflectionEnabledByDefault>
+
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
 
   </PropertyGroup>


### PR DESCRIPTION
## Summary
- Enables reflection-based System.Text.Json for OxfordLearnersDictionaryProcessor only
- Documents direct JSON reflection usage and AI SDK dependency internals

## Validation
- dotnet msbuild .\src\private\app\OxfordLearnersDictionaryProcessor\OxfordLearnersDictionaryProcessor.csproj -getProperty:JsonSerializerIsReflectionEnabledByDefault
- dotnet build .\src\private\app\OxfordLearnersDictionaryProcessor\OxfordLearnersDictionaryProcessor.csproj