### PR TITLE
fix(renovate): Bump SourceLink Unsafe Lower Bound

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -402,10 +402,10 @@
       "automerge": true
     },
     {
-      "description": "Update public System.Memory lower bounds with SourceLink when restore requires it.",
+      "description": "Update public transitive lower bounds with SourceLink when restore requires it.",
       "matchManagers": ["nuget"],
       "matchFileNames": ["src/public/lib/Directory.Packages.props"],
-      "matchPackageNames": ["System.Memory"],
+      "matchPackageNames": ["System.Memory", "System.Runtime.CompilerServices.Unsafe"],
       "rangeStrategy": "bump",
       "groupName": "MSBuild and Repository Build Tooling"
     },


### PR DESCRIPTION
## Summary
- extend the SourceLink public lower-bound Renovate rule to include System.Runtime.CompilerServices.Unsafe
- keep the rule scoped to src/public/lib/Directory.Packages.props and the MSBuild tooling group

## Validation
- npx --yes --package renovate@43.150.0 -- renovate-config-validator renovate.json