### PR TITLE
chore(renovate): Format Generated Pnpm Lockfiles

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -101,7 +101,11 @@ outputs = ["global.json"]
 
 [tasks.update-pnpm-lockfiles]
 description = "Refresh tracked pnpm lockfiles"
-run = 'pnpm install --lockfile-only --no-frozen-lockfile && pnpm --dir src/public/lib/hexo-renderer-asciidoc/examples/hexo-site install --lockfile-only --no-frozen-lockfile'
+run = '''
+pnpm install --lockfile-only --no-frozen-lockfile
+pnpm --dir src/public/lib/hexo-renderer-asciidoc/examples/hexo-site install --lockfile-only --no-frozen-lockfile
+pnpm exec -- prettier --write -- pnpm-lock.yaml src/public/lib/hexo-renderer-asciidoc/examples/hexo-site/pnpm-lock.yaml
+'''
 
 [tasks.update-uv-lock]
 description = "Refresh root uv lockfile"


### PR DESCRIPTION
Run Prettier after Renovate refreshes tracked pnpm lockfiles so generated lockfile artifacts satisfy the repository YAML formatting gate.

This keeps mise-managed pnpm updates from producing branches that fail validation only because the refreshed example lockfile is unformatted.