### PR TITLE
fix(renovate): Rebase Stale Dependency PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,7 +16,7 @@
   "prConcurrentLimit": 8,
   "branchConcurrentLimit": 8,
   "prHourlyLimit": 2,
-  "rebaseWhen": "conflicted",
+  "rebaseWhen": "behind-base-branch",
   "enabledManagers": ["bundler", "github-actions", "mise", "npm", "nuget", "pep621"],
   "ignorePaths": ["**/node_modules/**", "**/bower_components/**", "**/vendor/**"],
   "lockFileMaintenance": {


### PR DESCRIPTION
## Summary
- Change Renovate rebase behavior from conflict-only to `behind-base-branch`.
- Ensure existing Renovate PRs pick up workflow and post-upgrade fixes from `main` instead of staying on stale base commits.

## Validation
- `npx --yes --package renovate@43.150.0 -- renovate-config-validator renovate.json`