### PR TITLE
Address Document Translator CLI PR Review Feedback

### DIFF
--- a/src/private/app/document-translator-cli/Program.cs
+++ b/src/private/app/document-translator-cli/Program.cs
@@ -26,15 +26,17 @@ internal static class Program
         try
         {
             IDocumentTranslator translator = new AzureDocumentTranslator();
+            TextWriter standardOutput = Console.Out;
+            TextWriter standardError = Console.Error;
             return RunAsync(
                     args,
-                    Console.Out,
-                    Console.Error,
+                    standardOutput,
+                    standardError,
                     Environment.GetEnvironmentVariable,
                     (options, output, token) => ExecuteValidatedCommandAsync(
                         options,
                         output,
-                        Console.Error,
+                        standardError,
                         translator,
                         token),
                     cancellationTokenSource.Token)

--- a/src/private/app/document-translator-cli/TranslationOptionsValidator.cs
+++ b/src/private/app/document-translator-cli/TranslationOptionsValidator.cs
@@ -149,8 +149,14 @@ internal static partial class TranslationOptionsValidator
 
     private static Uri? ValidateEndpoint(string? endpoint, List<string> errors)
     {
-        endpoint = NormalizeNonSecretScalar(endpoint);
-        if (string.IsNullOrWhiteSpace(endpoint))
+        endpoint = endpoint?.Trim();
+        if (endpoint is not null && endpoint.Length == 0)
+        {
+            errors.Add("The --endpoint option must not be blank.");
+            return null;
+        }
+
+        if (endpoint is null)
         {
             errors.Add(
                 "The --endpoint option or AZURE_TRANSLATOR_ENDPOINT "

--- a/tests/private/app/document-translator-cli/ProgramTests.cs
+++ b/tests/private/app/document-translator-cli/ProgramTests.cs
@@ -336,9 +336,11 @@ public sealed class ProgramTests
         using TestDirectory directory = TestDirectory.Create();
         string inputPath = directory.WriteFile("source.txt", "content");
         string outputPath = directory.GetPath("translated.txt");
+        using StringWriter standardOutput = new();
+        using StringWriter standardError = new();
         bool executed = false;
 
-        int exitCode = await RunAsync(
+        int exitCode = await Program.RunAsync(
             [
                 "translate",
                 "--input",
@@ -352,17 +354,29 @@ public sealed class ProgramTests
                 "--key",
                 "secret",
             ],
+            standardOutput,
+            standardError,
             name => name == TranslationOptionResolver.EndpointEnvironmentVariable
                 ? "https://resource.cognitiveservices.azure.com/translator"
                 : null,
-            _ =>
+            (_, _, _) =>
             {
                 executed = true;
                 return new ValueTask<int>(Program.SuccessExitCode);
-            });
+            },
+            CancellationToken.None);
 
         Assert.Equal(Program.ValidationErrorExitCode, exitCode);
         Assert.False(executed);
+        Assert.Equal(string.Empty, standardOutput.ToString());
+        Assert.Contains(
+            "The --endpoint option must not be blank.",
+            standardError.ToString(),
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            TranslationOptionResolver.EndpointEnvironmentVariable,
+            standardError.ToString(),
+            StringComparison.Ordinal);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- clarify explicitly blank --endpoint validation so it no longer reports the missing endpoint/env-var message
- reuse the captured stderr writer in Main when wiring ExecuteValidatedCommandAsync
- update endpoint validation coverage for the PR review feedback

## Validation
- dotnet build src/private/app/document-translator-cli/DocumentTranslatorCli.csproj --no-restore
- dotnet test tests/private/app/document-translator-cli/Hcoona.DocumentTranslatorCli.Tests.csproj --no-restore

Follow-up to #316 because auto-merge completed after the review threads were resolved but before the local fix commit was pushed.