### PR TITLE
Restore Renovate Windows Child PATH Resolution

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -42,7 +42,7 @@ jobs:
     permissions:
       contents: read
     env:
-      RENOVATE_VERSION: 43.150.0
+      RENOVATE_VERSION: 43.200.1
       GIT_LFS_SKIP_SMUDGE: 1
     defaults:
       run:


### PR DESCRIPTION
## Summary

- upgrade the self-hosted Renovate runtime from 43.150.0 to 43.200.1
- restore `PATHEXT` propagation into Renovate's sanitized Windows child environment
- allow post-upgrade tasks to resolve `pkl` through the existing mise shim

## Responsibility and Trust Boundary

This PR owns only the Renovate runtime defect that prevented artifact generation for #404. It does not change repository package ownership, dependency versions, generated artifacts, command allowlists, or workflow permissions. The existing global configuration remains restricted to `hcoona/three`.

## Acceptance Evidence

- Renovate 43.150.0 reproduced `Required command 'pkl' was not found on PATH.` through its own Windows execution layer.
- Renovate 43.200.1 ran the same PowerShell post-upgrade command successfully, including the exact .NET SDK installation and locked restore.
- `renovate-config-validator` accepted the repository configuration.
- Local Renovate extraction completed successfully.
- `HK_FIX=0 hk check --pr` passed.

The selected pin is the first available published release containing the upstream Windows child-environment fix, minimizing unrelated Renovate behavior changes.

Related to #404.
