### PR TITLE
fix(renovate): Bump SourceLink Memory Lower Bound

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -406,6 +406,7 @@
       "matchManagers": ["nuget"],
       "matchFileNames": ["src/public/lib/Directory.Packages.props"],
       "matchPackageNames": ["System.Memory"],
+      "rangeStrategy": "bump",
       "groupName": "MSBuild and Repository Build Tooling"
     },
     {


### PR DESCRIPTION
## Summary
- Add `rangeStrategy: bump` to the narrow `System.Memory` SourceLink grouping rule.
- Allow Renovate to raise `[4.5.0,)` to the newer lower bound needed by the SourceLink/System.IO.Hashing restore graph.

## Validation
- `npx --yes --package renovate@43.150.0 -- renovate-config-validator renovate.json`