### PR TITLE
fix(renovate): Use Exact Nested Action Version Comment

### DIFF
--- a/src/public/lib/asciidoctor-latexmath/.github/workflows/ci.yml
+++ b/src/public/lib/asciidoctor-latexmath/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
             ghostscript
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@675dd7ba1b06c8786a1480d89c384f5620a42647 # v1
+        uses: ruby/setup-ruby@675dd7ba1b06c8786a1480d89c384f5620a42647 # v1.281.0
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true


### PR DESCRIPTION
## Summary
- Replace the nested `ruby/setup-ruby # v1` comment with `# v1.281.0`.
- Re-audit every SHA-pinned GitHub Action reference under the repository, including nested workflows.

## Validation
- `actionlint src/public/lib/asciidoctor-latexmath/.github/workflows/ci.yml`
- Verified every SHA-pinned action version comment in `*.yml` and `*.yaml` resolves to an exact upstream tag for its pinned SHA.