### PR TITLE
chore(renovate): Run Scheduled Renovate Hourly

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -2,7 +2,7 @@ name: Renovate
 
 on:
   schedule:
-    - cron: '0 3 * * *'
+    - cron: '17 * * * *'
   workflow_dispatch:
     inputs:
       log_level:


### PR DESCRIPTION
## Summary
- Run the scheduled Renovate workflow hourly at minute 17.
- Leave manual dispatch, Dependency Dashboard triggers, token permissions, concurrency, and lock-file maintenance scheduling unchanged.

## Validation
- YAML parse
- git diff --check
- Independent GPT-5.5 review
