### PR TITLE
fix(renovate): Use GitHub App Client ID

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -112,7 +112,7 @@ jobs:
         id: renovate-app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.SHUAIZHANG_RENOVATE_APP_ID }}
+          client-id: ${{ vars.SHUAIZHANG_RENOVATE_CLIENT_ID }}
           private-key: ${{ secrets.SHUAIZHANG_RENOVATE_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}


### PR DESCRIPTION
## Summary
- replace the deprecated create-github-app-token app-id input with client-id
- read the GitHub App client ID from vars.SHUAIZHANG_RENOVATE_CLIENT_ID
- keep the existing private-key secret and token permissions unchanged

## Validation
- actionlint .github/workflows/renovate.yml
- hk check --pr