### PR TITLE
chore(deps): Add Renovate Post Upgrade Task for Pnpm Lockfiles

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -78,6 +78,17 @@
       "automerge": true
     },
     {
+      "description": "Refresh tracked pnpm lockfiles after lock file maintenance updates.",
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["lockFileMaintenance"],
+      "postUpgradeTasks": {
+        "commands": ["mise install pnpm", "mise run --skip-tools --force update-pnpm-lockfiles"],
+        "fileFilters": ["pnpm-lock.yaml", "**/pnpm-lock.yaml"],
+        "executionMode": "branch"
+      },
+      "automerge": true
+    },
+    {
       "description": "Group GitHub Actions setup and CI tooling updates.",
       "matchManagers": ["github-actions"],
       "matchPackageNames": [


### PR DESCRIPTION
Add a Renovate lockFileMaintenance post-upgrade task so pnpm lockfile refreshes rerun the repo's existing pnpm lockfile formatter. This keeps the root and Hexo demo pnpm lockfiles consistent with hk/Prettier and prevents the PR 301 failure mode.