### PR TITLE
fix(renovate): Clarify Lock File Maintenance Title

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -26,7 +26,8 @@
     "enabled": true,
     "schedule": ["before 6am on tuesday"],
     "automerge": true,
-    "commitMessageAction": "refresh"
+    "commitMessageAction": "Refresh",
+    "commitMessageTopic": "Dependency Lock Files"
   },
   "vulnerabilityAlerts": {
     "enabled": true,


### PR DESCRIPTION
## Summary
- Rename the Renovate lock file maintenance title from the generic `refresh` action to `refresh dependency lock files`.
- Keep the weekly lock file maintenance schedule and automerge behavior unchanged.

## Validation
- `jq empty renovate.json`
- `npx --yes --package renovate renovate-config-validator renovate.json --strict`
- `git diff --check`