### PR TITLE
fix(renovate): Use Mise Ruby for Bundler Tools

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -20,6 +20,7 @@ jobs:
       contents: read
     env:
       RENOVATE_VERSION: 43.150.0
+      GIT_LFS_SKIP_SMUDGE: 1
     defaults:
       run:
         shell: bash

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -87,7 +87,7 @@ jobs:
 
       - name: Create Renovate GitHub App token
         id: renovate-app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
         with:
           app-id: ${{ secrets.SHUAIZHANG_RENOVATE_APP_ID }}
           private-key: ${{ secrets.SHUAIZHANG_RENOVATE_PRIVATE_KEY }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -84,10 +84,23 @@ jobs:
       - name: Install Renovate CLI
         run: npm install --global "renovate@${RENOVATE_VERSION}"
 
+      - name: Create Renovate GitHub App token
+        id: renovate-app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.SHUAIZHANG_RENOVATE_APP_ID }}
+          private-key: ${{ secrets.SHUAIZHANG_RENOVATE_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
+          permission-workflows: write
+
       - name: Run Renovate
         env:
           RENOVATE_CONFIG_FILE: .github/renovate/global.cjs
-          # RENOVATE_TOKEN may create dependency branches and PRs, but must not bypass branch protection.
+          # The Renovate GitHub App may create dependency branches and PRs, but must not bypass branch protection.
           # Renovate automerge is disabled in renovate.json.
-          RENOVATE_TOKEN: ${{ secrets.RENOVATE_TOKEN }}
+          RENOVATE_TOKEN: ${{ steps.renovate-app-token.outputs.token }}
         run: renovate

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -42,11 +42,6 @@ jobs:
         with:
           global-json-file: global.json
 
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@e65c17d16e57e481586a6a5a0282698790062f92 # v1
-        with:
-          ruby-version: '3.3'
-
       - name: Set up mise
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
@@ -59,7 +54,7 @@ jobs:
         run: |
           set -Eeuo pipefail
 
-          mise install pkl powershell pnpm uv
+          mise install pkl powershell pnpm uv ruby
           mise reshim
 
           gem install bundler -v 2.4.20 --no-document


### PR DESCRIPTION
## Summary
- remove the duplicate `ruby/setup-ruby` setup from the Renovate workflow
- install Ruby through Mise with the other post-upgrade tools
- prevent Windows PATH conflicts where Bundler is installed for one Ruby but executed by another

## Validation
- `pnpm exec prettier --check .github/workflows/renovate.yml`
- `python eng/scripts/hk_actionlint.py .github/workflows/renovate.yml`
- Bundler install/version smoke test with Mise Ruby
- two clean adversarial review rounds