### PR TITLE
docs(azureauth-credprovider): Add Credential Provider Research Docs

### DIFF
--- a/src/private/app/azureauth-credprovider/docs/high-level-design.md
+++ b/src/private/app/azureauth-credprovider/docs/high-level-design.md
@@ -20,6 +20,10 @@ The primary user-facing command is a standard CLI. The executable name is intent
 <primary-cli> configure nuget
 <primary-cli> configure python
 <primary-cli> configure npm
+<primary-cli> unconfigure git
+<primary-cli> unconfigure nuget
+<primary-cli> unconfigure python
+<primary-cli> unconfigure npm
 <primary-cli> doctor
 ```
 
@@ -30,7 +34,8 @@ The human-facing CLI owns:
 - diagnostics,
 - cache inspection and cleanup,
 - CI guidance,
-- installation verification.
+- installation verification,
+- integration removal.
 
 Protocol adapters are installed and configured by the CLI, but they are not the primary interface users interact with.
 
@@ -91,7 +96,7 @@ The core must not assume a single protocol output format. Protocol adapters are 
 
 | Entrypoint                     |                       Requirement level | Integration contract                                                         |
 | ------------------------------ | --------------------------------------: | ---------------------------------------------------------------------------- |
-| `git-credential-<helper-name>` |                    Strongly recommended | Git credential helper stdin/stdout protocol.                                 |
+| `git-credential-<helper-name>` |                                Required | Git credential helper stdin/stdout protocol.                                 |
 | NuGet plugin entry point       |                                Required | NuGet plugin handshake and authentication messages; launched with `-Plugin`. |
 | Python keyring backend package |                                Required | Python `keyring.backends` discovery and backend API.                         |
 | `keyring` executable shim      | Required for uv and pip subprocess mode | Keyring CLI-compatible `get` behavior.                                       |
@@ -123,13 +128,13 @@ The angle-bracketed helper name is a substitution placeholder. The configuration
 
 ## NuGet Adapter
 
-The NuGet adapter must be structured as a NuGet plugin because NuGet launches plugin files and passes fixed plugin arguments. It should not rely on a standard subcommand such as:
+The NuGet adapter must be structured as a NuGet plugin because NuGet launches plugin files and passes fixed plugin arguments. The default packaging model should be a plugin-shaped entry point that delegates to the shared core. The primary CLI may also implement plugin mode only if NuGet is configured to launch that executable directly as the plugin path; NuGet will not discover an arbitrary standard subcommand such as:
 
 ```text
 <primary-cli> nuget plugin
 ```
 
-unless the top-level executable itself is the plugin path and can enter plugin mode when launched with NuGet's arguments.
+as a command with arguments.
 
 The NuGet adapter must:
 
@@ -148,6 +153,8 @@ NuGet discovery options should be documented and diagnosed explicitly:
 | Direct plugin path   | Full path to the plugin entry point                                                     | Advanced override; cannot include extra subcommand arguments; can shadow convention discovery. |
 | Convention discovery | `.nuget/plugins/netcore/<name>/<name>.dll` and `.nuget/plugins/netfx/<name>/<name>.exe` | Preferred for broad developer-machine compatibility.                                           |
 | PATH discovery       | `nuget-plugin-*` executable where supported                                             | Still must enter NuGet plugin mode and speak the NuGet plugin protocol.                        |
+
+Default setup should prefer conventional plugin discovery. `NUGET_PLUGIN_PATHS` should remain an advanced diagnostic or explicit override path, not a global default, because mixed `dotnet` and NuGet.exe/MSBuild environments may require different plugin shapes.
 
 Interactive behavior is controlled by the invoking NuGet client. `dotnet restore` should require `--interactive` before the plugin initiates first-time user interaction. MSBuild restore should require `/p:NuGetInteractive=true`. NuGet.exe may prompt by default. The plugin must honor NuGet protocol `NonInteractive` and `CanShowDialog` values and must not prompt or block when `NonInteractive` is true.
 
@@ -214,13 +221,14 @@ Credential cache keys must include:
 - Azure DevOps host,
 - organization,
 - project when relevant,
+- feed identity for package-feed adapters,
 - service identity,
 - account,
 - tenant,
 - token audience,
 - credential type.
 
-Package-feed cache entries should include feed identity. Azure Repos Git should normally key credential storage by host and organization rather than by full repository path unless an explicit per-repository policy requires finer partitioning. No adapter should read a generic "current token" without ecosystem and audience validation.
+Azure Repos Git should normally key credential storage by host and organization rather than by full repository path unless an explicit per-repository policy requires finer partitioning. No adapter should read a generic "current token" without ecosystem and audience validation.
 
 ## CI Model
 
@@ -256,6 +264,17 @@ CI behavior must:
 - CI mode and secret handling.
 
 Diagnostics should never print access tokens, refresh tokens, PATs, Basic auth headers, npm tokens, NuGet API keys, or generated passwords.
+
+## Integration Removal
+
+`<primary-cli> unconfigure <ecosystem>` should remove only configuration and adapter registrations owned by this product. It must not delete unrelated user configuration, unrelated credential helpers, package source declarations, or credentials owned by other tools.
+
+Removal behavior should include:
+
+- Git: remove this product's configured helper entry and `dev.azure.com` path-forwarding setting only when it was installed by this product or explicitly selected by the user.
+- NuGet: remove this product's plugin installation or explicit plugin-path override without deleting unrelated NuGet package sources.
+- Python: remove this product's keyring backend or shim registration from the targeted Python environment without uninstalling unrelated keyring backends.
+- npm: remove this product's generated credential entries while preserving registry declarations and unrelated npm or Yarn configuration.
 
 ## Explicitly Deferred
 

--- a/src/private/app/azureauth-credprovider/docs/high-level-design.md
+++ b/src/private/app/azureauth-credprovider/docs/high-level-design.md
@@ -1,0 +1,277 @@
+# AzureAuth Credential Provider High-Level Design
+
+Status: **Draft design baseline**
+
+## Design Summary
+
+AzureAuth Credential Provider should be one product with one shared credential core and one human-facing CLI. It should expose additional machine-facing entry points only where host tools require a specific executable name, package entry point, file layout, or protocol invocation.
+
+The design intentionally separates implementation ownership from host-tool discovery. Git, NuGet, Python keyring, and npm-compatible tooling should not receive four independent credential implementations. They should receive thin adapters that delegate to the same credential core.
+
+## Target Command Model
+
+The primary user-facing command is a standard CLI:
+
+```powershell
+azureauth-credprovider login
+azureauth-credprovider logout
+azureauth-credprovider status
+azureauth-credprovider configure git
+azureauth-credprovider configure nuget
+azureauth-credprovider configure python
+azureauth-credprovider configure npm
+azureauth-credprovider doctor
+```
+
+The human-facing CLI owns:
+
+- login and account selection,
+- global and per-ecosystem configuration,
+- diagnostics,
+- cache inspection and cleanup,
+- CI guidance,
+- installation verification.
+
+Protocol adapters are installed and configured by the CLI, but they are not the primary interface users interact with.
+
+## High-Level Components
+
+```text
+                      +-----------------------------+
+                      | azureauth-credprovider CLI  |
+                      | login/configure/doctor      |
+                      +--------------+--------------+
+                                     |
+                                     v
+                      +-----------------------------+
+                      | Shared credential core      |
+                      | identity/cache/policy       |
+                      +---+-----------+--------+----+
+                          |           |        |
+          +---------------+           |        +----------------+
+          v                           v                         v
++---------------------+     +---------------------+     +---------------------+
+| Git adapter         |     | NuGet plugin        |     | npm config updater  |
+| git credential I/O  |     | NuGet plugin I/O    |     | npmrc/yarnrc I/O    |
++----------+----------+     +----------+----------+     +----------+----------+
+           |                           |                           |
+           v                           v                           v
+      Git client                 NuGet clients             npm/pnpm/Yarn
+
+          +------------------------------------------------+
+          | Python keyring backend and keyring CLI adapter |
+          +-------------------------+----------------------+
+                                    |
+                                    v
+                          pip / twine / uv
+```
+
+## Shared Credential Core
+
+The shared core owns credential behavior that must not diverge between ecosystems:
+
+- Azure DevOps host and feed canonicalization,
+- tenant and account selection,
+- interactive browser or device-code login,
+- non-interactive service identity flows,
+- token exchange and refresh,
+- secure credential cache access,
+- cache partitioning,
+- redaction,
+- policy enforcement,
+- diagnostic event generation.
+
+The core must not assume a single protocol output format. Protocol adapters are responsible for host-tool input and output.
+
+## Machine-Facing Entrypoints
+
+| Entrypoint                     |                       Requirement level | Integration contract                                                         |
+| ------------------------------ | --------------------------------------: | ---------------------------------------------------------------------------- |
+| `git-credential-azureauth`     |                    Strongly recommended | Git credential helper stdin/stdout protocol.                                 |
+| NuGet plugin entry point       |                                Required | NuGet plugin handshake and authentication messages; launched with `-Plugin`. |
+| Python keyring backend package |                                Required | Python `keyring.backends` discovery and backend API.                         |
+| `keyring` executable shim      | Required for uv and pip subprocess mode | Keyring CLI-compatible `get` behavior.                                       |
+| `azureauth-credprovider npm`   |                                Required | Reads and updates npm/Yarn registry config.                                  |
+| npm alias binary               |                                Optional | Compatibility wrapper for documentation or existing scripts.                 |
+
+## Git Adapter
+
+The Git adapter should support the Git credential helper protocol:
+
+```text
+git-credential-azureauth get
+git-credential-azureauth store
+git-credential-azureauth erase
+```
+
+The adapter reads credential records from stdin and writes only Git credential fields to stdout. It delegates account selection and token acquisition to the shared core.
+
+Recommended configuration:
+
+```powershell
+git config --global credential.helper azureauth
+git config --global credential.https://dev.azure.com.useHttpPath true
+```
+
+The `useHttpPath` setting is required for `dev.azure.com` because the organization is in the URL path. Legacy `<org>.visualstudio.com` remotes carry the organization in the host name and do not require the same setting.
+
+The configuration command should avoid shell snippets as the default. Shell snippets are useful for development, but they are harder to quote safely on Windows and less reliable in GUI Git clients. The installer must either place `git-credential-azureauth` where Git itself can discover it or configure a carefully quoted absolute helper path. `doctor` should validate helper discovery by invoking Git, not just by checking the current shell's `PATH`.
+
+## NuGet Adapter
+
+The NuGet adapter must be structured as a NuGet plugin because NuGet launches plugin files and passes fixed plugin arguments. It should not rely on a standard subcommand such as:
+
+```powershell
+azureauth-credprovider nuget plugin
+```
+
+unless the top-level executable itself is the plugin path and can enter plugin mode when launched with NuGet's arguments.
+
+The NuGet adapter must:
+
+- support NuGet plugin handshake behavior,
+- support authentication request handling,
+- respect non-interactive restore,
+- emit only protocol-valid content to stdout,
+- route diagnostics safely,
+- support dotnet CLI restore scenarios,
+- support Visual Studio/MSBuild/NuGet.exe scenarios where required by project scope.
+
+NuGet discovery options should be documented and diagnosed explicitly:
+
+| Mode                 | Shape                                                                                   | Operational note                                                                               |
+| -------------------- | --------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| Direct plugin path   | Full path to the plugin entry point                                                     | Advanced override; cannot include extra subcommand arguments; can shadow convention discovery. |
+| Convention discovery | `.nuget/plugins/netcore/<name>/<name>.dll` and `.nuget/plugins/netfx/<name>/<name>.exe` | Preferred for broad developer-machine compatibility.                                           |
+| PATH discovery       | `nuget-plugin-*` executable where supported                                             | Still must enter NuGet plugin mode and speak the NuGet plugin protocol.                        |
+
+Interactive behavior is controlled by the invoking NuGet client. `dotnet restore` should require `--interactive` before the plugin initiates first-time user interaction. MSBuild restore should require `/p:NuGetInteractive=true`. NuGet.exe may prompt by default. The plugin must honor NuGet protocol `NonInteractive` and `CanShowDialog` values and must not prompt or block when `NonInteractive` is true.
+
+## Python Adapter
+
+Python requires two adapter shapes for full coverage:
+
+1. A Python keyring backend package for twine and pip import mode.
+2. A `keyring` executable-compatible shim for uv and pip subprocess mode.
+
+The Python keyring backend should be intentionally thin. It should delegate credential acquisition to the shared core through an absolute helper path, a signed local broker, or a small trusted library boundary. It should not import a large credential implementation into arbitrary project virtual environments.
+
+The backend package must be available in the same Python environment as the tool that imports keyring. `configure python` and `doctor` should account for active virtual environments, pipx-installed twine, tox/nox environments, and isolated CI environments. A unified CLI alone cannot satisfy twine because twine imports Python keyring rather than invoking an arbitrary external subcommand.
+
+Keeping the large credential implementation outside the project virtual environment reduces the trusted code imported into arbitrary Python environments, but it is not a security boundary. The invoking package-manager process must receive credentials, so a compromised environment can still observe returned credentials.
+
+The `keyring` shim should support:
+
+```text
+keyring get <service> <username>    # stdout is the password
+keyring get <service> --mode creds  # stdout is newline-separated username and password
+```
+
+It must print only the expected keyring response to stdout.
+
+The shim must define exit behavior for no credential, unsupported host, and fatal errors. It should either delegate unsupported keyring commands to a real Python `keyring` CLI or avoid global shadowing by using controlled PATH injection. pip subprocess mode requires a username in the index URL and may ignore a `keyring` executable installed only in the current Python environment's scripts directory. uv invokes `keyring` from `PATH` directly and can use `--mode creds` when no username is present.
+
+## npm Adapter
+
+The npm-compatible adapter can be a standard CLI subcommand because npm, pnpm, and Yarn use registry configuration files rather than a credential-provider plugin protocol.
+
+The adapter should:
+
+- discover workspace-level `.npmrc` and `.yarnrc.yml` files,
+- parse registry and scoped registry entries,
+- request feed-specific credentials from the shared core,
+- read registry declarations from workspace files but write developer credentials only to user-level configuration by default,
+- support CI output modes that avoid persistent writes,
+- optionally support `pnpm:devPreinstall` or explicit bootstrap invocation.
+
+Recommended explicit invocation:
+
+```powershell
+azureauth-credprovider npm
+```
+
+Optional package-manager script:
+
+```json
+{
+    "scripts": {
+        "pnpm:devPreinstall": "azureauth-credprovider npm"
+    }
+}
+```
+
+This script requires the CLI to be available before `pnpm install` begins. npm `preinstall` should not be treated as a reliable first-auth hook for private dependency resolution; npm and Yarn should use an explicit bootstrap step before registry access that requires credentials.
+
+## Cache Model
+
+Credential cache keys must include:
+
+- ecosystem,
+- Azure DevOps host,
+- organization,
+- project when relevant,
+- service identity,
+- account,
+- tenant,
+- token audience,
+- credential type.
+
+Package-feed cache entries should include feed identity. Azure Repos Git should normally key credential storage by host and organization rather than by full repository path unless an explicit per-repository policy requires finer partitioning. No adapter should read a generic "current token" without ecosystem and audience validation.
+
+## CI Model
+
+CI mode should be explicit. The CLI should detect common CI environments but should not silently persist credentials just because it is running in CI.
+
+CI behavior should prefer:
+
+- workload identity federation,
+- managed identity where available,
+- Azure Pipelines system access token for Azure Pipelines scenarios,
+- short-lived tokens over personal access tokens,
+- temporary config files or environment variables over user-global writes.
+
+CI behavior must:
+
+- disable interactive prompts unless explicitly enabled,
+- redact all secrets,
+- avoid writing credentials into build caches,
+- provide cleanup guidance or cleanup hooks,
+- fail closed when required identity material is absent.
+
+## Diagnostics
+
+`azureauth-credprovider doctor` should validate:
+
+- Git helper executable discovery and `credential.useHttpPath` behavior for Azure Repos hosts,
+- NuGet plugin discovery and runtime compatibility,
+- Python keyring backend discovery,
+- `keyring` shim availability for uv,
+- npm and Yarn registry configuration format and required entries,
+- cache health and account selection,
+- host/feed canonicalization,
+- CI mode and secret handling.
+
+Diagnostics should never print access tokens, refresh tokens, PATs, Basic auth headers, npm tokens, NuGet API keys, or generated passwords.
+
+## Explicitly Deferred
+
+- Implementing package manager behavior.
+- Hosting or proxying Azure Artifacts feeds.
+- SSH key management for Azure Repos.
+- Visual Studio UI integration beyond NuGet plugin compatibility.
+- Automatically migrating existing user credential stores.
+- Transparent credentials for arbitrary non-Azure registries.
+- Requiring a background daemon; a broker process may be evaluated later but is not assumed.
+
+## Design Decision
+
+The project should proceed with a hybrid entry point architecture:
+
+```text
+one product
+one shared credential core
+one primary human CLI
+thin machine-facing adapters where host tools require them
+```
+
+This design satisfies real host-tool invocation constraints without splitting credential behavior into four independent products.

--- a/src/private/app/azureauth-credprovider/docs/high-level-design.md
+++ b/src/private/app/azureauth-credprovider/docs/high-level-design.md
@@ -1,26 +1,26 @@
-# AzureAuth Credential Provider High-Level Design
+# Unified Azure DevOps Credential Provider High-Level Design
 
 Status: **Draft design baseline**
 
 ## Design Summary
 
-AzureAuth Credential Provider should be one product with one shared credential core and one human-facing CLI. It should expose additional machine-facing entry points only where host tools require a specific executable name, package entry point, file layout, or protocol invocation.
+The credential provider should be one product with one shared credential core and one human-facing CLI. It should expose additional machine-facing entry points only where host tools require a specific executable name, package entry point, file layout, or protocol invocation.
 
 The design intentionally separates implementation ownership from host-tool discovery. Git, NuGet, Python keyring, and npm-compatible tooling should not receive four independent credential implementations. They should receive thin adapters that delegate to the same credential core.
 
 ## Target Command Model
 
-The primary user-facing command is a standard CLI:
+The primary user-facing command is a standard CLI. The executable name is intentionally provisional in this document:
 
-```powershell
-azureauth-credprovider login
-azureauth-credprovider logout
-azureauth-credprovider status
-azureauth-credprovider configure git
-azureauth-credprovider configure nuget
-azureauth-credprovider configure python
-azureauth-credprovider configure npm
-azureauth-credprovider doctor
+```text
+<primary-cli> login
+<primary-cli> logout
+<primary-cli> status
+<primary-cli> configure git
+<primary-cli> configure nuget
+<primary-cli> configure python
+<primary-cli> configure npm
+<primary-cli> doctor
 ```
 
 The human-facing CLI owns:
@@ -34,11 +34,13 @@ The human-facing CLI owns:
 
 Protocol adapters are installed and configured by the CLI, but they are not the primary interface users interact with.
 
+The design should explicitly evaluate AzureAuth, also known as `microsoft-authentication-cli`, as a candidate identity substrate. AzureAuth is an MSAL-based CLI for Microsoft Entra authentication and includes Azure DevOps token-oriented commands. If reused, it should sit below the shared credential core or behind a well-defined identity-provider abstraction; it should not replace the Git, NuGet, Python keyring, or npm protocol adapters.
+
 ## High-Level Components
 
 ```text
                       +-----------------------------+
-                      | azureauth-credprovider CLI  |
+                      | Primary CLI                 |
                       | login/configure/doctor      |
                       +--------------+--------------+
                                      |
@@ -81,17 +83,19 @@ The shared core owns credential behavior that must not diverge between ecosystem
 - policy enforcement,
 - diagnostic event generation.
 
+The shared core may use AzureAuth (`microsoft-authentication-cli`) for Microsoft Entra token acquisition and MSAL cache reuse if it satisfies the required token audiences, non-interactive behavior, installation model, logging policy, and protocol-adapter isolation constraints. The design should also permit a direct MSAL integration if shelling out to AzureAuth would make protocol adapters harder to secure or test.
+
 The core must not assume a single protocol output format. Protocol adapters are responsible for host-tool input and output.
 
 ## Machine-Facing Entrypoints
 
 | Entrypoint                     |                       Requirement level | Integration contract                                                         |
 | ------------------------------ | --------------------------------------: | ---------------------------------------------------------------------------- |
-| `git-credential-azureauth`     |                    Strongly recommended | Git credential helper stdin/stdout protocol.                                 |
+| `git-credential-<helper-name>` |                    Strongly recommended | Git credential helper stdin/stdout protocol.                                 |
 | NuGet plugin entry point       |                                Required | NuGet plugin handshake and authentication messages; launched with `-Plugin`. |
 | Python keyring backend package |                                Required | Python `keyring.backends` discovery and backend API.                         |
 | `keyring` executable shim      | Required for uv and pip subprocess mode | Keyring CLI-compatible `get` behavior.                                       |
-| `azureauth-credprovider npm`   |                                Required | Reads and updates npm/Yarn registry config.                                  |
+| `<primary-cli> npm`            |                                Required | Reads and updates npm/Yarn registry config.                                  |
 | npm alias binary               |                                Optional | Compatibility wrapper for documentation or existing scripts.                 |
 
 ## Git Adapter
@@ -99,30 +103,30 @@ The core must not assume a single protocol output format. Protocol adapters are 
 The Git adapter should support the Git credential helper protocol:
 
 ```text
-git-credential-azureauth get
-git-credential-azureauth store
-git-credential-azureauth erase
+git-credential-<helper-name> get
+git-credential-<helper-name> store
+git-credential-<helper-name> erase
 ```
 
 The adapter reads credential records from stdin and writes only Git credential fields to stdout. It delegates account selection and token acquisition to the shared core.
 
 Recommended configuration:
 
-```powershell
-git config --global credential.helper azureauth
+```text
+git config --global credential.helper <helper-name>
 git config --global credential.https://dev.azure.com.useHttpPath true
 ```
 
 The `useHttpPath` setting is required for `dev.azure.com` because the organization is in the URL path. Legacy `<org>.visualstudio.com` remotes carry the organization in the host name and do not require the same setting.
 
-The configuration command should avoid shell snippets as the default. Shell snippets are useful for development, but they are harder to quote safely on Windows and less reliable in GUI Git clients. The installer must either place `git-credential-azureauth` where Git itself can discover it or configure a carefully quoted absolute helper path. `doctor` should validate helper discovery by invoking Git, not just by checking the current shell's `PATH`.
+The angle-bracketed helper name is a substitution placeholder. The configuration command should avoid shell snippets as the default. Shell snippets are useful for development, but they are harder to quote safely on Windows and less reliable in GUI Git clients. The installer must either place `git-credential-<helper-name>` where Git itself can discover it or configure a carefully quoted absolute helper path. `doctor` should validate helper discovery by invoking Git, not just by checking the current shell's `PATH`.
 
 ## NuGet Adapter
 
 The NuGet adapter must be structured as a NuGet plugin because NuGet launches plugin files and passes fixed plugin arguments. It should not rely on a standard subcommand such as:
 
-```powershell
-azureauth-credprovider nuget plugin
+```text
+<primary-cli> nuget plugin
 ```
 
 unless the top-level executable itself is the plugin path and can enter plugin mode when launched with NuGet's arguments.
@@ -186,8 +190,8 @@ The adapter should:
 
 Recommended explicit invocation:
 
-```powershell
-azureauth-credprovider npm
+```text
+<primary-cli> npm
 ```
 
 Optional package-manager script:
@@ -195,7 +199,7 @@ Optional package-manager script:
 ```json
 {
     "scripts": {
-        "pnpm:devPreinstall": "azureauth-credprovider npm"
+        "pnpm:devPreinstall": "<primary-cli> npm"
     }
 }
 ```
@@ -240,7 +244,7 @@ CI behavior must:
 
 ## Diagnostics
 
-`azureauth-credprovider doctor` should validate:
+`<primary-cli> doctor` should validate:
 
 - Git helper executable discovery and `credential.useHttpPath` behavior for Azure Repos hosts,
 - NuGet plugin discovery and runtime compatibility,

--- a/src/private/app/azureauth-credprovider/docs/high-level-design.md
+++ b/src/private/app/azureauth-credprovider/docs/high-level-design.md
@@ -254,7 +254,7 @@ CI behavior must:
 
 `<primary-cli> doctor` should validate:
 
-- Git helper executable discovery and `credential.useHttpPath` behavior for Azure Repos hosts,
+- Git helper executable discovery and `credential.https://dev.azure.com.useHttpPath` behavior for Azure Repos hosts,
 - NuGet plugin discovery and runtime compatibility,
 - Python keyring backend discovery,
 - `keyring` shim availability for uv,

--- a/src/private/app/azureauth-credprovider/docs/requirements.md
+++ b/src/private/app/azureauth-credprovider/docs/requirements.md
@@ -1,0 +1,136 @@
+# AzureAuth Credential Provider Requirements
+
+Status: **Draft requirements baseline**
+
+## Goal
+
+Build a unified credential provider for Azure DevOps and Azure Artifacts that covers four developer ecosystems:
+
+1. Azure Repos Git authentication.
+2. NuGet and .NET package restore against Azure Artifacts feeds.
+3. Python package consumption and publishing through pip, twine, uv, and Python keyring.
+4. npm-compatible package consumption for npm, pnpm, and Yarn.
+
+The product should provide a consistent setup, login, diagnostics, and configuration experience while satisfying each host tool's native credential discovery and protocol contract.
+
+## Audience
+
+This project targets senior software engineers who maintain developer tooling, internal platform SDKs, CI bootstrap flows, and cross-platform authentication integrations.
+
+## Product Boundary
+
+The product is a credential acquisition, refresh, and configuration layer. It is not a package manager, Git client, feed server, Azure DevOps client replacement, or CI orchestration system.
+
+The product owns:
+
+- interactive and non-interactive credential acquisition,
+- account and tenant selection,
+- host/feed canonicalization,
+- secure token cache coordination,
+- protocol adapters for host-tool credential exchange,
+- user-facing configuration and diagnostics commands.
+
+Azure DevOps and Azure Artifacts own:
+
+- repository and feed authorization,
+- token validation,
+- package and Git data plane operations,
+- service-side policy enforcement.
+
+Host tools own:
+
+- Git clone/fetch/push behavior,
+- NuGet restore/push behavior,
+- pip/twine/uv package operations,
+- npm/pnpm/yarn install/publish behavior.
+
+## Functional Requirements
+
+1. Provide one human-facing CLI for setup, login, logout, status, diagnostics, and ecosystem configuration.
+2. Support Azure Repos HTTPS Git remotes hosted on `dev.azure.com` and legacy `*.visualstudio.com` hosts.
+3. Support Azure Artifacts NuGet v3 feeds for `dotnet`, NuGet.exe, MSBuild, and Visual Studio restore scenarios.
+4. Support Azure Artifacts Python simple-index and upload endpoints for pip, twine, and uv workflows.
+5. Support Azure Artifacts npm registry endpoints for npm, pnpm, and Yarn workflows.
+6. Reuse a single credential core for token acquisition, account selection, cache access, and policy enforcement.
+7. Provide entry points that conform to each host tool's required discovery and invocation protocol.
+8. Avoid duplicating credential logic across ecosystem adapters.
+9. Preserve host-tool protocol boundaries: protocol adapters must write only protocol-valid content to stdout.
+10. Provide configuration commands that can install, verify, and remove each ecosystem integration.
+11. Support non-interactive CI operation without persisting secrets by default.
+12. Provide a `doctor` command that validates Git helper configuration, NuGet plugin discovery, Python keyring availability, npm registry configuration, credential cache health, and common CI misconfigurations.
+
+## Non-Functional Requirements
+
+1. Use American English in all product documentation and command help.
+2. Maintain a professional tone suitable for experienced engineers and platform owners.
+3. Support Windows as a first-class platform, including Git for Windows, Visual Studio/MSBuild, PowerShell, `.exe`, `.cmd`, and path-with-spaces scenarios.
+4. Support Linux and macOS developer and CI environments.
+5. Keep protocol adapters small, deterministic, and testable.
+6. Keep token handling centralized and auditable.
+7. Redact secrets in stdout, stderr, logs, traces, dry-run output, and error messages.
+8. Partition credential cache entries by ecosystem, service identity, feed or host, account, tenant, token audience, and credential type.
+9. Prefer short-lived or identity-derived credentials over long-lived personal access tokens.
+10. Avoid writing credentials into repository-local configuration files by default.
+
+## Integration Requirements by Ecosystem
+
+### Git
+
+1. Provide a Git credential helper-compatible entry point.
+2. Read Git credential records from stdin and write only Git credential fields to stdout.
+3. Support `get`, `store`, and `erase` operations.
+4. Configure Azure Repos hosts in a way that preserves organization identity for `dev.azure.com` URLs.
+5. Configure `credential.https://dev.azure.com.useHttpPath=true` for `dev.azure.com` HTTPS remotes so the helper receives the organization path.
+6. Prefer helper configuration that avoids shell snippets when an installed helper entry point is available.
+
+### NuGet
+
+1. Provide a NuGet plugin-compatible entry point that supports NuGet's plugin handshake and authentication request protocol.
+2. Enter plugin mode when launched by NuGet with fixed plugin arguments.
+3. Support .NET Core plugin discovery for `dotnet restore`.
+4. Support .NET Framework-compatible plugin discovery where Visual Studio, MSBuild, or NuGet.exe scenarios require it.
+5. Respect NuGet's interactive and non-interactive restore settings.
+
+### Python
+
+1. Provide a Python keyring backend package for tools that import Python keyring directly.
+2. Provide a `keyring` command-compatible shim for tools that use subprocess keyring mode.
+3. Support pip, twine, and uv without requiring credentials in source-controlled project files.
+4. Keep trusted credential logic outside arbitrary project virtual environments where practical.
+5. Support Azure Artifacts Python simple-index and upload endpoints in both organization-scoped and project-scoped forms.
+
+### npm, pnpm, and Yarn
+
+1. Provide an npm ecosystem command that reads npm and Yarn registry configuration and updates credential material safely.
+2. Support `.npmrc` registry entries for npm and pnpm.
+3. Support `.yarnrc.yml` registry entries for Yarn Berry (Yarn 2+), including `npmRegistryServer`, `npmScopes`, and auth material under `npmRegistries`.
+4. Support invocation from package-manager lifecycle or bootstrap scripts when the CLI is already available.
+5. Avoid writing raw long-lived tokens to repository-local `.npmrc` files by default.
+
+## Non-Goals
+
+1. Do not implement a Git remote transport.
+2. Do not implement a package manager.
+3. Do not host package feeds or Git repositories.
+4. Do not require developers to learn protocol adapter commands for normal operation.
+5. Do not rely on a single standard CLI subcommand model for every host-tool integration when the host tool requires a different discovery contract.
+6. Do not create four independent credential products with separate token acquisition implementations.
+7. Do not store secrets in project files by default.
+8. Do not support unauthenticated HTTP remotes or package feeds.
+9. Do not authenticate Azure Repos SSH remotes or manage SSH keys; Git support is HTTPS credential-helper only.
+
+## Open Questions
+
+1. Whether the shared credential core should be a library, a local broker process, or a single executable invoked by adapters.
+2. Whether the NuGet adapter should ship as one multi-target package, separate netcore/netfx artifacts, or a top-level executable that also supports `-Plugin`.
+3. Whether the Python keyring backend should call an absolute external helper path or use an embedded shared library.
+4. Whether npm compatibility aliases should be provided in addition to the primary `company-auth npm` command.
+5. Which identity flows are mandatory for MVP: interactive browser, device code, PAT, service principal, managed identity, workload identity federation, or Azure Pipelines system access token.
+
+## Acceptance Criteria for the Design Phase
+
+1. The design documents explain why one shared core is required and why some host tools still need protocol-specific entry points.
+2. The design identifies the minimum entry point surface for Git, NuGet, Python, and npm-compatible tooling.
+3. The design documents source evidence from existing Microsoft tools and local protocol experiments.
+4. The design distinguishes implementation boundaries from host-tool discovery boundaries.
+5. The design provides security requirements for token cache partitioning, protocol stdout, CI operation, and configuration-file writes.

--- a/src/private/app/azureauth-credprovider/docs/requirements.md
+++ b/src/private/app/azureauth-credprovider/docs/requirements.md
@@ -1,4 +1,4 @@
-# AzureAuth Credential Provider Requirements
+# Unified Azure DevOps Credential Provider Requirements
 
 Status: **Draft requirements baseline**
 
@@ -57,7 +57,8 @@ Host tools own:
 9. Preserve host-tool protocol boundaries: protocol adapters must write only protocol-valid content to stdout.
 10. Provide configuration commands that can install, verify, and remove each ecosystem integration.
 11. Support non-interactive CI operation without persisting secrets by default.
-12. Provide a `doctor` command that validates Git helper configuration, NuGet plugin discovery, Python keyring availability, npm registry configuration, credential cache health, and common CI misconfigurations.
+12. Evaluate AzureAuth, also known as `microsoft-authentication-cli`, as a candidate identity substrate for Microsoft Entra token acquisition, MSAL cache reuse, and Azure DevOps token-oriented flows.
+13. Provide a `doctor` command that validates Git helper configuration, NuGet plugin discovery, Python keyring availability, npm registry configuration, credential cache health, and common CI misconfigurations.
 
 ## Non-Functional Requirements
 
@@ -124,7 +125,7 @@ Host tools own:
 1. Whether the shared credential core should be a library, a local broker process, or a single executable invoked by adapters.
 2. Whether the NuGet adapter should ship as one multi-target package, separate netcore/netfx artifacts, or a top-level executable that also supports `-Plugin`.
 3. Whether the Python keyring backend should call an absolute external helper path or use an embedded shared library.
-4. Whether npm compatibility aliases should be provided in addition to the primary `company-auth npm` command.
+4. Whether npm compatibility aliases should be provided in addition to the primary npm credential refresh command.
 5. Which identity flows are mandatory for MVP: interactive browser, device code, PAT, service principal, managed identity, workload identity federation, or Azure Pipelines system access token.
 
 ## Acceptance Criteria for the Design Phase

--- a/src/private/app/azureauth-credprovider/docs/requirements.md
+++ b/src/private/app/azureauth-credprovider/docs/requirements.md
@@ -58,7 +58,7 @@ Host tools own:
 10. Provide configuration commands that can install, verify, and remove each ecosystem integration.
 11. Support non-interactive CI operation without persisting secrets by default.
 12. Evaluate AzureAuth, also known as `microsoft-authentication-cli`, as a candidate identity substrate for Microsoft Entra token acquisition, MSAL cache reuse, and Azure DevOps token-oriented flows.
-13. Provide a `doctor` command that validates Git helper configuration, NuGet plugin discovery, Python keyring availability, npm registry configuration, credential cache health, and common CI misconfigurations.
+13. Provide a `doctor` command that validates Git helper configuration through Git's own discovery behavior, NuGet plugin discovery, Python keyring availability, npm registry configuration, credential cache health, and common CI misconfigurations.
 
 ## Non-Functional Requirements
 
@@ -91,6 +91,7 @@ Host tools own:
 3. Support .NET Core plugin discovery for `dotnet restore`.
 4. Support .NET Framework-compatible plugin discovery where Visual Studio, MSBuild, or NuGet.exe scenarios require it.
 5. Respect NuGet's interactive and non-interactive restore settings.
+6. Prefer NuGet's conventional plugin installation locations for default setup, with `NUGET_PLUGIN_PATHS` reserved for advanced diagnostics or explicit overrides.
 
 ### Python
 
@@ -99,6 +100,7 @@ Host tools own:
 3. Support pip, twine, and uv without requiring credentials in source-controlled project files.
 4. Keep trusted credential logic outside arbitrary project virtual environments where practical.
 5. Support Azure Artifacts Python simple-index and upload endpoints in both organization-scoped and project-scoped forms.
+6. Provide supported bootstrap paths that make the Python keyring backend discoverable in the exact Python environment running pip or twine, including virtual environments, pipx-managed tools, and isolated CI environments.
 
 ### npm, pnpm, and Yarn
 

--- a/src/private/app/azureauth-credprovider/docs/research.md
+++ b/src/private/app/azureauth-credprovider/docs/research.md
@@ -1,0 +1,262 @@
+# AzureAuth Credential Provider Research Notes
+
+Status: **Draft research baseline**
+
+## Executive Summary
+
+Azure Repos Git, Azure Artifacts NuGet feeds, Azure Artifacts Python feeds, and Azure Artifacts npm feeds can be covered by one credential product, but not by a single command-line invocation pattern. The research indicates a common credential core should be shared across ecosystems, while host-tool integration must respect each ecosystem's native credential discovery mechanism.
+
+The most important implementation finding is that NuGet, Python keyring, and npm ultimately delegate to the Azure Artifacts Credential Provider pattern for Azure Artifacts package feeds. Git does not use that provider; Azure Repos Git authentication is handled by Git Credential Manager-style credential helper integration.
+
+## Local Source Inventory
+
+The following implementation references are available under `/workspace/public/`:
+
+| Area                           | Local path                                         | Role                                                                                                                                               |
+| ------------------------------ | -------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Azure Repos Git                | `/workspace/public/git-credential-manager`         | Git Credential Manager source and Azure Repos host provider implementation.                                                                        |
+| NuGet and .NET package restore | `/workspace/public/artifacts-credprovider`         | Azure Artifacts Credential Provider source for NuGet, dotnet, and MSBuild.                                                                         |
+| Python keyring                 | `/workspace/public/artifacts-keyring`              | Python keyring backend source for pip and twine Azure Artifacts authentication.                                                                    |
+| npm and pnpm                   | `/workspace/public/artifacts-npm-credprovider`     | Extracted `@microsoft/artifacts-npm-credprovider` package version `1.1.3`.                                                                         |
+| Node wrapper for the provider  | `/workspace/public/artifacts-credprovider-wrapper` | Extracted `@microsoft/artifacts-credprovider-wrapper` package version `1.1.4`; its installer downloaded the Linux x64 Credential Provider payload. |
+| AzureAuth helper               | `/workspace/public/microsoft-authentication-cli`   | Related Microsoft authentication CLI; not the primary implementation for these integrations.                                                       |
+
+`uv` and `MicrosoftDocs/azure-devops-docs` are useful references, but they are not credential-provider implementation source trees for this project.
+
+## Package Feed Credential Dependency Chain
+
+The three package-feed ecosystems converge on Azure Artifacts Credential Provider:
+
+```text
+NuGet / dotnet
+  -> artifacts-credprovider
+
+Python / pip / twine / uv
+  -> artifacts-keyring
+  -> bundled or invoked artifacts-credprovider
+
+npm / pnpm / Yarn
+  -> artifacts-npm-credprovider
+  -> artifacts-credprovider-wrapper
+  -> downloaded artifacts-credprovider payload
+```
+
+Azure Repos Git is separate:
+
+```text
+Git / Azure Repos
+  -> git-credential-manager-style helper
+  -> Azure Repos OAuth/PAT/service identity flows
+```
+
+## Git and Azure Repos
+
+Azure Repos supports current `dev.azure.com` HTTPS clone URLs and legacy `*.visualstudio.com` HTTPS clone URLs. SSH uses Azure DevOps SSH URL formats and does not use Git Credential Manager.
+
+Git credential helper discovery is sensitive to command form. Local experiments confirmed:
+
+```text
+credential.helper=company
+  -> Git invokes git-credential-company get
+
+credential.helper=!company-auth git credential-helper
+  -> Git invokes company-auth git credential-helper get
+
+credential.helper=/abs/path/company-auth git credential-helper
+  -> Git invokes /abs/path/company-auth git credential-helper get
+
+credential.helper=company-auth git credential-helper
+  -> Git attempts git credential-company-auth ...
+  -> This fails unless a git-credential-company-auth helper exists.
+```
+
+Implication: a single CLI can implement the logic, but a production installation should provide a Git helper-shaped entry point or configure an absolute helper command carefully. The recommended user configuration is the standard helper shorthand plus explicit `dev.azure.com` path forwarding:
+
+```powershell
+git config --global credential.helper company
+git config --global credential.https://dev.azure.com.useHttpPath true
+```
+
+with an installed `git-credential-company` executable that delegates to the shared core. The `useHttpPath` setting is required for `dev.azure.com` because the Azure DevOps organization is in the URL path. Legacy `<org>.visualstudio.com` remotes carry the organization in the host name and do not need the same setting.
+
+The configure command must either install the helper into a location Git itself can discover or configure a carefully quoted absolute helper path. The doctor command should validate discovery through Git, not only through the current shell, because GUI Git clients may run with a different `PATH`.
+
+Git identity flows should be treated as separate support levels rather than a single generic authentication mode:
+
+| Flow                                                                 | Support implication                                                                                         |
+| -------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| Interactive user OAuth                                               | Primary developer flow for HTTPS remotes.                                                                   |
+| PAT                                                                  | Compatibility flow; avoid embedding tokens in remotes.                                                      |
+| Direct bearer token                                                  | Useful for controlled CI commands such as `http.extraheader`; not a persistent developer setup.             |
+| Service principal, managed identity, or workload identity federation | Viable only when the Azure DevOps organization and repository permissions are configured for that identity. |
+| Azure Pipelines system access token                                  | Pipeline-specific flow; configure as CI bootstrap rather than normal desktop Git helper state.              |
+
+## NuGet and .NET
+
+Azure Artifacts NuGet feeds use NuGet service index URLs:
+
+```text
+https://pkgs.dev.azure.com/<ORG>/<PROJECT>/_packaging/<FEED>/nuget/v3/index.json
+https://pkgs.dev.azure.com/<ORG>/_packaging/<FEED>/nuget/v3/index.json
+https://<ORG>.pkgs.visualstudio.com/<PROJECT>/_packaging/<FEED>/nuget/v3/index.json
+https://<ORG>.pkgs.visualstudio.com/_packaging/<FEED>/nuget/v3/index.json
+```
+
+NuGet integration is plugin-based. NuGet discovers plugin files and launches them with fixed plugin arguments. Local experiments confirmed:
+
+```text
+NUGET_PLUGIN_PATHS=/tmp/nuget-plugin-probe
+  -> plugin launched with argv: -Plugin
+
+NUGET_PLUGIN_PATHS="/tmp/nuget-plugin-probe nuget"
+  -> plugin was not launched
+```
+
+Implication: NuGet cannot be configured to call `company-auth nuget plugin` through `NUGET_PLUGIN_PATHS`. The product needs one of these shapes:
+
+1. A top-level executable that itself handles NuGet's `-Plugin` invocation.
+2. A NuGet plugin-shaped executable or DLL that delegates to the shared core.
+3. Conventional NuGet plugin installation paths for dotnet and Visual Studio/MSBuild scenarios.
+
+The existing Azure Artifacts Credential Provider demonstrates this dual-mode model: it can run as a NuGet plugin and can also be invoked in standalone credential-acquisition mode.
+
+NuGet discovery modes have different operational consequences:
+
+| Mode                 | Shape                                                                                   | Notes                                                                                  |
+| -------------------- | --------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| Direct plugin path   | Full path to a plugin executable or DLL                                                 | Advanced override; no extra arguments or subcommands; can shadow convention discovery. |
+| Convention discovery | `.nuget/plugins/netcore/<name>/<name>.dll` and `.nuget/plugins/netfx/<name>/<name>.exe` | Preferred for broad tool compatibility.                                                |
+| PATH discovery       | `nuget-plugin-*` executable on `PATH` where supported by the NuGet client version       | Useful for tool-style distribution, but still requires plugin protocol behavior.       |
+
+Prefer conventional installation under NuGet plugin folders for normal developer machines. Use `NUGET_PLUGIN_PATHS` only as an advanced or diagnostic override. Avoid setting it globally in environments that use both `dotnet` and NuGet.exe/MSBuild because the .NET Core and .NET Framework plugin shapes differ.
+
+## Python, pip, twine, uv, and keyring
+
+Azure Artifacts Python feeds use these endpoints:
+
+```text
+https://pkgs.dev.azure.com/<ORG>/_packaging/<FEED>/pypi/simple/
+https://pkgs.dev.azure.com/<ORG>/_packaging/<FEED>/pypi/upload/
+https://pkgs.dev.azure.com/<ORG>/<PROJECT>/_packaging/<FEED>/pypi/simple/
+https://pkgs.dev.azure.com/<ORG>/<PROJECT>/_packaging/<FEED>/pypi/upload/
+```
+
+Python tooling has two materially different credential integration paths:
+
+1. In import mode, pip and twine import Python `keyring` and discover backend packages through Python package metadata.
+2. uv and pip subprocess mode call a command named `keyring`.
+
+Local subprocess-shape testing confirmed that a `keyring` executable must support the subset of the Python keyring CLI used by pip and uv:
+
+```text
+keyring get <service> <username>    # stdout is the password
+keyring get <service> --mode creds  # stdout is newline-separated username and password
+```
+
+pip and uv both have subprocess keyring modes, but their discovery semantics differ. uv invokes `keyring` from `PATH` directly. pip subprocess mode calls `keyring get <service> <username>` and requires a username in the index URL. pip also avoids the current Python environment's scripts directory when selecting a subprocess `keyring` executable, so a shim installed only into a project virtual environment may be ignored by pip subprocess mode.
+
+Implication: `company-auth python keyring` is not directly discoverable by all Python tools. A robust product needs:
+
+- a Python keyring backend package for import-mode tools such as twine and pip import mode,
+- a `keyring` executable-compatible shim for uv and subprocess-mode tools,
+- both delegating to the shared credential core.
+
+The existing `artifacts-keyring` package is a keyring backend, not just a standalone CLI. It invokes the Azure Artifacts Credential Provider and adapts the returned credentials to Python keyring.
+
+The Python backend package must be installable into the exact Python environment that runs pip or twine. A globally installed CLI is not enough for twine installed in a project virtual environment, pipx environment, tox/nox environment, or isolated CI environment. Supported bootstrap paths should include installing the backend into the active environment, injecting it into a pipx-managed twine environment, or using subprocess mode where the host tool supports it.
+
+Keeping the large credential implementation outside the project virtual environment reduces how much trusted code is imported into arbitrary Python environments, but it is not a security boundary. Any process running pip, twine, uv, a Python keyring backend, or a PATH-resolved `keyring` shim can observe credentials returned to it. The design should treat project virtual environments as untrusted for implementation integrity while recognizing that the requesting package-manager process must receive credentials to complete authentication.
+
+## npm, pnpm, and Yarn
+
+Azure Artifacts npm feeds use npm-compatible registry URLs:
+
+```text
+https://pkgs.dev.azure.com/<ORG>/_packaging/<FEED>/npm/registry/
+https://pkgs.dev.azure.com/<ORG>/<PROJECT>/_packaging/<FEED>/npm/registry/
+```
+
+The npm ecosystem does not expose a NuGet-style credential-provider plugin protocol for Azure Artifacts feeds. Authentication is driven by registry configuration files:
+
+- `.npmrc` for npm and pnpm,
+- `.yarnrc.yml` for Yarn Berry.
+
+The extracted `@microsoft/artifacts-npm-credprovider` package is a CLI, not a package-manager plugin. It reads npm or Yarn registry configuration, obtains credentials through `@microsoft/artifacts-credprovider-wrapper`, and writes credential material back to the relevant npm or Yarn configuration location.
+
+Local lifecycle script testing confirmed npm and pnpm can run arbitrary commands:
+
+```text
+npm preinstall -> arbitrary command
+pnpm:devPreinstall -> arbitrary command before pnpm install
+```
+
+`pnpm:devPreinstall` can refresh credentials before a local `pnpm install`, but only when the credential-provider CLI is already available before pnpm starts. npm `preinstall` is an arbitrary lifecycle script, not a reliable initial-auth bootstrap hook for private registry resolution. npm and Yarn should use an explicit external bootstrap step, a globally or otherwise preinstalled CLI, or CI setup before running `npm install`, `npm ci`, or `yarn install`.
+
+Implication: npm-compatible tooling can use a standard CLI subcommand such as:
+
+```powershell
+company-auth npm
+```
+
+An npm-specific alias is optional for clearer documentation and compatibility with existing scripts, but it is not required by npm, pnpm, or Yarn mechanics.
+
+## Entrypoint Architecture Finding
+
+The research rejects two oversimplified designs:
+
+1. **Four separate products.** This would duplicate credential logic, increase version skew, and fragment cache policy.
+2. **One CLI with only four standard subcommands.** This does not satisfy NuGet and Python discovery contracts and is fragile for production Git integration.
+
+The recommended design is:
+
+```text
+One product
+  -> one shared credential core
+  -> one human-facing CLI
+  -> thin machine-facing adapters only where required
+```
+
+Minimum recommended machine-facing surfaces:
+
+| Surface                        | Reason                                                     |
+| ------------------------------ | ---------------------------------------------------------- |
+| `git-credential-company`       | Stable Git helper discovery.                               |
+| NuGet plugin entry point       | NuGet launches plugin files with fixed `-Plugin` behavior. |
+| Python keyring backend package | Required for twine and pip import mode.                    |
+| `keyring` executable shim      | Required for uv and pip subprocess mode.                   |
+| `company-auth npm`             | Sufficient for npm, pnpm, and Yarn config-file workflows.  |
+
+## Security Findings
+
+1. Protocol adapters must never print human diagnostics to protocol stdout.
+2. Token caches must be partitioned by ecosystem, account, tenant, host/feed identity, token audience, and credential type.
+3. Git shell snippets are convenient but should not be the default production configuration on Windows or GUI Git clients.
+4. NuGet plugin mode must not emit banners, update notices, prompts, or non-protocol JSON to stdout.
+5. Python keyring adapters should be small and should avoid importing a large trusted authentication implementation from arbitrary project virtual environments.
+6. npm config updates must avoid writing raw long-lived secrets into repository-local `.npmrc` files by default.
+7. CI mode should be explicit, non-interactive, ephemeral, and log-safe.
+
+## Monorepo Integration Notes
+
+This repository already has:
+
+- root pnpm workspace configuration,
+- root `nuget.config`,
+- Central Package Management for C#,
+- root uv workspace configuration,
+- GitHub Actions CI.
+
+The current repository does not already contain active Azure Artifacts feed configuration, `pkgs.dev.azure.com` package source settings, `tool.uv.index`, `artifacts-keyring` project configuration, `npmAuthenticate`, `NuGetAuthenticate`, or Azure Pipelines YAML. Azure Artifacts support would be additive.
+
+## Evidence Quality
+
+The findings are based on:
+
+- source inspection of local Microsoft credential provider repositories and extracted packages,
+- official documentation research,
+- local Git credential helper protocol experiments,
+- local NuGet plugin path experiments,
+- local keyring command-shape experiments,
+- local npm and pnpm lifecycle script experiments,
+- independent ecosystem-focused research agents,
+- adversarial architecture, cross-platform, and security reviews.

--- a/src/private/app/azureauth-credprovider/docs/research.md
+++ b/src/private/app/azureauth-credprovider/docs/research.md
@@ -231,12 +231,23 @@ Minimum recommended machine-facing surfaces:
 ## Security Findings
 
 1. Protocol adapters must never print human diagnostics to protocol stdout.
-2. Token caches must be partitioned by ecosystem, account, tenant, host/feed identity, token audience, and credential type.
+2. Token caches must be partitioned by ecosystem, host, organization, project when relevant, service identity, feed identity for package-feed adapters, account, tenant, token audience, and credential type.
 3. Git shell snippets are convenient but should not be the default production configuration on Windows or GUI Git clients.
 4. NuGet plugin mode must not emit banners, update notices, prompts, or non-protocol JSON to stdout.
 5. Python keyring adapters should be small and should avoid importing a large trusted authentication implementation from arbitrary project virtual environments.
 6. npm config updates must avoid writing raw long-lived secrets into repository-local `.npmrc` files by default.
 7. CI mode should be explicit, non-interactive, ephemeral, and log-safe.
+
+## Integration Removal Implications
+
+The same host-tool discovery mechanisms that require explicit configuration also require explicit teardown semantics. Removal should be scoped to configuration and adapter registrations owned by this product, not to all related host-tool state.
+
+Research implications by ecosystem:
+
+- Git removal should remove only this product's credential helper configuration and any `dev.azure.com` path-forwarding setting installed by this product or explicitly selected by the user.
+- NuGet removal should remove this product's plugin installation or explicit plugin-path override without deleting unrelated NuGet package sources or package source credentials.
+- Python removal should remove this product's keyring backend or shim registration from the targeted Python environment without uninstalling unrelated keyring backends.
+- npm removal should remove generated credential entries while preserving registry declarations and unrelated npm or Yarn configuration.
 
 ## Monorepo Integration Notes
 

--- a/src/private/app/azureauth-credprovider/docs/research.md
+++ b/src/private/app/azureauth-credprovider/docs/research.md
@@ -1,4 +1,4 @@
-# AzureAuth Credential Provider Research Notes
+# Unified Azure DevOps Credential Provider Research Notes
 
 Status: **Draft research baseline**
 
@@ -19,7 +19,7 @@ The following implementation references are available under `/workspace/public/`
 | Python keyring                 | `/workspace/public/artifacts-keyring`              | Python keyring backend source for pip and twine Azure Artifacts authentication.                                                                    |
 | npm and pnpm                   | `/workspace/public/artifacts-npm-credprovider`     | Extracted `@microsoft/artifacts-npm-credprovider` package version `1.1.3`.                                                                         |
 | Node wrapper for the provider  | `/workspace/public/artifacts-credprovider-wrapper` | Extracted `@microsoft/artifacts-credprovider-wrapper` package version `1.1.4`; its installer downloaded the Linux x64 Credential Provider payload. |
-| AzureAuth helper               | `/workspace/public/microsoft-authentication-cli`   | Related Microsoft authentication CLI; not the primary implementation for these integrations.                                                       |
+| AzureAuth helper               | `/workspace/public/microsoft-authentication-cli`   | Related Microsoft MSAL-based authentication CLI with Azure DevOps token commands; candidate identity substrate, not a host-tool protocol adapter.  |
 
 `uv` and `MicrosoftDocs/azure-devops-docs` are useful references, but they are not credential-provider implementation source trees for this project.
 
@@ -56,30 +56,30 @@ Azure Repos supports current `dev.azure.com` HTTPS clone URLs and legacy `*.visu
 Git credential helper discovery is sensitive to command form. Local experiments confirmed:
 
 ```text
-credential.helper=company
-  -> Git invokes git-credential-company get
+credential.helper=<helper-name>
+  -> Git invokes git-credential-<helper-name> get
 
-credential.helper=!company-auth git credential-helper
-  -> Git invokes company-auth git credential-helper get
+credential.helper=!<primary-cli> git credential-helper
+  -> Git invokes <primary-cli> git credential-helper get
 
-credential.helper=/abs/path/company-auth git credential-helper
-  -> Git invokes /abs/path/company-auth git credential-helper get
+credential.helper=/abs/path/<primary-cli> git credential-helper
+  -> Git invokes /abs/path/<primary-cli> git credential-helper get
 
-credential.helper=company-auth git credential-helper
-  -> Git attempts git credential-company-auth ...
-  -> This fails unless a git-credential-company-auth helper exists.
+credential.helper=<primary-cli> git credential-helper
+  -> Git attempts git credential-<primary-cli> ...
+  -> This fails unless a git-credential-<primary-cli> helper exists.
 ```
 
 Implication: a single CLI can implement the logic, but a production installation should provide a Git helper-shaped entry point or configure an absolute helper command carefully. The recommended user configuration is the standard helper shorthand plus explicit `dev.azure.com` path forwarding:
 
 ```powershell
-git config --global credential.helper company
+git config --global credential.helper <helper-name>
 git config --global credential.https://dev.azure.com.useHttpPath true
 ```
 
-with an installed `git-credential-company` executable that delegates to the shared core. The `useHttpPath` setting is required for `dev.azure.com` because the Azure DevOps organization is in the URL path. Legacy `<org>.visualstudio.com` remotes carry the organization in the host name and do not need the same setting.
+with an installed `git-credential-<helper-name>` executable that delegates to the shared core. The `useHttpPath` setting is required for `dev.azure.com` because the Azure DevOps organization is in the URL path. Legacy `<org>.visualstudio.com` remotes carry the organization in the host name and do not need the same setting.
 
-The configure command must either install the helper into a location Git itself can discover or configure a carefully quoted absolute helper path. The doctor command should validate discovery through Git, not only through the current shell, because GUI Git clients may run with a different `PATH`.
+The angle-bracketed values in the previous snippet are substitution placeholders, not literal command text. The configure command must either install the helper into a location Git itself can discover or configure a carefully quoted absolute helper path. The doctor command should validate discovery through Git, not only through the current shell, because GUI Git clients may run with a different `PATH`.
 
 Git identity flows should be treated as separate support levels rather than a single generic authentication mode:
 
@@ -112,7 +112,7 @@ NUGET_PLUGIN_PATHS="/tmp/nuget-plugin-probe nuget"
   -> plugin was not launched
 ```
 
-Implication: NuGet cannot be configured to call `company-auth nuget plugin` through `NUGET_PLUGIN_PATHS`. The product needs one of these shapes:
+Implication: NuGet cannot be configured to call a normal `<primary-cli> nuget plugin` subcommand through `NUGET_PLUGIN_PATHS`. The product needs one of these shapes:
 
 1. A top-level executable that itself handles NuGet's `-Plugin` invocation.
 2. A NuGet plugin-shaped executable or DLL that delegates to the shared core.
@@ -155,7 +155,7 @@ keyring get <service> --mode creds  # stdout is newline-separated username and p
 
 pip and uv both have subprocess keyring modes, but their discovery semantics differ. uv invokes `keyring` from `PATH` directly. pip subprocess mode calls `keyring get <service> <username>` and requires a username in the index URL. pip also avoids the current Python environment's scripts directory when selecting a subprocess `keyring` executable, so a shim installed only into a project virtual environment may be ignored by pip subprocess mode.
 
-Implication: `company-auth python keyring` is not directly discoverable by all Python tools. A robust product needs:
+Implication: a normal `<primary-cli> python keyring` subcommand is not directly discoverable by all Python tools. A robust product needs:
 
 - a Python keyring backend package for import-mode tools such as twine and pip import mode,
 - a `keyring` executable-compatible shim for uv and subprocess-mode tools,
@@ -194,9 +194,11 @@ pnpm:devPreinstall -> arbitrary command before pnpm install
 
 Implication: npm-compatible tooling can use a standard CLI subcommand such as:
 
-```powershell
-company-auth npm
+```text
+<primary-cli> npm
 ```
+
+`<primary-cli>` is a substitution placeholder for the final executable name, not a literal command.
 
 An npm-specific alias is optional for clearer documentation and compatibility with existing scripts, but it is not required by npm, pnpm, or Yarn mechanics.
 
@@ -220,11 +222,11 @@ Minimum recommended machine-facing surfaces:
 
 | Surface                        | Reason                                                     |
 | ------------------------------ | ---------------------------------------------------------- |
-| `git-credential-company`       | Stable Git helper discovery.                               |
+| `git-credential-<helper-name>` | Stable Git helper discovery.                               |
 | NuGet plugin entry point       | NuGet launches plugin files with fixed `-Plugin` behavior. |
 | Python keyring backend package | Required for twine and pip import mode.                    |
 | `keyring` executable shim      | Required for uv and pip subprocess mode.                   |
-| `company-auth npm`             | Sufficient for npm, pnpm, and Yarn config-file workflows.  |
+| `<primary-cli> npm`            | Sufficient for npm, pnpm, and Yarn config-file workflows.  |
 
 ## Security Findings
 


### PR DESCRIPTION
## Summary

- add AzureAuth Credential Provider requirements under `src/private/app/azureauth-credprovider/docs`
- document Git, NuGet, Python keyring, and npm-compatible Azure DevOps credential-provider research
- capture the high-level architecture decision: one shared credential core with protocol-specific entry points where host tools require them

## Validation

- commit hooks: typos, editorconfig-check, markdownlint-cli2, markdown-prettier, commitlint
- second-pass GPT-5.5 technical reviews for Git, NuGet, Python, npm, and tone/audience fit reported no significant issues
