### PR TITLE
Fix CodeQL PR Trigger for Docs-Only Changes

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,9 +13,6 @@ on:
   pull_request:
     branches:
       - main
-    paths-ignore:
-      - '**/*.md'
-      - '**/*.txt'
   merge_group:
     branches:
       - main


### PR DESCRIPTION
## Summary
- allow CodeQL pull_request runs for docs-only changes
- preserve the existing C# empty SARIF placeholder path when no C# files changed

## Validation
- actionlint .github/workflows/codeql.yml