### PR TITLE
fix(renovate): Stabilize Dependency Update Rings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Set up PNPM
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
         with:
-          version: 10
+          version: 10.33.4
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
@@ -176,7 +176,7 @@ jobs:
       - name: Set up PNPM
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
         with:
-          version: 10
+          version: 10.33.4
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/release-orchestrate.yml
+++ b/.github/workflows/release-orchestrate.yml
@@ -149,7 +149,7 @@ permissions:
 env:
   PYTHON_VERSION: '3.14'
   NODE_VERSION: '24'
-  PNPM_VERSION: '10'
+  PNPM_VERSION: '10.33.4'
   RUBY_VERSION: '3.3'
   # SYNC[tool-versions]: keep in step with EXPECTED_*_VERSION in lint-version-consistency job env below.
   # Updating only one side will either cause the lint gate to fail (if env is updated but
@@ -199,7 +199,7 @@ jobs:
     env:
       EXPECTED_PYTHON_VERSION: '3.14'
       EXPECTED_NODE_VERSION: '24'
-      EXPECTED_PNPM_VERSION: '10'
+      EXPECTED_PNPM_VERSION: '10.33.4'
       EXPECTED_RUBY_VERSION: '3.3'
       # SYNC[add-new-language] — add EXPECTED_<LANG>_VERSION: '<version>' here for each new language tool
       # SYNC[tool-versions]: keep in step with the workflow-level env: block above.
@@ -1079,7 +1079,7 @@ jobs:
       # Hardcoded: uses: with: does not support env context; keep in sync with env.PYTHON_VERSION, env.NODE_VERSION, env.PNPM_VERSION
       python_version: '3.14'
       node_version: '24'
-      pnpm_version: '10'
+      pnpm_version: '10.33.4'
       artifact_name: ${{ inputs.artifact_prefix }}-${{ needs.resolve.outputs.project }}-dist
       # Defensive: pack_mode uses == true rather than a bare boolean test to prevent
       # string-coercion bugs (e.g., string 'false' being truthy) if this input's type
@@ -1796,7 +1796,7 @@ jobs:
       version: ${{ needs.resolve.outputs.version }}
       # Hardcoded: uses: with: does not support env context; keep in sync with env.NODE_VERSION, env.PNPM_VERSION
       node_version: '24'
-      pnpm_version: '10'
+      pnpm_version: '10.33.4'
       artifact_name: ${{ inputs.artifact_prefix }}-${{ needs.resolve.outputs.project }}-dist
 
   attest-wxt-enabled:

--- a/mise.lock
+++ b/mise.lock
@@ -323,36 +323,36 @@ checksum = "sha256:3af84f8f6753ae6cfab50f7127fbfb3b53d374c03079ca0cec27eddffc492
 url = "https://github.com/apple/pkl/releases/download/0.30.0/pkl-windows-amd64.exe"
 
 [[tools.pnpm]]
-version = "10.32.1"
+version = "10.33.4"
 backend = "aqua:pnpm/pnpm"
 
 [tools.pnpm."platforms.linux-arm64"]
-checksum = "sha256:c0db0b837971fde6f9781af8914e54eb163721193a36d35cbcf1794b3474a407"
-url = "https://github.com/pnpm/pnpm/releases/download/v10.32.1/pnpm-linux-arm64"
+checksum = "sha256:d29649c7380b5cd522f574208fbd35335846686498f45004604d3f5b8658b5cb"
+url = "https://github.com/pnpm/pnpm/releases/download/v10.33.4/pnpm-linux-arm64"
 
 [tools.pnpm."platforms.linux-arm64-musl"]
-checksum = "sha256:c0db0b837971fde6f9781af8914e54eb163721193a36d35cbcf1794b3474a407"
-url = "https://github.com/pnpm/pnpm/releases/download/v10.32.1/pnpm-linux-arm64"
+checksum = "sha256:d29649c7380b5cd522f574208fbd35335846686498f45004604d3f5b8658b5cb"
+url = "https://github.com/pnpm/pnpm/releases/download/v10.33.4/pnpm-linux-arm64"
 
 [tools.pnpm."platforms.linux-x64"]
-checksum = "sha256:c5607a86bfb948297e96b393a53c90107766fe56329e62967b1f239d861d4363"
-url = "https://github.com/pnpm/pnpm/releases/download/v10.32.1/pnpm-linux-x64"
+checksum = "sha256:ff1795595535a10d0dfe327303f3dd02377be141190b1f5756de68edde2cf813"
+url = "https://github.com/pnpm/pnpm/releases/download/v10.33.4/pnpm-linux-x64"
 
 [tools.pnpm."platforms.linux-x64-musl"]
-checksum = "sha256:c5607a86bfb948297e96b393a53c90107766fe56329e62967b1f239d861d4363"
-url = "https://github.com/pnpm/pnpm/releases/download/v10.32.1/pnpm-linux-x64"
+checksum = "sha256:ff1795595535a10d0dfe327303f3dd02377be141190b1f5756de68edde2cf813"
+url = "https://github.com/pnpm/pnpm/releases/download/v10.33.4/pnpm-linux-x64"
 
 [tools.pnpm."platforms.macos-arm64"]
-checksum = "sha256:b0904b4e0cf36704fcdc24bcdb5f03388799a631510d1fb0d459ea69c7b1e2d9"
-url = "https://github.com/pnpm/pnpm/releases/download/v10.32.1/pnpm-macos-arm64"
+checksum = "sha256:7aae186a04e1ffaa0047d43cd07d68a98dec303304f28be52234ba955d26c671"
+url = "https://github.com/pnpm/pnpm/releases/download/v10.33.4/pnpm-macos-arm64"
 
 [tools.pnpm."platforms.macos-x64"]
-checksum = "sha256:8b83277343bbc400fdb90608bd51b4f56e380e6624ac5fd0e11d6c08815e3f04"
-url = "https://github.com/pnpm/pnpm/releases/download/v10.32.1/pnpm-macos-x64"
+checksum = "sha256:3b0c97b9f794cdda293949a8ee0e0151ca08f512f4a832408386221c7c73eec6"
+url = "https://github.com/pnpm/pnpm/releases/download/v10.33.4/pnpm-macos-x64"
 
 [tools.pnpm."platforms.windows-x64"]
-checksum = "sha256:849141504c83bcd08a3d84dc20d43cff2584d672138d28c33ad62bdac809e7f2"
-url = "https://github.com/pnpm/pnpm/releases/download/v10.32.1/pnpm-win-x64.exe"
+checksum = "sha256:3268b2f29defe0dce8a3a26c0ef01488f0d4aa4872923173186ef618ab7d68ef"
+url = "https://github.com/pnpm/pnpm/releases/download/v10.33.4/pnpm-win-x64.exe"
 
 [[tools.powershell]]
 version = "7.5.4"

--- a/mise.toml
+++ b/mise.toml
@@ -18,7 +18,7 @@ python = "3.14"
 ruby = "3.3"
 
 # Package Managers
-pnpm = "10"
+pnpm = "10.33.4"
 uv = "latest"
 
 # Git Commit Hook Manager

--- a/renovate.json
+++ b/renovate.json
@@ -43,6 +43,12 @@
       "rangeStrategy": "replace"
     },
     {
+      "description": "Keep pnpm on v10 while Node 20 remains in the support matrix.",
+      "matchManagers": ["github-actions", "mise"],
+      "matchDepNames": ["pnpm"],
+      "allowedVersions": "<11"
+    },
+    {
       "description": "JavaScript development dependencies may update lower bounds normally.",
       "matchManagers": ["npm"],
       "matchDepTypes": ["devDependencies"],
@@ -362,7 +368,7 @@
     {
       "description": "Group Microsoft.Extensions updates.",
       "matchManagers": ["nuget"],
-      "matchPackageNames": ["/^Microsoft\\.Extensions\\./"],
+      "matchPackageNames": ["/^Microsoft\\.Extensions\\./", "Serilog.Extensions.Logging"],
       "groupName": "Microsoft.Extensions Packages"
     },
     {
@@ -467,7 +473,7 @@
       "groupName": "Mise pnpm",
       "postUpgradeTasks": {
         "commands": ["mise install pnpm", "mise run --skip-tools --force update-pnpm-lockfiles"],
-        "fileFilters": ["pnpm-lock.yaml", "**/pnpm-lock.yaml"],
+        "fileFilters": ["mise.lock", "pnpm-lock.yaml", "**/pnpm-lock.yaml"],
         "executionMode": "branch"
       },
       "automerge": true
@@ -510,6 +516,23 @@
       "description": "Automerge all Renovate dependency PRs through GitHub after required checks pass.",
       "matchManagers": ["bundler", "github-actions", "mise", "npm", "nuget", "pep621"],
       "automerge": true
+    },
+    {
+      "description": "Require manual approval for .NET test platform major updates until the MTP 2 runner migration is ready.",
+      "matchManagers": ["nuget"],
+      "matchPackageNames": [
+        "/^Microsoft\\.Testing\\./",
+        "/^MSTest\\./",
+        "coverlet.collector",
+        "Microsoft.NET.Test.Sdk",
+        "xunit",
+        "xunit.abstractions",
+        "xunit.runner.visualstudio",
+        "xunit.v3"
+      ],
+      "matchUpdateTypes": ["major"],
+      "dependencyDashboardApproval": true,
+      "automerge": false
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -473,7 +473,7 @@
       "groupName": "Mise pnpm",
       "postUpgradeTasks": {
         "commands": ["mise install pnpm", "mise run --skip-tools --force update-pnpm-lockfiles"],
-        "fileFilters": ["mise.lock", "pnpm-lock.yaml", "**/pnpm-lock.yaml"],
+        "fileFilters": ["mise.lock", "**/mise.lock", "**/.mise.lock", "pnpm-lock.yaml", "**/pnpm-lock.yaml"],
         "executionMode": "branch"
       },
       "automerge": true

--- a/src/private/app/DotNetLockFileLister/Program.cs
+++ b/src/private/app/DotNetLockFileLister/Program.cs
@@ -92,8 +92,10 @@ using (var reader = XmlReader.Create(
         await XDocument.LoadAsync(reader, LoadOptions.SetLineInfo, CancellationToken.None);
 }
 
-var packageVersions = centralPackageVersionsFile
-    .Root
+var centralPackageVersionsRoot = centralPackageVersionsFile.Root
+    ?? throw new InvalidOperationException("Directory.Packages.props is missing a document element.");
+
+var packageVersions = centralPackageVersionsRoot
     .ElementsNoNamespace("ItemGroup")
     .SelectMany(itemGroup => itemGroup.ElementsNoNamespace("PackageVersion"))
     .ToDictionary(

--- a/src/private/app/DotNetLockFileLister/Program.cs
+++ b/src/private/app/DotNetLockFileLister/Program.cs
@@ -93,7 +93,8 @@ using (var reader = XmlReader.Create(
 }
 
 var centralPackageVersionsRoot = centralPackageVersionsFile.Root
-    ?? throw new InvalidOperationException("Directory.Packages.props is missing a document element.");
+    ?? throw new InvalidOperationException(
+        "Directory.Packages.props is missing a document element.");
 
 var packageVersions = centralPackageVersionsRoot
     .ElementsNoNamespace("ItemGroup")

--- a/src/public/lib/hexo-renderer-asciidoc/.mise.lock
+++ b/src/public/lib/hexo-renderer-asciidoc/.mise.lock
@@ -24,8 +24,36 @@ version = "0.30.0"
 backend = "aqua:apple/pkl"
 
 [[tools.pnpm]]
-version = "10.22.0"
+version = "10.33.4"
 backend = "aqua:pnpm/pnpm"
+
+[tools.pnpm."platforms.linux-arm64"]
+checksum = "sha256:d29649c7380b5cd522f574208fbd35335846686498f45004604d3f5b8658b5cb"
+url = "https://github.com/pnpm/pnpm/releases/download/v10.33.4/pnpm-linux-arm64"
+
+[tools.pnpm."platforms.linux-arm64-musl"]
+checksum = "sha256:d29649c7380b5cd522f574208fbd35335846686498f45004604d3f5b8658b5cb"
+url = "https://github.com/pnpm/pnpm/releases/download/v10.33.4/pnpm-linux-arm64"
+
+[tools.pnpm."platforms.linux-x64"]
+checksum = "sha256:ff1795595535a10d0dfe327303f3dd02377be141190b1f5756de68edde2cf813"
+url = "https://github.com/pnpm/pnpm/releases/download/v10.33.4/pnpm-linux-x64"
+
+[tools.pnpm."platforms.linux-x64-musl"]
+checksum = "sha256:ff1795595535a10d0dfe327303f3dd02377be141190b1f5756de68edde2cf813"
+url = "https://github.com/pnpm/pnpm/releases/download/v10.33.4/pnpm-linux-x64"
+
+[tools.pnpm."platforms.macos-arm64"]
+checksum = "sha256:7aae186a04e1ffaa0047d43cd07d68a98dec303304f28be52234ba955d26c671"
+url = "https://github.com/pnpm/pnpm/releases/download/v10.33.4/pnpm-macos-arm64"
+
+[tools.pnpm."platforms.macos-x64"]
+checksum = "sha256:3b0c97b9f794cdda293949a8ee0e0151ca08f512f4a832408386221c7c73eec6"
+url = "https://github.com/pnpm/pnpm/releases/download/v10.33.4/pnpm-macos-x64"
+
+[tools.pnpm."platforms.windows-x64"]
+checksum = "sha256:3268b2f29defe0dce8a3a26c0ef01488f0d4aa4872923173186ef618ab7d68ef"
+url = "https://github.com/pnpm/pnpm/releases/download/v10.33.4/pnpm-win-x64.exe"
 
 [[tools.ruby]]
 version = "3.4.7"

--- a/src/public/lib/hexo-renderer-asciidoc/.mise.toml
+++ b/src/public/lib/hexo-renderer-asciidoc/.mise.toml
@@ -4,7 +4,7 @@
 [tools]
 hk = "latest"
 node = "24"
-pnpm = "latest"
+pnpm = "10.33.4"
 pkl = "latest"
 typos = "latest"
 go = "latest"


### PR DESCRIPTION
## Summary
- pin pnpm to 10.33.4 across CI, release, root mise, and the nested Hexo example mise config so jobs do not float to freshly published pnpm patches outside Renovate stability windows
- group Serilog.Extensions.Logging with Microsoft.Extensions updates and gate .NET test stack major updates through the Dependency Dashboard
- include mise.lock in pnpm post-upgrade artifacts and fix DotNetLockFileLister for NuGet.ProjectModel nullable annotations

## Validation
- npx --yes --package renovate@43.150.0 -- renovate-config-validator renovate.json --strict
- hk validate
- HK_FIX=0 hk check --step actionlint .github/workflows/ci.yml .github/workflows/release-orchestrate.yml
- HK_FIX=0 hk check --step toml-taplo-format mise.toml src/public/lib/hexo-renderer-asciidoc/.mise.toml
- GITHUB_WORKSPACE=$PWD EXPECTED_PYTHON_VERSION=3.14 EXPECTED_NODE_VERSION=24 EXPECTED_PNPM_VERSION=10.33.4 EXPECTED_RUBY_VERSION=3.3 bash eng/scripts/release_orchestrate_lint_tool_versions.sh
- dotnet build src/private/app/DotNetLockFileLister/DotNetLockFileLister.csproj -c Debug