### PR TITLE
fix(cf-ddns-updater): Address PR 303 Review Feedback

### DIFF
--- a/src/private/app/cf-ddns-updater/CloudflareDomainCanonicalizer.cs
+++ b/src/private/app/cf-ddns-updater/CloudflareDomainCanonicalizer.cs
@@ -1,6 +1,5 @@
 using System.Globalization;
 using System.Net;
-using System.Text;
 
 namespace Hcoona.CfDdnsUpdater;
 

--- a/src/private/app/cf-ddns-updater/ReconciliationApp.cs
+++ b/src/private/app/cf-ddns-updater/ReconciliationApp.cs
@@ -240,7 +240,7 @@ internal sealed partial class ReconciliationApp(
         EventId = 1,
         Level = LogLevel.Information,
         Message =
-            "Cloudflare DDNS updater scaffold started for {DomainCount} domain(s); " +
+            "Cloudflare DDNS updater started for {DomainCount} domain(s); " +
             "IPv6 disabled: {DisableIpv6}.")]
     private static partial void LogStarted(
         ILogger logger,

--- a/src/private/app/cf-ddns-updater/TraceIpDiscoveryService.cs
+++ b/src/private/app/cf-ddns-updater/TraceIpDiscoveryService.cs
@@ -482,6 +482,7 @@ internal sealed class CloudflareTraceRetryHandler : DelegatingHandler
             HttpRequestMessage retryRequest = attempt == 1 ? request : CloneRequest(request);
             HttpResponseMessage? response = null;
             bool returnResponse = false;
+            bool disposeRequest = attempt > 1;
             try
             {
                 response = await base.SendAsync(
@@ -543,6 +544,11 @@ internal sealed class CloudflareTraceRetryHandler : DelegatingHandler
             }
             finally
             {
+                if (disposeRequest)
+                {
+                    retryRequest.Dispose();
+                }
+
                 if (!returnResponse)
                 {
                     response?.Dispose();

--- a/tests/private/app/cf-ddns-updater/ProgramBootstrapTests.cs
+++ b/tests/private/app/cf-ddns-updater/ProgramBootstrapTests.cs
@@ -1,5 +1,4 @@
 using System.Reflection;
-using System.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Xunit;

--- a/tests/private/app/cf-ddns-updater/TraceIpDiscoveryServiceTests.cs
+++ b/tests/private/app/cf-ddns-updater/TraceIpDiscoveryServiceTests.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;


### PR DESCRIPTION
## Summary
- Carry the post-merge cf-ddns-updater review feedback onto a clean origin/main-based branch.
- Remove unused imports, update the startup log wording, and dispose cloned retry requests in the Cloudflare trace retry handler.
- Keep unrelated Hexo .mise.lock churn out of this PR.

## Validation
- dotnet build src/private/app/cf-ddns-updater/CfDdnsUpdater.csproj --configuration Debug --verbosity minimal
- dotnet test tests/private/app/cf-ddns-updater/Hcoona.CfDdnsUpdater.Tests.csproj --configuration Debug --no-restore --verbosity minimal
- dotnet format src/private/app/cf-ddns-updater/CfDdnsUpdater.csproj --verify-no-changes --verbosity minimal
- dotnet format tests/private/app/cf-ddns-updater/Hcoona.CfDdnsUpdater.Tests.csproj --verify-no-changes --verbosity minimal
- Independent adversarial subagent review: No blocking findings.