### PR TITLE
fix(renovate): Clarify Lockfile Maintenance Titles

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -24,7 +24,7 @@
     "schedule": ["before 6am on tuesday"],
     "automerge": true,
     "commitMessageAction": "Refresh",
-    "commitMessageTopic": "Dependency Lock Files"
+    "commitMessageTopic": "{{#if groupName}}{{groupName}} Lock Files{{else}}Dependency Lock Files{{/if}}"
   },
   "vulnerabilityAlerts": {
     "enabled": true,


### PR DESCRIPTION
## Summary\n- Include the Renovate group name in lockfile maintenance commit topics when a grouped maintenance branch is created.\n- Keep the default lockfile maintenance title unchanged for the general branch.\n\n## Validation\n- `node -e 'JSON.parse(require("fs").readFileSync("renovate.json","utf8"))'`\n- `npx --yes --package renovate renovate-config-validator renovate.json`