### PR TITLE
fix(renovate): Use Exact GitHub Action Version Comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
           python-version: '3.14'
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@e65c17d16e57e481586a6a5a0282698790062f92 # v1
+        uses: ruby/setup-ruby@e65c17d16e57e481586a6a5a0282698790062f92 # v1.300.0
         with:
           ruby-version: '3.4.9'
           bundler-cache: true
@@ -251,7 +251,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@e65c17d16e57e481586a6a5a0282698790062f92 # v1
+        uses: ruby/setup-ruby@e65c17d16e57e481586a6a5a0282698790062f92 # v1.300.0
         with:
           ruby-version: '3.4.9'
 

--- a/.github/workflows/release-build-ruby-gem.yml
+++ b/.github/workflows/release-build-ruby-gem.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Setup Ruby (Bundler)
         if: ${{ hashFiles(format('{0}/Gemfile', inputs.package_dir)) != '' }}
-        uses: ruby/setup-ruby@e65c17d16e57e481586a6a5a0282698790062f92 # v1
+        uses: ruby/setup-ruby@e65c17d16e57e481586a6a5a0282698790062f92 # v1.300.0
         with:
           ruby-version: ${{ inputs.ruby_version }}
           bundler-cache: true
@@ -67,7 +67,7 @@ jobs:
 
       - name: Setup Ruby
         if: ${{ hashFiles(format('{0}/Gemfile', inputs.package_dir)) == '' }}
-        uses: ruby/setup-ruby@e65c17d16e57e481586a6a5a0282698790062f92 # v1
+        uses: ruby/setup-ruby@e65c17d16e57e481586a6a5a0282698790062f92 # v1.300.0
         with:
           ruby-version: ${{ inputs.ruby_version }}
 

--- a/.github/workflows/release-orchestrate.yml
+++ b/.github/workflows/release-orchestrate.yml
@@ -932,7 +932,7 @@ jobs:
           bash "${GITHUB_WORKSPACE}/eng/scripts/validate_pypi_remote_digests.sh"
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           packages-dir: ${{ github.workspace }}/out/
           skip-existing: true
@@ -1511,7 +1511,7 @@ jobs:
           path: ${{ github.workspace }}/out
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@e65c17d16e57e481586a6a5a0282698790062f92 # v1
+        uses: ruby/setup-ruby@e65c17d16e57e481586a6a5a0282698790062f92 # v1.300.0
         with:
           ruby-version: ${{ env.RUBY_VERSION }}
 
@@ -1628,7 +1628,7 @@ jobs:
           path: ${{ github.workspace }}/out
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@e65c17d16e57e481586a6a5a0282698790062f92 # v1
+        uses: ruby/setup-ruby@e65c17d16e57e481586a6a5a0282698790062f92 # v1.300.0
         with:
           ruby-version: ${{ env.RUBY_VERSION }}
 


### PR DESCRIPTION
## Summary
- Replace SHA-pinned `ruby/setup-ruby` comments from `# v1` to `# v1.300.0`.
- Replace the SHA-pinned `pypa/gh-action-pypi-publish` comment from `# v1` to `# v1.14.0`.
- Audit all other SHA-pinned GitHub Action comments and leave the ones whose comments resolve to exact tags.

## Validation
- `actionlint .github/workflows/ci.yml .github/workflows/release-build-ruby-gem.yml .github/workflows/release-orchestrate.yml`
- Verified every SHA-pinned action version comment resolves to an exact upstream tag for the pinned SHA.