### PR TITLE
fix(renovate): Sync Generated Global.json Sources for MSBuild Tooling

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -425,7 +425,14 @@
       "matchFileNames": ["src/public/lib/Directory.Packages.props"],
       "matchPackageNames": ["System.Memory", "System.Runtime.CompilerServices.Unsafe"],
       "rangeStrategy": "bump",
-      "groupName": "MSBuild and Repository Build Tooling"
+      "groupName": "MSBuild and Repository Build Tooling",
+      "postUpgradeTasks": {
+        "commands": [
+          "pwsh -NoLogo -NoProfile -NonInteractive -File eng/scripts/Update-RenovateGlobalJsonArtifacts.ps1"
+        ],
+        "fileFilters": ["mise.lock", "global.pkl", "global.json", "**/packages.lock.json"],
+        "executionMode": "branch"
+      }
     },
     {
       "description": "Group MSBuild and repository build tooling.",

--- a/renovate.json
+++ b/renovate.json
@@ -438,7 +438,14 @@
         "Nerdbank.GitVersioning",
         "System.IO.Hashing"
       ],
-      "groupName": "MSBuild and Repository Build Tooling"
+      "groupName": "MSBuild and Repository Build Tooling",
+      "postUpgradeTasks": {
+        "commands": [
+          "pwsh -NoLogo -NoProfile -NonInteractive -File eng/scripts/Update-RenovateGlobalJsonArtifacts.ps1"
+        ],
+        "fileFilters": ["mise.lock", "global.pkl", "global.json", "**/packages.lock.json"],
+        "executionMode": "branch"
+      }
     },
     {
       "description": "Update Nerdbank.GitVersioning packages and tools together.",


### PR DESCRIPTION
## Summary
- run the global.json artifact sync task for the grouped MSBuild tooling Renovate rule
- ensure grouped updates like #354 commit global.pkl alongside generated global.json

## Validation
- hk check --no-progress --no-fail-fast --from-ref origin/main --to-ref HEAD
- independent GPT-5.5 code review: no blocking issues