### PR TITLE
fix(renovate): Normalize Post-Upgrade Tool PATH

### DIFF
--- a/.github/renovate/global.cjs
+++ b/.github/renovate/global.cjs
@@ -5,7 +5,7 @@ module.exports = {
   requireConfig: 'required',
   allowedCommands: [
     String.raw`^pwsh -NoLogo -NoProfile -NonInteractive -File eng/scripts/Update-RenovateGlobalJsonArtifacts\.ps1$`,
-    String.raw`^mise run --skip-tools update-global-json$`,
+    String.raw`^pkl eval -f json global\.pkl -o global\.json$`,
     String.raw`^mise install pnpm$`,
     String.raw`^mise run --skip-tools --force update-pnpm-lockfiles$`,
     String.raw`^mise install uv$`,

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -123,10 +123,26 @@ jobs:
           permission-workflows: write
 
       - name: Run Renovate
+        shell: pwsh
         env:
           RENOVATE_CONFIG_FILE: .github/renovate/global.cjs
           LOG_LEVEL: ${{ github.event.inputs.log_level || 'info' }}
           # The Renovate GitHub App may create dependency branches and PRs, but must not bypass branch protection.
           # Renovate automerge is controlled by renovate.json and remains subject to CI and branch protection.
           RENOVATE_TOKEN: ${{ steps.renovate-app-token.outputs.token }}
-        run: renovate
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          $miseRoot = Join-Path $env:LOCALAPPDATA 'mise'
+          $env:Path = @(
+            (Join-Path $miseRoot 'shims')
+            (Join-Path $miseRoot 'bin')
+            $env:Path
+          ) -join [System.IO.Path]::PathSeparator
+
+          node -e @'
+          const { execFileSync } = require('node:child_process');
+          execFileSync('pwsh', ['-NoLogo', '-NoProfile', '-NonInteractive', '-Command', 'Get-Command mise,pkl,pwsh,pnpm,uv,ruby,bundle'], { stdio: 'inherit' });
+          '@
+
+          renovate

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -142,7 +142,7 @@ jobs:
 
           node -e @'
           const { execFileSync } = require('node:child_process');
-          execFileSync('pwsh', ['-NoLogo', '-NoProfile', '-NonInteractive', '-Command', 'Get-Command mise,pkl,pwsh,pnpm,uv,ruby,bundle'], { stdio: 'inherit' });
+          execFileSync('pwsh', ['-NoLogo', '-NoProfile', '-NonInteractive', '-Command', 'Get-Command mise,pkl,pwsh,pnpm,uv,ruby,bundle -ErrorAction Stop | Out-Null'], { stdio: 'inherit' });
           '@
 
           renovate

--- a/eng/scripts/Update-RenovateGlobalJsonArtifacts.ps1
+++ b/eng/scripts/Update-RenovateGlobalJsonArtifacts.ps1
@@ -322,8 +322,8 @@ $msBuildSdkVersions = Get-MsBuildSdkVersionMap -Path $GlobalJsonPath
 Update-MiseLockDotNetSdkVersion -Path $MiseLockPath -Version $dotNetSdkVersion
 Update-GlobalPklMsBuildSdkVersion -Path $GlobalPklPath -Versions $msBuildSdkVersions
 
-Test-RequiredCommand -Name "mise"
-mise run --skip-tools update-global-json
+Test-RequiredCommand -Name "pkl"
+pkl eval -f json $GlobalPklPath -o $GlobalJsonPath
 
 if (-not $SkipRestore) {
     $expectedMiseLockContent = Get-Content -Path $MiseLockPath -Raw

--- a/renovate.json
+++ b/renovate.json
@@ -445,7 +445,7 @@
       "matchManagers": ["mise"],
       "matchDepNames": ["core:dotnet", "dotnet"],
       "postUpgradeTasks": {
-        "commands": ["mise run --skip-tools update-global-json"],
+        "commands": ["pkl eval -f json global.pkl -o global.json"],
         "fileFilters": ["global.json"],
         "executionMode": "branch"
       },


### PR DESCRIPTION
## Summary
- Normalize the Windows PATH used by the Run Renovate step so Node-spawned post-upgrade tasks can resolve mise-installed tools.
- Add a smoke check that mirrors Renovate launching PowerShell before the Renovate CLI starts.
- Regenerate global.json via the exact pkl command instead of the mise task and update the allowed command list accordingly.

## Context
PR #264 reported an artifact update failure because Update-RenovateGlobalJsonArtifacts.ps1 could not resolve mise from the Renovate post-upgrade task environment. The dependency test failures in #264 appear separate from this artifact-generation environment issue.

## Validation
- jq empty renovate.json
- node --check .github/renovate/global.cjs
- actionlint .github/workflows/renovate.yml
- npx --yes --package renovate renovate-config-validator renovate.json --strict
- RENOVATE_CONFIG_FILE=.github/renovate/global.cjs npx --yes --package renovate renovate-config-validator --strict
- hk check --pr