### PR TITLE
Build global.json from mise.lock

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -139,6 +139,12 @@ repos:
     language: system
     pass_filenames: true
     files: \.env$|[^/]*\.env$|\.env\.[^/]*$|(?:.*/)*\.env$|(?:.*/)*[^/]*\.env$|(?:.*/)*\.env\.[^/]*$
+  - id: global-json
+    name: Global Json
+    entry: pwsh -NoLogo -NoProfile -File eng/pre-commit/Test-PklEvalSync.ps1 -Source global.pkl -Target global.json -Format json
+    language: system
+    pass_filenames: false
+    files: global\.pkl$|global\.json$|mise\.lock$
   - id: pre-commit-config
     name: Pre Commit Config
     entry: pwsh -NoLogo -NoProfile -File eng/pre-commit/Test-PklEvalSync.ps1 -Source .pre-commit-config.pkl -Target .pre-commit-config.yaml -Format yaml

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
     "version": "10.0.201",
-    "rollForward": "latestMinor"
+    "rollForward": "disable"
   },
   "msbuild-sdks": {
     "DotNet.ReproducibleBuilds.Isolated": "2.0.2",

--- a/global.pkl
+++ b/global.pkl
@@ -1,0 +1,27 @@
+local miseLock = read("mise.lock").text
+local dotnetLockBlock = miseLock.split("[[tools.dotnet]]")[1].split("[[")[0]
+local dotnetLockLines = dotnetLockBlock.split("\n")
+local dotnetLockVersion =
+  dotnetLockLines.filter((line) -> line.trim().startsWith("version = ")).single.split("\"")[1]
+local dotnetLockBackend =
+  dotnetLockLines.filter((line) -> line.trim().startsWith("backend = ")).single.split("\"")[1]
+
+local dotnetSdkVersion =
+  if (dotnetLockBackend == "core:dotnet")
+    dotnetLockVersion
+  else
+    throw("mise.lock [[tools.dotnet]] must use backend \"core:dotnet\".")
+
+sdk = new Dynamic {
+  ["version"] = dotnetSdkVersion
+  ["rollForward"] = "disable"
+}
+
+`msbuild-sdks` = new Dynamic {
+  ["DotNet.ReproducibleBuilds.Isolated"] = "2.0.2"
+  ["Microsoft.Build.Artifacts"] = "6.1.63"
+  ["Microsoft.Build.CopyOnWrite"] = "1.0.334"
+  ["Microsoft.Build.NoTargets"] = "3.7.134"
+  ["Microsoft.Build.Traversal"] = "4.1.82"
+  ["MSTest.Sdk"] = "3.11.1"
+}

--- a/global.pkl
+++ b/global.pkl
@@ -1,10 +1,41 @@
 local miseLock = read("mise.lock").text
-local dotnetLockBlock = miseLock.split("[[tools.dotnet]]")[1].split("[[")[0]
+local dotnetLockBlockParts = miseLock.split("[[tools.dotnet]]")
+local dotnetLockBlock =
+  if (dotnetLockBlockParts.length == 2)
+    dotnetLockBlockParts[1].split("[[")[0]
+  else
+    throw(
+      "mise.lock must contain exactly one [[tools.dotnet]] block; found \(dotnetLockBlockParts.length - 1)."
+    )
 local dotnetLockLines = dotnetLockBlock.split("\n")
+local dotnetLockVersionLines =
+  dotnetLockLines.filter((line) -> line.trim().startsWith("version = "))
+local dotnetLockBackendLines =
+  dotnetLockLines.filter((line) -> line.trim().startsWith("backend = "))
+local dotnetLockVersionParts =
+  if (dotnetLockVersionLines.length == 1)
+    dotnetLockVersionLines.single.split("\"")
+  else
+    throw(
+      "mise.lock [[tools.dotnet]] must contain exactly one version entry; found \(dotnetLockVersionLines.length)."
+    )
+local dotnetLockBackendParts =
+  if (dotnetLockBackendLines.length == 1)
+    dotnetLockBackendLines.single.split("\"")
+  else
+    throw(
+      "mise.lock [[tools.dotnet]] must contain exactly one backend entry; found \(dotnetLockBackendLines.length)."
+    )
 local dotnetLockVersion =
-  dotnetLockLines.filter((line) -> line.trim().startsWith("version = ")).single.split("\"")[1]
+  if (dotnetLockVersionParts.length >= 2)
+    dotnetLockVersionParts[1]
+  else
+    throw("mise.lock [[tools.dotnet]] version entry must be a quoted string.")
 local dotnetLockBackend =
-  dotnetLockLines.filter((line) -> line.trim().startsWith("backend = ")).single.split("\"")[1]
+  if (dotnetLockBackendParts.length >= 2)
+    dotnetLockBackendParts[1]
+  else
+    throw("mise.lock [[tools.dotnet]] backend entry must be a quoted string.")
 
 local dotnetSdkVersion =
   if (dotnetLockBackend == "core:dotnet")

--- a/hk.pkl
+++ b/hk.pkl
@@ -274,6 +274,26 @@ local function getTestPklEvalSyncCommand(
   ).join(" ")
 
 local code_generation_guard = new Mapping<String, Step> {
+  ["global-json"] {
+    local file_list =
+      List(
+        "global.pkl",
+        "global.json",
+        "mise.lock",
+      )
+    profiles = List("small")
+    glob = file_list
+    stage = file_list
+    check =
+      getTestPklEvalSyncCommand(
+        "global.pkl",
+        "global.json",
+        "json",
+        List(),
+      )
+    fix = "pkl eval -f json global.pkl -o global.json"
+  }
+
   ["pre-commit-config"] {
     local file_list =
       List(

--- a/mise.toml
+++ b/mise.toml
@@ -93,6 +93,12 @@ run = "dotnet tool restore"
 description = "Generate .NET solution file for local development"
 run = 'dotnet slngen --nologo --ignoreMainProject --launch false --loadprojects false --folders true --collapsefolders true -o main.sln'
 
+[tasks.update-global-json]
+description = "Update global.json from global.pkl and mise.lock"
+run = 'pkl eval -f json global.pkl -o global.json'
+sources = ["global.pkl", "mise.lock"]
+outputs = ["global.json"]
+
 [tasks.update-pre-commit-config]
 description = "Update .pre-commit-config.yaml from .pre-commit-config.pkl"
 run = 'pkl eval .pre-commit-config.pkl -o .pre-commit-config.yaml'

--- a/src/private/app/vscode-copilot-telegram-hook/packages.lock.json
+++ b/src/private/app/vscode-copilot-telegram-hook/packages.lock.json
@@ -10,9 +10,9 @@
       },
       "Microsoft.DotNet.ILCompiler": {
         "type": "Direct",
-        "requested": "[10.0.7, )",
-        "resolved": "10.0.7",
-        "contentHash": "2H7j1NltkQx04sPWBkUtFrZNBtro7vwsxRtdThP0oDj6Sn3ouGHCQlxATZ4Me2aJE67+KiXMX2V1IHDjt1uIpw=="
+        "requested": "[10.0.5, )",
+        "resolved": "10.0.5",
+        "contentHash": "yadTZIkStCVsG8nGwvfroSfBApPsgjQbodQyaIfp53dgayE0qhZpywixiCB6lx57JYQ+KVg1m1AFLrj54pxpZg=="
       },
       "Microsoft.Extensions.Hosting": {
         "type": "Direct",
@@ -71,9 +71,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.7, )",
-        "resolved": "10.0.7",
-        "contentHash": "AA/yhzFHNtQZXLdqjzujPy25G8EWwGWsAnxOE2zYSBoT/8QHP6ketN3CToD3DFreO653ipUwnKHo22B8AlBMCw=="
+        "requested": "[10.0.5, )",
+        "resolved": "10.0.5",
+        "contentHash": "A+5ZuQ0f449tM+MQrhf6R9ZX7lYpjk/ODEwLYKrnF6111rtARx8fVsm4YznUnQiKnnXfaXNBqgxmil6RW3L3SA=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
@@ -480,17 +480,17 @@
     "net10.0/linux-x64": {
       "Microsoft.DotNet.ILCompiler": {
         "type": "Direct",
-        "requested": "[10.0.7, )",
-        "resolved": "10.0.7",
-        "contentHash": "2H7j1NltkQx04sPWBkUtFrZNBtro7vwsxRtdThP0oDj6Sn3ouGHCQlxATZ4Me2aJE67+KiXMX2V1IHDjt1uIpw==",
+        "requested": "[10.0.5, )",
+        "resolved": "10.0.5",
+        "contentHash": "yadTZIkStCVsG8nGwvfroSfBApPsgjQbodQyaIfp53dgayE0qhZpywixiCB6lx57JYQ+KVg1m1AFLrj54pxpZg==",
         "dependencies": {
-          "runtime.linux-x64.Microsoft.DotNet.ILCompiler": "10.0.7"
+          "runtime.linux-x64.Microsoft.DotNet.ILCompiler": "10.0.5"
         }
       },
       "runtime.linux-x64.Microsoft.DotNet.ILCompiler": {
         "type": "Transitive",
-        "resolved": "10.0.7",
-        "contentHash": "bz+Di9NJXvaWTvoma5Pf9JrgFj6MGkbPo9dlWRo+jOHXDEme511jeWVEBWoPdoDe6BjDWRngGi9P9EUBCCgzgw=="
+        "resolved": "10.0.5",
+        "contentHash": "QYAggijHfk8FpLrPVhaESEOCYGWzEjA9JLapzg6XMFK5TGmwQ2HIqEprFv28MwvB5GdPGaZVLXE5icnkgLUfSA=="
       },
       "System.Diagnostics.EventLog": {
         "type": "Transitive",
@@ -501,17 +501,17 @@
     "net10.0/win-x64": {
       "Microsoft.DotNet.ILCompiler": {
         "type": "Direct",
-        "requested": "[10.0.7, )",
-        "resolved": "10.0.7",
-        "contentHash": "2H7j1NltkQx04sPWBkUtFrZNBtro7vwsxRtdThP0oDj6Sn3ouGHCQlxATZ4Me2aJE67+KiXMX2V1IHDjt1uIpw==",
+        "requested": "[10.0.5, )",
+        "resolved": "10.0.5",
+        "contentHash": "yadTZIkStCVsG8nGwvfroSfBApPsgjQbodQyaIfp53dgayE0qhZpywixiCB6lx57JYQ+KVg1m1AFLrj54pxpZg==",
         "dependencies": {
-          "runtime.win-x64.Microsoft.DotNet.ILCompiler": "10.0.7"
+          "runtime.win-x64.Microsoft.DotNet.ILCompiler": "10.0.5"
         }
       },
       "runtime.win-x64.Microsoft.DotNet.ILCompiler": {
         "type": "Transitive",
-        "resolved": "10.0.7",
-        "contentHash": "pdlgAPDgcAMCi1XMrgKTPcovBzM0IG9j8LbsIyXS8XXXIrPRyygByqJPJnPtTPDIHxXsLmd3tlMEDULglbBdKA=="
+        "resolved": "10.0.5",
+        "contentHash": "vblLkpVhSDYOmrEW0jypX7YVtLg7idU1QzUyx45ZdZ2sFUSSf3mYFCr0FW3+KZgXWpN1ve9ZPrxNywvHISF4bA=="
       },
       "System.Diagnostics.EventLog": {
         "type": "Transitive",

--- a/src/public/app/ImageOcclusionEditor/ImageOcclusionEditorWinUI3/packages.lock.json
+++ b/src/public/app/ImageOcclusionEditor/ImageOcclusionEditorWinUI3/packages.lock.json
@@ -25,15 +25,15 @@
       },
       "Microsoft.DotNet.ILCompiler": {
         "type": "Direct",
-        "requested": "[10.0.7, )",
-        "resolved": "10.0.7",
-        "contentHash": "2H7j1NltkQx04sPWBkUtFrZNBtro7vwsxRtdThP0oDj6Sn3ouGHCQlxATZ4Me2aJE67+KiXMX2V1IHDjt1uIpw=="
+        "requested": "[10.0.5, )",
+        "resolved": "10.0.5",
+        "contentHash": "yadTZIkStCVsG8nGwvfroSfBApPsgjQbodQyaIfp53dgayE0qhZpywixiCB6lx57JYQ+KVg1m1AFLrj54pxpZg=="
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.7, )",
-        "resolved": "10.0.7",
-        "contentHash": "AA/yhzFHNtQZXLdqjzujPy25G8EWwGWsAnxOE2zYSBoT/8QHP6ketN3CToD3DFreO653ipUwnKHo22B8AlBMCw=="
+        "requested": "[10.0.5, )",
+        "resolved": "10.0.5",
+        "contentHash": "A+5ZuQ0f449tM+MQrhf6R9ZX7lYpjk/ODEwLYKrnF6111rtARx8fVsm4YznUnQiKnnXfaXNBqgxmil6RW3L3SA=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
@@ -168,11 +168,11 @@
     "net10.0-windows10.0.22000/win-x64": {
       "Microsoft.DotNet.ILCompiler": {
         "type": "Direct",
-        "requested": "[10.0.7, )",
-        "resolved": "10.0.7",
-        "contentHash": "2H7j1NltkQx04sPWBkUtFrZNBtro7vwsxRtdThP0oDj6Sn3ouGHCQlxATZ4Me2aJE67+KiXMX2V1IHDjt1uIpw==",
+        "requested": "[10.0.5, )",
+        "resolved": "10.0.5",
+        "contentHash": "yadTZIkStCVsG8nGwvfroSfBApPsgjQbodQyaIfp53dgayE0qhZpywixiCB6lx57JYQ+KVg1m1AFLrj54pxpZg==",
         "dependencies": {
-          "runtime.win-x64.Microsoft.DotNet.ILCompiler": "10.0.7"
+          "runtime.win-x64.Microsoft.DotNet.ILCompiler": "10.0.5"
         }
       },
       "Microsoft.WindowsAppSDK": {
@@ -192,8 +192,8 @@
       },
       "runtime.win-x64.Microsoft.DotNet.ILCompiler": {
         "type": "Transitive",
-        "resolved": "10.0.7",
-        "contentHash": "pdlgAPDgcAMCi1XMrgKTPcovBzM0IG9j8LbsIyXS8XXXIrPRyygByqJPJnPtTPDIHxXsLmd3tlMEDULglbBdKA=="
+        "resolved": "10.0.5",
+        "contentHash": "vblLkpVhSDYOmrEW0jypX7YVtLg7idU1QzUyx45ZdZ2sFUSSf3mYFCr0FW3+KZgXWpN1ve9ZPrxNywvHISF4bA=="
       },
       "SkiaSharp.NativeAssets.Win32": {
         "type": "Transitive",

--- a/src/public/app/PhiFailureDetector.Console/packages.lock.json
+++ b/src/public/app/PhiFailureDetector.Console/packages.lock.json
@@ -10,9 +10,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.7, )",
-        "resolved": "10.0.7",
-        "contentHash": "AA/yhzFHNtQZXLdqjzujPy25G8EWwGWsAnxOE2zYSBoT/8QHP6ketN3CToD3DFreO653ipUwnKHo22B8AlBMCw=="
+        "requested": "[10.0.5, )",
+        "resolved": "10.0.5",
+        "contentHash": "A+5ZuQ0f449tM+MQrhf6R9ZX7lYpjk/ODEwLYKrnF6111rtARx8fVsm4YznUnQiKnnXfaXNBqgxmil6RW3L3SA=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",

--- a/src/public/lib/CircularList/packages.lock.json
+++ b/src/public/lib/CircularList/packages.lock.json
@@ -236,9 +236,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.26, )",
-        "resolved": "8.0.26",
-        "contentHash": "o7/yVssM2r9Wyln2s9edBd5ANZXqdSdBI+g7JqXkyJmXrhs2WsJp25K5yPnYrTgdKBCjKB8bg+O2oew4sgzFaA=="
+        "requested": "[8.0.25, )",
+        "resolved": "8.0.25",
+        "contentHash": "sqX4nmBft05ivqKvUT4nxaN8rT3apCLt9SWFkfRrQPwra1zPwFknQAw1lleuMCKOCLvVmOWwrC2iPSm9RiXZUg=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
@@ -290,9 +290,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[9.0.15, )",
-        "resolved": "9.0.15",
-        "contentHash": "EejcbfCMR77Dthy77qxRbEShmzLApHZUPqXMBVQK+A0pNrRThkaHoGGMGvbq/gTkC/waKcDEgjBkbaejB58Wtw=="
+        "requested": "[9.0.14, )",
+        "resolved": "9.0.14",
+        "contentHash": "+MeWjj5sGq6Oj/l0E9RPMgXDyCIPxczzCbGuvuVTZFEGiy2S/atsfoAoKUnkEin/GeGpN+HenCzRmiQKSc99eQ=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",

--- a/src/public/lib/Hjg.Pngcs/packages.lock.json
+++ b/src/public/lib/Hjg.Pngcs/packages.lock.json
@@ -92,9 +92,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.26, )",
-        "resolved": "8.0.26",
-        "contentHash": "o7/yVssM2r9Wyln2s9edBd5ANZXqdSdBI+g7JqXkyJmXrhs2WsJp25K5yPnYrTgdKBCjKB8bg+O2oew4sgzFaA=="
+        "requested": "[8.0.25, )",
+        "resolved": "8.0.25",
+        "contentHash": "sqX4nmBft05ivqKvUT4nxaN8rT3apCLt9SWFkfRrQPwra1zPwFknQAw1lleuMCKOCLvVmOWwrC2iPSm9RiXZUg=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
@@ -132,9 +132,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[9.0.15, )",
-        "resolved": "9.0.15",
-        "contentHash": "EejcbfCMR77Dthy77qxRbEShmzLApHZUPqXMBVQK+A0pNrRThkaHoGGMGvbq/gTkC/waKcDEgjBkbaejB58Wtw=="
+        "requested": "[9.0.14, )",
+        "resolved": "9.0.14",
+        "contentHash": "+MeWjj5sGq6Oj/l0E9RPMgXDyCIPxczzCbGuvuVTZFEGiy2S/atsfoAoKUnkEin/GeGpN+HenCzRmiQKSc99eQ=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",

--- a/src/public/lib/Memoization/packages.lock.json
+++ b/src/public/lib/Memoization/packages.lock.json
@@ -310,9 +310,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.26, )",
-        "resolved": "8.0.26",
-        "contentHash": "o7/yVssM2r9Wyln2s9edBd5ANZXqdSdBI+g7JqXkyJmXrhs2WsJp25K5yPnYrTgdKBCjKB8bg+O2oew4sgzFaA=="
+        "requested": "[8.0.25, )",
+        "resolved": "8.0.25",
+        "contentHash": "sqX4nmBft05ivqKvUT4nxaN8rT3apCLt9SWFkfRrQPwra1zPwFknQAw1lleuMCKOCLvVmOWwrC2iPSm9RiXZUg=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
@@ -378,9 +378,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[9.0.15, )",
-        "resolved": "9.0.15",
-        "contentHash": "EejcbfCMR77Dthy77qxRbEShmzLApHZUPqXMBVQK+A0pNrRThkaHoGGMGvbq/gTkC/waKcDEgjBkbaejB58Wtw=="
+        "requested": "[9.0.14, )",
+        "resolved": "9.0.14",
+        "contentHash": "+MeWjj5sGq6Oj/l0E9RPMgXDyCIPxczzCbGuvuVTZFEGiy2S/atsfoAoKUnkEin/GeGpN+HenCzRmiQKSc99eQ=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",

--- a/src/public/lib/MicrosoftExtensions.Logging.MSTest/packages.lock.json
+++ b/src/public/lib/MicrosoftExtensions.Logging.MSTest/packages.lock.json
@@ -567,9 +567,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.26, )",
-        "resolved": "8.0.26",
-        "contentHash": "o7/yVssM2r9Wyln2s9edBd5ANZXqdSdBI+g7JqXkyJmXrhs2WsJp25K5yPnYrTgdKBCjKB8bg+O2oew4sgzFaA=="
+        "requested": "[8.0.25, )",
+        "resolved": "8.0.25",
+        "contentHash": "sqX4nmBft05ivqKvUT4nxaN8rT3apCLt9SWFkfRrQPwra1zPwFknQAw1lleuMCKOCLvVmOWwrC2iPSm9RiXZUg=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
@@ -658,9 +658,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[9.0.15, )",
-        "resolved": "9.0.15",
-        "contentHash": "EejcbfCMR77Dthy77qxRbEShmzLApHZUPqXMBVQK+A0pNrRThkaHoGGMGvbq/gTkC/waKcDEgjBkbaejB58Wtw=="
+        "requested": "[9.0.14, )",
+        "resolved": "9.0.14",
+        "contentHash": "+MeWjj5sGq6Oj/l0E9RPMgXDyCIPxczzCbGuvuVTZFEGiy2S/atsfoAoKUnkEin/GeGpN+HenCzRmiQKSc99eQ=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",

--- a/src/public/lib/MicrosoftExtensions.Logging.Xunit/packages.lock.json
+++ b/src/public/lib/MicrosoftExtensions.Logging.Xunit/packages.lock.json
@@ -243,9 +243,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.26, )",
-        "resolved": "8.0.26",
-        "contentHash": "o7/yVssM2r9Wyln2s9edBd5ANZXqdSdBI+g7JqXkyJmXrhs2WsJp25K5yPnYrTgdKBCjKB8bg+O2oew4sgzFaA=="
+        "requested": "[8.0.25, )",
+        "resolved": "8.0.25",
+        "contentHash": "sqX4nmBft05ivqKvUT4nxaN8rT3apCLt9SWFkfRrQPwra1zPwFknQAw1lleuMCKOCLvVmOWwrC2iPSm9RiXZUg=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
@@ -325,9 +325,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[9.0.15, )",
-        "resolved": "9.0.15",
-        "contentHash": "EejcbfCMR77Dthy77qxRbEShmzLApHZUPqXMBVQK+A0pNrRThkaHoGGMGvbq/gTkC/waKcDEgjBkbaejB58Wtw=="
+        "requested": "[9.0.14, )",
+        "resolved": "9.0.14",
+        "contentHash": "+MeWjj5sGq6Oj/l0E9RPMgXDyCIPxczzCbGuvuVTZFEGiy2S/atsfoAoKUnkEin/GeGpN+HenCzRmiQKSc99eQ=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",

--- a/src/public/lib/PhiFailureDetector/packages.lock.json
+++ b/src/public/lib/PhiFailureDetector/packages.lock.json
@@ -265,9 +265,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.26, )",
-        "resolved": "8.0.26",
-        "contentHash": "o7/yVssM2r9Wyln2s9edBd5ANZXqdSdBI+g7JqXkyJmXrhs2WsJp25K5yPnYrTgdKBCjKB8bg+O2oew4sgzFaA=="
+        "requested": "[8.0.25, )",
+        "resolved": "8.0.25",
+        "contentHash": "sqX4nmBft05ivqKvUT4nxaN8rT3apCLt9SWFkfRrQPwra1zPwFknQAw1lleuMCKOCLvVmOWwrC2iPSm9RiXZUg=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
@@ -319,9 +319,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[9.0.15, )",
-        "resolved": "9.0.15",
-        "contentHash": "EejcbfCMR77Dthy77qxRbEShmzLApHZUPqXMBVQK+A0pNrRThkaHoGGMGvbq/gTkC/waKcDEgjBkbaejB58Wtw=="
+        "requested": "[9.0.14, )",
+        "resolved": "9.0.14",
+        "contentHash": "+MeWjj5sGq6Oj/l0E9RPMgXDyCIPxczzCbGuvuVTZFEGiy2S/atsfoAoKUnkEin/GeGpN+HenCzRmiQKSc99eQ=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",


### PR DESCRIPTION
## Summary
- generate `global.json` from `global.pkl`, with the .NET SDK version read from `mise.lock`
- disable SDK roll-forward so NuGet lock files stay aligned with the pinned SDK
- add an HK `global-json` guard and regenerate `.pre-commit-config.yaml`
- refresh affected NuGet lock files for SDK 10.0.201

## Validation
- `mise trust`
- `mise run update-global-json`
- `hk validate`
- `hk run pre-commit --check --no-progress`
- `dotnet restore dirs.proj -p:RestoreLockedMode=true --verbosity minimal`