### PR TITLE
fix(renovate): Consolidate Dashboard Tooling Groups

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -148,6 +148,14 @@
       "postUpdateOptions": ["pnpmDedupe"]
     },
     {
+      "description": "Group Biome updates across JavaScript workspaces.",
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["@biomejs/biome"],
+      "groupName": "Biome",
+      "postUpdateOptions": ["pnpmDedupe"],
+      "automerge": true
+    },
+    {
       "description": "Group Commitlint packages.",
       "matchManagers": ["npm"],
       "matchPackageNames": ["/^@commitlint\\//"],
@@ -459,15 +467,21 @@
       "automerge": true
     },
     {
-      "description": "Group pnpm mise updates and refresh pnpm lockfiles.",
+      "description": "Refresh pnpm lockfiles after mise pnpm updates.",
       "matchManagers": ["mise"],
       "matchDepNames": ["pnpm"],
-      "groupName": "Mise pnpm",
       "postUpgradeTasks": {
         "commands": ["mise install pnpm", "mise run --skip-tools --force update-pnpm-lockfiles"],
         "fileFilters": ["mise.lock", "**/mise.lock", "**/.mise.lock", "pnpm-lock.yaml", "**/pnpm-lock.yaml"],
         "executionMode": "branch"
       },
+      "automerge": true
+    },
+    {
+      "description": "Group pnpm tool version updates across workflows and mise.",
+      "matchManagers": ["github-actions", "mise"],
+      "matchDepNames": ["pnpm"],
+      "groupName": "pnpm",
       "automerge": true
     },
     {


### PR DESCRIPTION
## Summary\n- Group @biomejs/biome updates across JavaScript workspaces into one Renovate branch.\n- Split pnpm mise artifact refresh from cross-manager pnpm grouping so workflow and mise pnpm updates share one dashboard item without broadening post-upgrade tasks.\n- Leave lock-file maintenance entries unchanged because they are schedule/gate noise rather than a failing duplicate.\n\n## Validation\n- `node -e 'JSON.parse(require("fs").readFileSync("renovate.json","utf8"))'`\n- `npx --yes --package renovate renovate-config-validator renovate.json`