### PR TITLE
fix(renovate): Exempt GitHub Actions Digests From Stability Gate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -131,6 +131,13 @@
       "automerge": true
     },
     {
+      "description": "Do not apply release-age checks to GitHub Actions digest pinning because Renovate cannot reliably timestamp digest and pinDigest updates.",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["digest", "pin", "pinDigest"],
+      "minimumReleaseAge": null,
+      "automerge": true
+    },
+    {
       "description": "Group low-risk root JS formatter patch updates.",
       "matchManagers": ["npm"],
       "matchFileNames": ["package.json"],


### PR DESCRIPTION
## Summary
- Exempts GitHub Actions `digest`, `pin`, and `pinDigest` updates from Renovate minimum release age checks.
- Keeps the global 3-day stability gate for timestamped dependency releases.
- Allows digest pinning PRs to reach GitHub squash automerge once CI and rulesets pass.

## Validation
- `jq empty renovate.json`
- `npx --yes --package renovate renovate-config-validator renovate.json --strict`
- `git diff --check`