### PR TITLE
Fix CF DDNS Timer Example

### DIFF
--- a/src/private/app/cf-ddns-updater/docs/systemd/cf-ddns-updater.timer.example
+++ b/src/private/app/cf-ddns-updater/docs/systemd/cf-ddns-updater.timer.example
@@ -2,7 +2,7 @@
 Description=Run Cloudflare DDNS updater periodically
 
 [Timer]
-OnBootSec=5m
+OnActiveSec=5m
 OnUnitActiveSec=1h
 Persistent=true
 Unit=cf-ddns-updater.service


### PR DESCRIPTION
## Summary\n- Replace OnBootSec with OnActiveSec in the CF DDNS updater systemd timer example.\n- Ensure newly enabled or restarted timers schedule a first future run instead of remaining elapsed after the boot trigger has passed.\n\n## Validation\n- Confirmed the local user timer reran at 23:53 and scheduled the next run for 00:53.\n- Ran systemd-analyze --user verify against a copied timer unit with the corrected setting.\n- Commit hooks passed.