### PR TITLE
Fix WinUI NativeAOT publish configuration

### DIFF
--- a/src/public/app/ImageOcclusionEditor/ImageOcclusionEditorWinUI3/ImageOcclusionEditorWinUI3.csproj
+++ b/src/public/app/ImageOcclusionEditor/ImageOcclusionEditorWinUI3/ImageOcclusionEditorWinUI3.csproj
@@ -16,6 +16,7 @@
     <Nullable>enable</Nullable>
 
     <PublishAot>true</PublishAot>
+    <PublishSingleFile>true</PublishSingleFile>
     <ControlFlowGuard>Guard</ControlFlowGuard>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
@@ -37,7 +38,10 @@
     <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
     <WindowsPackageType>None</WindowsPackageType>
     <EnableMsixTooling>true</EnableMsixTooling>
+    <IncludeAllContentForSelfExtract>true</IncludeAllContentForSelfExtract>
     <SelfContained>true</SelfContained>
+    <!-- Svg.Model 5.1.1 emits an upstream IL2104 trim warning during NativeAOT publish; keep it visible but non-fatal. -->
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);IL2104</WarningsNotAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
@@ -55,6 +59,7 @@
   <ItemGroup>
     <None Include="svg-edit\**">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </None>
   </ItemGroup>
 </Project>

--- a/src/public/app/ImageOcclusionEditor/ImageOcclusionEditorWinUI3/MainWindow.xaml
+++ b/src/public/app/ImageOcclusionEditor/ImageOcclusionEditorWinUI3/MainWindow.xaml
@@ -41,6 +41,7 @@
     <!-- Using explicit Source to test if WebView2 works -->
     <WebView2 x:Name="webView"
       Grid.Row="0"
+      AutomationProperties.AutomationId="SvgEditorWebView"
       DefaultBackgroundColor="White" />
 
     <!-- Bottom Panel for Buttons -->
@@ -57,6 +58,7 @@
 
           <!-- Cancel Button -->
           <Button Content="Cancel (ESC)"
+            AutomationProperties.AutomationId="CancelButton"
             MinWidth="160"
             MinHeight="36"
             Padding="16,8"
@@ -69,6 +71,7 @@
 
           <!-- Save Button -->
           <Button Content="Save (Ctrl+Shift+S)"
+            AutomationProperties.AutomationId="SaveButton"
             MinWidth="160"
             MinHeight="36"
             Padding="16,8"
@@ -82,6 +85,7 @@
 
           <!-- Save & Exit Button -->
           <Button Content="Save &amp; Exit (Ctrl+S)"
+            AutomationProperties.AutomationId="SaveExitButton"
             MinWidth="160"
             MinHeight="36"
             Padding="16,8"

--- a/src/public/app/ImageOcclusionEditor/script/Setup.iss
+++ b/src/public/app/ImageOcclusionEditor/script/Setup.iss
@@ -1,7 +1,7 @@
 #define MyAppName "Image Occlusion Editor"
 ; PublishDir can be injected from the build script or csproj via /DPublishDir="..."
 #ifndef PublishDir
-#define PublishDir "..\ImageOcclusionEditorWinUI3\bin\x64\Release\net9.0-windows10.0.22000.0\win-x64\publish"
+#define PublishDir "..\ImageOcclusionEditorWinUI3\bin\x64\Release\net10.0-windows10.0.22000.0\win-x64\publish"
 #endif
 ; Use PublishDir directly; caller must pass a clean path without trailing backslash
 #define MyAppExePath PublishDir + "\ImageOcclusionEditor.exe"


### PR DESCRIPTION
## Summary
- Configure the WinUI app for unpackaged, self-contained, NativeAOT publish settings aligned with Microsoft Learn single-file requirements.
- Copy generated svg-edit assets to publish output when present.
- Add stable UIA AutomationIds for the WebView and bottom action buttons.

## Validation
- `mise exec -- dotnet publish ... -c Release -r win-x64 /p:RestoreLockedMode=true` succeeded.
- Published output has no MSIX and no managed `ImageOcclusionEditor.dll`; NativeAOT keeps the Windows App SDK/native payload as loose files.
- UIA/visual smoke validation passed with copied PNG inputs, including save updating only the copied occlusion file.