### PR TITLE
fix(build): Avoid Duplicate MSTest SDK Package Versions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -28,8 +28,9 @@
     <PackageVersion Include="Microsoft.SemanticKernel" Version="1.78.0" />
     <PackageVersion Include="Microsoft.SemanticKernel.Connectors.AzureOpenAI" Version="1.78.0" />
     <PackageVersion Include="Microsoft.SemanticKernel.Connectors.OpenAI" Version="1.78.0" />
-    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.9.0" />
-    <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="2.3.0" />
+    <!-- MSTest.Sdk owns these versions for SDK-style MSTest projects. -->
+    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.9.0" Condition="'$(UsingMSTestSdk)' != 'true'" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="2.3.0" Condition="'$(UsingMSTestSdk)' != 'true'" />
     <PackageVersion Include="Microsoft.Web.WebView2" Version="1.0.4078.44" />
     <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.2270" />
     <PackageVersion Include="Microsoft.WindowsAppSDK" Version="2.2.0" />


### PR DESCRIPTION
## Summary

- Let `MSTest.Sdk` own the implicit CodeCoverage and TRX report package versions in SDK-style MSTest projects.
- Retain repository central versions for non-MSTest test projects that reference those extensions explicitly.
- Prevent the duplicate `PackageVersion` items introduced by MSTest.Sdk 4.3.x under Central Package Management.

## Responsibility and Trust Boundary

The repository owns versions for explicit non-MSTest consumers. MSTest.Sdk owns its implicit extension references for projects using the standard `<Project Sdk="MSTest.Sdk">` form. The current MSTest projects do not use manual SDK layering or explicit references to these two extensions.

## Acceptance

- Windows-host locked restore, Debug build, and the CI-equivalent test loop completed successfully on the current MSTest.Sdk 4.2.3 baseline.
- Evaluated MSBuild items confirm MSTest projects use SDK-provided versions while the xUnit MTP project retains `Directory.Packages.props` ownership.
- `hk check --pr` completed successfully.
- Independent precommit and immutable-commit reviews reported no findings.

## Follow-Up

This is a prerequisite for replacing #404 with a human-owned MSTest 4.3 upgrade PR.