### PR TITLE
fix(renovate): Address Renovate Workflow Warnings

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   renovate:
     name: Run Renovate
-    runs-on: windows-latest
+    runs-on: windows-2025-vs2026
     if: >-
       ${{
         github.event_name != 'issues' ||
@@ -110,7 +110,7 @@ jobs:
 
       - name: Create Renovate GitHub App token
         id: renovate-app-token
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.SHUAIZHANG_RENOVATE_APP_ID }}
           private-key: ${{ secrets.SHUAIZHANG_RENOVATE_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary
- Pin the Renovate workflow runner to `windows-2025-vs2026` instead of the floating `windows-latest` label.
- Upgrade `actions/create-github-app-token` to v3.2.0, which runs on Node.js 24.

## Validation
- `git diff --check`
- `mise x actionlint -- actionlint .github/workflows/renovate.yml`