### PR TITLE
fix(renovate): Read GitHub App Client ID From Secrets

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -112,7 +112,7 @@ jobs:
         id: renovate-app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          client-id: ${{ vars.SHUAIZHANG_RENOVATE_CLIENT_ID }}
+          client-id: ${{ secrets.SHUAIZHANG_RENOVATE_CLIENT_ID }}
           private-key: ${{ secrets.SHUAIZHANG_RENOVATE_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}


### PR DESCRIPTION
## Summary
- Read `SHUAIZHANG_RENOVATE_CLIENT_ID` from repository secrets instead of repository variables.
- Keep the `actions/create-github-app-token` `client-id` input aligned with the configured credential source.

## Validation
- `actionlint .github/workflows/renovate.yml`