### PR TITLE
chore(deps): Refresh Pnpm Lockfiles After Npm Updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -78,9 +78,8 @@
       "automerge": true
     },
     {
-      "description": "Refresh tracked pnpm lockfiles after lock file maintenance updates.",
+      "description": "Refresh tracked pnpm lockfiles after npm updates.",
       "matchManagers": ["npm"],
-      "matchUpdateTypes": ["lockFileMaintenance"],
       "postUpgradeTasks": {
         "commands": ["mise install pnpm", "mise run --skip-tools --force update-pnpm-lockfiles"],
         "fileFilters": ["pnpm-lock.yaml", "**/pnpm-lock.yaml"],


### PR DESCRIPTION
The previous lockFileMaintenance-scoped rule did not fire on PR 301. Broaden the Renovate post-upgrade task to all npm updates so pnpm lockfile formatting always runs when Renovate touches pnpm-managed lockfiles.