### PR TITLE
fix(renovate): Group SourceLink With Hashing Dependency

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -394,14 +394,9 @@
         "DotNet.ReproducibleBuilds",
         "DotNet.ReproducibleBuilds.Isolated",
         "Microsoft.SourceLink.GitHub",
-        "Nerdbank.GitVersioning"
+        "Nerdbank.GitVersioning",
+        "System.IO.Hashing"
       ],
-      "groupName": "MSBuild and Repository Build Tooling"
-    },
-    {
-      "description": "Update SourceLink with the direct package version it requires for restore.",
-      "matchManagers": ["nuget"],
-      "matchPackageNames": ["Microsoft.SourceLink.GitHub", "System.IO.Hashing"],
       "groupName": "MSBuild and Repository Build Tooling"
     },
     {

--- a/renovate.json
+++ b/renovate.json
@@ -399,6 +399,12 @@
       "groupName": "MSBuild and Repository Build Tooling"
     },
     {
+      "description": "Update SourceLink with the direct package version it requires for restore.",
+      "matchManagers": ["nuget"],
+      "matchPackageNames": ["Microsoft.SourceLink.GitHub", "System.IO.Hashing"],
+      "groupName": "MSBuild and Repository Build Tooling"
+    },
+    {
       "description": "Update Nerdbank.GitVersioning packages and tools together.",
       "matchManagers": ["nuget", "npm"],
       "matchPackageNames": ["Nerdbank.GitVersioning", "nbgv", "nerdbank-gitversioning"],


### PR DESCRIPTION
## Summary
- Group `System.IO.Hashing` with `Microsoft.SourceLink.GitHub` Renovate updates.
- Prevent NuGet downgrade artifact errors when SourceLink requires a newer hashing package than the central version.

## Validation
- `npx --yes --package renovate@43.150.0 -- renovate-config-validator renovate.json`