### PR TITLE
fix(renovate): Request Commit Status Permission

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -119,6 +119,7 @@ jobs:
           permission-contents: write
           permission-issues: write
           permission-pull-requests: write
+          permission-statuses: write
           permission-workflows: write
 
       - name: Run Renovate


### PR DESCRIPTION
## Summary
- Request permission-statuses: write when creating the Renovate GitHub App token.
- Preserve GitHub App-only Renovate authentication with no GITHUB_TOKEN fallback.

## Reason
Debug logs showed Renovate aborting after GitHub rejected POST /repos/hcoona/three/statuses/{sha} for the renovate/stability-days commit status.

## Validation
- YAML parse
- git diff --check