### PR TITLE
fix(renovate): Split Mise Post-Upgrade Commands

### DIFF
--- a/.github/renovate/global.cjs
+++ b/.github/renovate/global.cjs
@@ -6,8 +6,9 @@ module.exports = {
   allowedCommands: [
     String.raw`^pwsh -NoLogo -NoProfile -NonInteractive -File eng/scripts/Update-RenovateGlobalJsonArtifacts\.ps1$`,
     String.raw`^mise run --skip-tools update-global-json$`,
+    String.raw`^mise install pnpm$`,
+    String.raw`^mise run --skip-tools --force update-pnpm-lockfiles$`,
+    String.raw`^mise install uv$`,
     String.raw`^mise run --skip-tools --force update-uv-lock$`,
-    String.raw`^mise install pnpm && mise run --skip-tools --force update-pnpm-lockfiles$`,
-    String.raw`^mise install uv && mise run --skip-tools --force update-uv-lock$`,
   ],
 };

--- a/renovate.json
+++ b/renovate.json
@@ -457,7 +457,7 @@
       "matchDepNames": ["pnpm"],
       "groupName": "Mise pnpm",
       "postUpgradeTasks": {
-        "commands": ["mise install pnpm && mise run --skip-tools --force update-pnpm-lockfiles"],
+        "commands": ["mise install pnpm", "mise run --skip-tools --force update-pnpm-lockfiles"],
         "fileFilters": ["pnpm-lock.yaml", "**/pnpm-lock.yaml"],
         "executionMode": "branch"
       },
@@ -469,7 +469,7 @@
       "matchDepNames": ["uv"],
       "groupName": "Mise uv",
       "postUpgradeTasks": {
-        "commands": ["mise install uv && mise run --skip-tools --force update-uv-lock"],
+        "commands": ["mise install uv", "mise run --skip-tools --force update-uv-lock"],
         "fileFilters": ["uv.lock"],
         "executionMode": "branch"
       },


### PR DESCRIPTION
## Summary
- split pnpm and uv Renovate post-upgrade tasks into separate mise install and lockfile refresh commands
- update the self-hosted Renovate allowed command list to match the exact separated commands
- avoid shell control operators in post-upgrade tasks so Renovate does not pass them to mise install

## Context
PR #256 reported an artifact update failure because Renovate ran the combined pnpm install-and-refresh command without shell control-flow semantics, causing --skip-tools to be parsed by mise install.

## Validation
- jq empty renovate.json
- node --check .github/renovate/global.cjs
- npx --yes --package renovate renovate-config-validator renovate.json --strict
- RENOVATE_CONFIG_FILE=.github/renovate/global.cjs npx --yes --package renovate renovate-config-validator --strict
- hk check --pr