### PR TITLE
Migrate the Hexo AsciiDoc Renderer to Asciidoctor 4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,6 +180,7 @@ jobs:
 
     env:
       NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages
+      PACKAGE_DIR: src/public/lib/hexo-renderer-asciidoc
 
     steps:
       - name: Checkout
@@ -210,11 +211,24 @@ jobs:
           pnpm install --frozen-lockfile
           dotnet tool restore
 
-      - name: Run tests
+      - name: Record actual tool versions
+        run: |
+          set -Eeuo pipefail
+          echo "node=$(node --version)"
+          echo "pnpm=$(pnpm --version)"
+          echo "npm=$(npm --version)"
+
+      - name: Type check package
+        run: pnpm --dir "${PACKAGE_DIR}" run typecheck
+
+      - name: Run monorepo tests
         run: pnpm run test
 
-      - name: Build
+      - name: Build monorepo
         run: pnpm run build
+
+      - name: Pack and probe published artifact
+        run: pnpm --dir "${PACKAGE_DIR}" run validate:packed-artifact
 
   python-tests:
     name: Test (Python 3.14)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,9 +71,9 @@ importers:
 
   src/public/lib/hexo-renderer-asciidoc:
     dependencies:
-      asciidoctor:
-        specifier: 3.0.4
-        version: 3.0.4(chokidar@3.6.0)
+      '@asciidoctor/core':
+        specifier: 4.0.4
+        version: 4.0.4
       cheerio:
         specifier: ^1.2.0
         version: 1.2.0
@@ -157,20 +157,9 @@ packages:
       rollup:
         optional: true
 
-  '@asciidoctor/cli@4.0.0':
-    resolution: {integrity: sha512-x2T9gW42921Zd90juEagtbViPZHNP2MWf0+6rJEkOzW7E9m3TGJtz+Guye9J0gwrpZsTMGCpfYMQy1We3X7osg==}
-    engines: {node: '>=16', npm: '>=8.0.0'}
-    hasBin: true
-    peerDependencies:
-      '@asciidoctor/core': '>=2 <4'
-
-  '@asciidoctor/core@3.0.4':
-    resolution: {integrity: sha512-41SDMi7iRRBViPe0L6VWFTe55bv6HEOJeRqMj5+E5wB1YPdUPuTucL4UAESPZM6OWmn4t/5qM5LusXomFUVwVQ==}
-    engines: {node: '>=16', npm: '>=8'}
-
-  '@asciidoctor/opal-runtime@3.0.1':
-    resolution: {integrity: sha512-iW7ACahOG0zZft4A/4CqDcc7JX+fWRNjV5tFAVkNCzwZD+EnFolPaUOPYt8jzadc0+Bgd80cQTtRMQnaaV1kkg==}
-    engines: {node: '>=16'}
+  '@asciidoctor/core@4.0.4':
+    resolution: {integrity: sha512-U9oBUBxsUXKMAqaVgzKTw/SaZh9YoCNmpUon3WxSZzdNBq/q8WzxbeuJKqhHVUk3ztKu2jK7EpLB5XOwlrYgJA==}
+    engines: {node: '>=20'}
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -1248,11 +1237,6 @@ packages:
     resolution: {integrity: sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
-  acorn@7.4.1:
-    resolution: {integrity: sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
-
   acorn@8.17.0:
     resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
     engines: {node: '>=0.4.0'}
@@ -1317,14 +1301,6 @@ packages:
   asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
 
-  asciidoctor@3.0.4:
-    resolution: {integrity: sha512-hIc0Bx73wePxtic+vWBHOIgMfKSNiCmRz7BBfkyykXATrw20YGd5a3CozCHvqEPH+Wxp5qKD4aBsgtokez8nEA==}
-    engines: {node: '>=16', npm: '>=8'}
-    hasBin: true
-
-  assert-never@1.4.0:
-    resolution: {integrity: sha512-5oJg84os6NMQNl27T9LnZkvvqzvAnHu03ShCnoj6bsJwS7L8AO4lf+C/XjK/nvzEqQB744moC6V128RucQd1jA==}
-
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -1344,10 +1320,6 @@ packages:
 
   atomically@2.1.1:
     resolution: {integrity: sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ==}
-
-  babel-walk@3.0.0-canary-5:
-    resolution: {integrity: sha512-GAwkz0AihzY5bkwIY5QDR+LvsRQgB/B+1foMPvi0FZPMl5fjD7ICiznUiBdLYMH1QYe6vqu4gWYytZOccLouFw==}
-    engines: {node: '>= 10.0.0'}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -1372,9 +1344,6 @@ packages:
 
   brace-expansion@1.1.16:
     resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
-
-  brace-expansion@2.1.2:
-    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -1406,14 +1375,6 @@ packages:
     resolution: {integrity: sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==}
     engines: {node: '>=20.19.0'}
 
-  call-bind-apply-helpers@1.0.2:
-    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
-    engines: {node: '>= 0.4'}
-
-  call-bound@1.0.4:
-    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
-    engines: {node: '>= 0.4'}
-
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
@@ -1438,9 +1399,6 @@ packages:
 
   character-entities@2.0.2:
     resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
-
-  character-parser@2.2.0:
-    resolution: {integrity: sha512-+UqJQjFEFaTAs3bNsF2j2kEN1baG/zghZbdqoYEDxGZtJo9LBzl1A+m0D4n3qKx8N2FNv8/Xp6yV9mQmBuptaw==}
 
   character-reference-invalid@2.0.1:
     resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
@@ -1487,9 +1445,6 @@ packages:
   cli-truncate@5.2.0:
     resolution: {integrity: sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==}
     engines: {node: '>=20'}
-
-  cliui@7.0.4:
-    resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
 
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
@@ -1548,9 +1503,6 @@ packages:
   consola@3.4.2:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
-
-  constantinople@4.0.1:
-    resolution: {integrity: sha512-vCrqcSIq4//Gx74TXXCGnHpulY1dskqLTFGDmhrGxzeXL8lF8kvXv6mpNWlJj1uD4DW23D4ljAqbY4RRaaUZIw==}
 
   conventional-changelog-angular@9.2.1:
     resolution: {integrity: sha512-oWSL6ZhnXbYraOFTK3PgRAQJ8fADDAEv5K6AdeyQPLvjFmhG8+ejL0jZZp/R7vTmGJaBvZEE+sE7dB4bCv7sAw==}
@@ -1675,9 +1627,6 @@ packages:
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
-  doctypes@1.1.0:
-    resolution: {integrity: sha512-LLBi6pEqS6Do3EKQ3J0NqHWV5hhb78Pi8vvESYwyOy2c31ZEZVdtitdzsQsKb7878PEERhzUk0ftqGhG6Mz+pQ==}
-
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
 
@@ -1732,17 +1681,8 @@ packages:
       oxc-resolver:
         optional: true
 
-  dunder-proto@1.0.1:
-    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
-    engines: {node: '>= 0.4'}
-
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
-
-  ejs@3.1.10:
-    resolution: {integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==}
-    engines: {node: '>=0.10.0'}
-    hasBin: true
 
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
@@ -1784,20 +1724,12 @@ packages:
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
 
-  es-define-property@1.0.1:
-    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
-    engines: {node: '>= 0.4'}
-
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
   es-module-lexer@2.3.1:
     resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
-
-  es-object-atoms@1.1.2:
-    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
-    engines: {node: '>= 0.4'}
 
   es-toolkit@1.49.0:
     resolution: {integrity: sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g==}
@@ -1879,9 +1811,6 @@ packages:
       picomatch:
         optional: true
 
-  filelist@1.0.6:
-    resolution: {integrity: sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==}
-
   filesize@11.0.22:
     resolution: {integrity: sha512-RlCVs9CY+oSsRnNZn95J9vDXjNjOwddKyTFjOYtA4yxYVIxBnwiVVGJX+TFhsmu3uUf81JDGyijtYL9xgawlTw==}
     engines: {node: '>= 10.8.0'}
@@ -1907,9 +1836,6 @@ packages:
     resolution: {integrity: sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA==}
     engines: {node: '>=14.14'}
 
-  fs.realpath@1.0.0:
-    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
-
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1930,16 +1856,8 @@ packages:
     resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
     engines: {node: '>=18'}
 
-  get-intrinsic@1.3.0:
-    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
-    engines: {node: '>= 0.4'}
-
   get-port-please@3.2.0:
     resolution: {integrity: sha512-I9QVvBw5U/hw3RmWpYKRumUeaDgxTPd401x364rLmWBJcOQ753eov1eTgzDqRG9bqFIfDc7gfzcQEWrUri3o1A==}
-
-  get-proto@1.0.1:
-    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
-    engines: {node: '>= 0.4'}
 
   get-tsconfig@5.0.0-beta.5:
     resolution: {integrity: sha512-/6gFNr0N04nob252sTQxyFLi3eKFRqIg1I87YcqAMT1i6SQrSF6KujUEQrtrjMV0H/eejTCltLdDSTEMzHbnsQ==}
@@ -1956,11 +1874,6 @@ packages:
   glob-to-regexp@0.4.1:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
 
-  glob@8.1.0:
-    resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
-    engines: {node: '>=12'}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
-
   global-directory@4.0.1:
     resolution: {integrity: sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==}
     engines: {node: '>=18'}
@@ -1972,10 +1885,6 @@ packages:
   globby@16.2.0:
     resolution: {integrity: sha512-QrJia2qDf5BB/V6HYlDTs0I0lBahyjLzpGQg3KT7FnCdTonAyPy2RtY802m2k4ALx6Dp752f82WsOczEVr3l6Q==}
     engines: {node: '>=20'}
-
-  gopd@1.2.0:
-    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
-    engines: {node: '>= 0.4'}
 
   graceful-fs@4.2.10:
     resolution: {integrity: sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==}
@@ -1989,22 +1898,9 @@ packages:
   growly@1.3.0:
     resolution: {integrity: sha512-+xGQY0YyAWCnqy7Cd++hc2JqMYzlm0dG30Jd0beaA64sROr8C4nt8Yc9V5Ro3avlSUDTN0ulqP/VBKi1/lLygw==}
 
-  handlebars@4.7.9:
-    resolution: {integrity: sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==}
-    engines: {node: '>=0.4.7'}
-    hasBin: true
-
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
-
-  has-symbols@1.1.0:
-    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
-    engines: {node: '>= 0.4'}
-
-  has-tostringtag@1.0.2:
-    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
-    engines: {node: '>= 0.4'}
 
   hasown@2.0.4:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
@@ -2089,10 +1985,6 @@ packages:
     resolution: {integrity: sha512-NkJQA7oZ4YHQhd2+H3BoRFKF3d/XNsiKpHZCQEMH9pDX27hQQLsTyOocyRgaIVtf8gHX3Nt3LPkR4e5EdtPAGQ==}
     engines: {node: ^22.18.0 || >=24.0.0}
 
-  inflight@1.0.6:
-    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
-    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
-
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
@@ -2144,9 +2036,6 @@ packages:
     resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     hasBin: true
-
-  is-expression@4.0.0:
-    resolution: {integrity: sha512-zMIXX63sxzG3XrkHkrAPvm/OVZVSCPNkwMHU8oTX7/U3AL78I0QXCEICXUM13BIa8TYGZ68PiTKfQz3yaTNr4A==}
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -2216,13 +2105,6 @@ packages:
     resolution: {integrity: sha512-GljRxhWvlCNRfZyORiH77FwdFwGcMO620o37EOYC0ORWdq+WYNVqW0w2Juzew4M+L81l6/QS3t5gkkihyRqv9w==}
     engines: {node: '>=0.10.0'}
 
-  is-promise@2.2.2:
-    resolution: {integrity: sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==}
-
-  is-regex@1.2.1:
-    resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
-    engines: {node: '>= 0.4'}
-
   is-relative@0.1.3:
     resolution: {integrity: sha512-wBOr+rNM4gkAZqoLRJI4myw5WzzIdQosFAAbnvfXP5z1LyzgAI3ivOKehC5KfqlQJZoihVhirgtCBj378Eg8GA==}
     engines: {node: '>=0.10.0'}
@@ -2260,11 +2142,6 @@ packages:
     resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
     engines: {node: '>=8'}
 
-  jake@10.9.4:
-    resolution: {integrity: sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==}
-    engines: {node: '>=10'}
-    hasBin: true
-
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
@@ -2272,9 +2149,6 @@ packages:
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
-
-  js-stringify@1.0.2:
-    resolution: {integrity: sha512-rtS5ATOo2Q5k1G+DADISilDA6lv79zIiwFd6CcjuIxGKLFm5C+RLImRscVap9k55i+MOZwgliw+NejvkLuGD5g==}
 
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
@@ -2330,9 +2204,6 @@ packages:
   jsonwebtoken@9.0.3:
     resolution: {integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==}
     engines: {node: '>=12', npm: '>=6'}
-
-  jstransformer@1.0.0:
-    resolution: {integrity: sha512-C9YK3Rf8q6VAPDCCU9fnqo3mAfOH6vUGnMcP4AQAYIEpWtfGLpwOTmZ+igtdK5y+VvI2n3CyYSzy4Qh34eq24A==}
 
   jszip@3.10.1:
     resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
@@ -2535,10 +2406,6 @@ packages:
   marky@1.3.0:
     resolution: {integrity: sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==}
 
-  math-intrinsics@1.1.0:
-    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
-    engines: {node: '>= 0.4'}
-
   mdurl@2.0.0:
     resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
 
@@ -2639,10 +2506,6 @@ packages:
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
-  minimatch@5.1.9:
-    resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
-    engines: {node: '>=10'}
-
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
@@ -2677,9 +2540,6 @@ packages:
 
   nanospinner@1.2.2:
     resolution: {integrity: sha512-Zt/AmG6qRU3e+WnzGGLuMCEAO/dAu45stNbHY223tUxldaDAeE+FxSPsd9Q+j+paejmm0ZbrNVs5Sraqy3dRxA==}
-
-  neo-async@2.6.2:
-    resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
   nerdbank-gitversioning@3.10.91:
     resolution: {integrity: sha512-uECx6ljRpnU7vWMJmhKnyl8Zn0LAtA6TLZETLmsZ8QQiBAKiGcxZayzmoRkutOzMnQCDf/pr08Bpy0kFBQ3a9g==}
@@ -2724,10 +2584,6 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  object-assign@4.1.1:
-    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
-    engines: {node: '>=0.10.0'}
-
   obug@2.1.3:
     resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
     engines: {node: '>=12.20.0'}
@@ -2741,9 +2597,6 @@ packages:
   on-exit-leak-free@2.1.2:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
     engines: {node: '>=14.0.0'}
-
-  once@1.4.0:
-    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   onetime@7.0.0:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
@@ -2866,9 +2719,6 @@ packages:
     resolution: {integrity: sha512-NV8aTmpwrZv+Iys54sSFOBx3tuVaOBvvrft5PNppnxy9xpU/akHbaWIril22AB22zaPgrgwKdD0KsrM0ptUtpg==}
     engines: {node: '>=6'}
 
-  promise@7.3.1:
-    resolution: {integrity: sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==}
-
   prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
@@ -2880,42 +2730,6 @@ packages:
     resolution: {integrity: sha512-EePAn3VIHJS/jqCuvs1NgPgoecCT8+RsES76hbgYe2Ze1dyvB0tX60C1PCrV8Z8fv56mW3E59s9Gd/GwWiw7dw==}
     engines: {node: '>=18.0.0'}
     hasBin: true
-
-  pug-attrs@3.0.0:
-    resolution: {integrity: sha512-azINV9dUtzPMFQktvTXciNAfAuVh/L/JCl0vtPCwvOA21uZrC08K/UnmrL+SXGEVc1FwzjW62+xw5S/uaLj6cA==}
-
-  pug-code-gen@3.0.4:
-    resolution: {integrity: sha512-6okWYIKdasTyXICyEtvobmTZAVX57JkzgzIi4iRJlin8kmhG+Xry2dsus+Mun/nGCn6F2U49haHI5mkELXB14g==}
-
-  pug-error@2.1.0:
-    resolution: {integrity: sha512-lv7sU9e5Jk8IeUheHata6/UThZ7RK2jnaaNztxfPYUY+VxZyk/ePVaNZ/vwmH8WqGvDz3LrNYt/+gA55NDg6Pg==}
-
-  pug-filters@4.0.0:
-    resolution: {integrity: sha512-yeNFtq5Yxmfz0f9z2rMXGw/8/4i1cCFecw/Q7+D0V2DdtII5UvqE12VaZ2AY7ri6o5RNXiweGH79OCq+2RQU4A==}
-
-  pug-lexer@5.0.1:
-    resolution: {integrity: sha512-0I6C62+keXlZPZkOJeVam9aBLVP2EnbeDw3An+k0/QlqdwH6rv8284nko14Na7c0TtqtogfWXcRoFE4O4Ff20w==}
-
-  pug-linker@4.0.0:
-    resolution: {integrity: sha512-gjD1yzp0yxbQqnzBAdlhbgoJL5qIFJw78juN1NpTLt/mfPJ5VgC4BvkoD3G23qKzJtIIXBbcCt6FioLSFLOHdw==}
-
-  pug-load@3.0.0:
-    resolution: {integrity: sha512-OCjTEnhLWZBvS4zni/WUMjH2YSUosnsmjGBB1An7CsKQarYSWQ0GCVyd4eQPMFJqZ8w9xgs01QdiZXKVjk92EQ==}
-
-  pug-parser@6.0.0:
-    resolution: {integrity: sha512-ukiYM/9cH6Cml+AOl5kETtM9NR3WulyVP2y4HOU45DyMim1IeP/OOiyEWRr6qk5I5klpsBnbuHpwKmTx6WURnw==}
-
-  pug-runtime@3.0.1:
-    resolution: {integrity: sha512-L50zbvrQ35TkpHwv0G6aLSuueDRwc/97XdY8kL3tOT0FmhgG7UypU3VztfV/LATAvmUfYi4wNxSajhSAeNN+Kg==}
-
-  pug-strip-comments@2.0.0:
-    resolution: {integrity: sha512-zo8DsDpH7eTkPHCXFeAk1xZXJbyoTfdPlNR0bK7rpOMuhBYb0f5qUVCO1xlsitYd3w5FQTK7zpNVKb3rZoUrrQ==}
-
-  pug-walk@2.0.0:
-    resolution: {integrity: sha512-yYELe9Q5q9IQhuvqsZNwA5hfPkMJ8u92bQLIMcsMxf/VADjNtEYptU+inlufAFYcWdHlwNfZOEnOOQrZrcyJCQ==}
-
-  pug@3.0.4:
-    resolution: {integrity: sha512-kFfq5mMzrS7+wrl5pLJzZEzemx34OQ0w4SARfhy/3yxTlhbstsudDwJzhf1hP02yHzbjoVMSXUj/Sz6RNfMyXg==}
 
   punycode.js@2.3.1:
     resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
@@ -3257,9 +3071,6 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
-  token-stream@1.0.0:
-    resolution: {integrity: sha512-VSsyNPPW74RpHwR8Fc21uubwHY7wMDeJLys2IX5zJNih+OnAnaifKHo+1LHT7DAdloQ7apeaaWg8l7qnf/TnEg==}
-
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
@@ -3322,11 +3133,6 @@ packages:
 
   ufo@1.6.4:
     resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
-
-  uglify-js@3.19.3:
-    resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
-    engines: {node: '>=0.8.0'}
-    hasBin: true
 
   uhyphen@0.2.0:
     resolution: {integrity: sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA==}
@@ -3407,10 +3213,6 @@ packages:
     peerDependenciesMeta:
       synckit:
         optional: true
-
-  unxhr@1.2.0:
-    resolution: {integrity: sha512-6cGpm8NFXPD9QbSNx0cD2giy7teZ6xOkCUH3U89WKVkL9N9rBrWjlCwhR94Re18ZlAop4MOc3WU1M3Hv/bgpIw==}
-    engines: {node: '>=8.11'}
 
   update-notifier@7.3.1:
     resolution: {integrity: sha512-+dwUY4L35XFYEzE+OAL3sarJdUioVovq+8f7lcIJ7wnmnYQV5UD1Y/lcwaMSyaQ6Bj3JMj1XSTjZbNLHn/19yA==}
@@ -3513,10 +3315,6 @@ packages:
       jsdom:
         optional: true
 
-  void-elements@3.1.0:
-    resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
-    engines: {node: '>=0.10.0'}
-
   warehouse@6.0.0:
     resolution: {integrity: sha512-eOlhyPp5HC951QVDgAeculpSxvfum4UZAbqXSzocqbdiziTseFJFYxmhsKqrQ3wrwgtzPGgkVN2rPL31YLQ0SA==}
     engines: {node: '>=18'}
@@ -3568,13 +3366,6 @@ packages:
   winreg@0.0.12:
     resolution: {integrity: sha512-typ/+JRmi7RqP1NanzFULK36vczznSNN8kWVA9vIqXyv8GhghUlwhGp1Xj3Nms1FsPcNnsQrJOR10N58/nQ9hQ==}
 
-  with@7.0.2:
-    resolution: {integrity: sha512-RNGKj82nUPg3g5ygxkQl0R937xLyho1J24ItRCBTr/m1YnZkzJy1hUiHUJrc/VlsDQzsCnInEGSg3bci0Lmd4w==}
-    engines: {node: '>= 10.0.0'}
-
-  wordwrap@1.0.0:
-    resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
-
   wrap-ansi@10.0.0:
     resolution: {integrity: sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==}
     engines: {node: '>=20'}
@@ -3586,9 +3377,6 @@ packages:
   wrap-ansi@9.0.2:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
-
-  wrappy@1.0.2:
-    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
   wsl-utils@0.3.1:
     resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
@@ -3628,10 +3416,6 @@ packages:
     resolution: {integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=23}
 
-  yargs@17.3.1:
-    resolution: {integrity: sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==}
-    engines: {node: '>=12'}
-
   yargs@17.7.3:
     resolution: {integrity: sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==}
     engines: {node: '>=12'}
@@ -3669,20 +3453,7 @@ snapshots:
       source-map: 0.7.6
       yargs: 17.7.3
 
-  '@asciidoctor/cli@4.0.0(@asciidoctor/core@3.0.4)':
-    dependencies:
-      '@asciidoctor/core': 3.0.4
-      yargs: 17.3.1
-
-  '@asciidoctor/core@3.0.4':
-    dependencies:
-      '@asciidoctor/opal-runtime': 3.0.1
-      unxhr: 1.2.0
-
-  '@asciidoctor/opal-runtime@3.0.1':
-    dependencies:
-      glob: 8.1.0
-      unxhr: 1.2.0
+  '@asciidoctor/core@4.0.4': {}
 
   '@babel/code-frame@7.29.7':
     dependencies:
@@ -4483,8 +4254,6 @@ snapshots:
 
   abbrev@3.0.1: {}
 
-  acorn@7.4.1: {}
-
   acorn@8.17.0: {}
 
   adm-zip@0.5.18: {}
@@ -4533,19 +4302,6 @@ snapshots:
 
   asap@2.0.6: {}
 
-  asciidoctor@3.0.4(chokidar@3.6.0):
-    dependencies:
-      '@asciidoctor/cli': 4.0.0(@asciidoctor/core@3.0.4)
-      '@asciidoctor/core': 3.0.4
-      ejs: 3.1.10
-      handlebars: 4.7.9
-      nunjucks: 3.2.4(chokidar@3.6.0)
-      pug: 3.0.4
-    transitivePeerDependencies:
-      - chokidar
-
-  assert-never@1.4.0: {}
-
   assertion-error@2.0.1: {}
 
   ast-v8-to-istanbul@1.0.5:
@@ -4566,10 +4322,6 @@ snapshots:
     dependencies:
       stubborn-fs: 2.0.0
       when-exit: 2.1.5
-
-  babel-walk@3.0.0-canary-5:
-    dependencies:
-      '@babel/types': 7.29.7
 
   balanced-match@1.0.2: {}
 
@@ -4596,10 +4348,6 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
-
-  brace-expansion@2.1.2:
-    dependencies:
-      balanced-match: 1.0.2
 
   braces@3.0.3:
     dependencies:
@@ -4634,16 +4382,6 @@ snapshots:
 
   cac@7.0.0: {}
 
-  call-bind-apply-helpers@1.0.2:
-    dependencies:
-      es-errors: 1.3.0
-      function-bind: 1.1.2
-
-  call-bound@1.0.4:
-    dependencies:
-      call-bind-apply-helpers: 1.0.2
-      get-intrinsic: 1.3.0
-
   callsites@3.1.0: {}
 
   camel-case@4.1.2:
@@ -4660,10 +4398,6 @@ snapshots:
   character-entities-legacy@3.0.0: {}
 
   character-entities@2.0.2: {}
-
-  character-parser@2.2.0:
-    dependencies:
-      is-regex: 1.2.1
 
   character-reference-invalid@2.0.1: {}
 
@@ -4734,12 +4468,6 @@ snapshots:
       slice-ansi: 8.0.0
       string-width: 8.2.2
 
-  cliui@7.0.4:
-    dependencies:
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-      wrap-ansi: 7.0.0
-
   cliui@8.0.1:
     dependencies:
       string-width: 4.2.3
@@ -4796,11 +4524,6 @@ snapshots:
       xdg-basedir: 5.1.0
 
   consola@3.4.2: {}
-
-  constantinople@4.0.1:
-    dependencies:
-      '@babel/parser': 7.29.7
-      '@babel/types': 7.29.7
 
   conventional-changelog-angular@9.2.1:
     dependencies:
@@ -4904,8 +4627,6 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
-  doctypes@1.1.0: {}
-
   dom-serializer@2.0.0:
     dependencies:
       domelementtype: 2.3.0
@@ -4956,19 +4677,9 @@ snapshots:
 
   dts-resolver@3.0.0: {}
 
-  dunder-proto@1.0.1:
-    dependencies:
-      call-bind-apply-helpers: 1.0.2
-      es-errors: 1.3.0
-      gopd: 1.2.0
-
   ecdsa-sig-formatter@1.0.11:
     dependencies:
       safe-buffer: 5.2.1
-
-  ejs@3.1.10:
-    dependencies:
-      jake: 10.9.4
 
   emoji-regex@10.6.0: {}
 
@@ -4997,15 +4708,9 @@ snapshots:
     dependencies:
       is-arrayish: 0.2.1
 
-  es-define-property@1.0.1: {}
-
   es-errors@1.3.0: {}
 
   es-module-lexer@2.3.1: {}
-
-  es-object-atoms@1.1.2:
-    dependencies:
-      es-errors: 1.3.0
 
   es-toolkit@1.49.0: {}
 
@@ -5088,10 +4793,6 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.5
 
-  filelist@1.0.6:
-    dependencies:
-      minimatch: 5.1.9
-
   filesize@11.0.22: {}
 
   fill-range@7.1.1:
@@ -5116,8 +4817,6 @@ snapshots:
       jsonfile: 6.2.1
       universalify: 2.0.1
 
-  fs.realpath@1.0.0: {}
-
   fsevents@2.3.3:
     optional: true
 
@@ -5136,25 +4835,7 @@ snapshots:
 
   get-east-asian-width@1.6.0: {}
 
-  get-intrinsic@1.3.0:
-    dependencies:
-      call-bind-apply-helpers: 1.0.2
-      es-define-property: 1.0.1
-      es-errors: 1.3.0
-      es-object-atoms: 1.1.2
-      function-bind: 1.1.2
-      get-proto: 1.0.1
-      gopd: 1.2.0
-      has-symbols: 1.1.0
-      hasown: 2.0.4
-      math-intrinsics: 1.1.0
-
   get-port-please@3.2.0: {}
-
-  get-proto@1.0.1:
-    dependencies:
-      dunder-proto: 1.0.1
-      es-object-atoms: 1.1.2
 
   get-tsconfig@5.0.0-beta.5:
     dependencies:
@@ -5167,14 +4848,6 @@ snapshots:
       is-glob: 4.0.3
 
   glob-to-regexp@0.4.1: {}
-
-  glob@8.1.0:
-    dependencies:
-      fs.realpath: 1.0.0
-      inflight: 1.0.6
-      inherits: 2.0.4
-      minimatch: 5.1.9
-      once: 1.4.0
 
   global-directory@4.0.1:
     dependencies:
@@ -5193,8 +4866,6 @@ snapshots:
       slash: 5.1.0
       unicorn-magic: 0.4.0
 
-  gopd@1.2.0: {}
-
   graceful-fs@4.2.10: {}
 
   graceful-fs@4.2.11: {}
@@ -5203,22 +4874,7 @@ snapshots:
 
   growly@1.3.0: {}
 
-  handlebars@4.7.9:
-    dependencies:
-      minimist: 1.2.8
-      neo-async: 2.6.2
-      source-map: 0.6.1
-      wordwrap: 1.0.0
-    optionalDependencies:
-      uglify-js: 3.19.3
-
   has-flag@4.0.0: {}
-
-  has-symbols@1.1.0: {}
-
-  has-tostringtag@1.0.2:
-    dependencies:
-      has-symbols: 1.1.0
 
   hasown@2.0.4:
     dependencies:
@@ -5350,11 +5006,6 @@ snapshots:
 
   import-without-cache@0.4.0: {}
 
-  inflight@1.0.6:
-    dependencies:
-      once: 1.4.0
-      wrappy: 1.0.2
-
   inherits@2.0.4: {}
 
   ini@1.3.8: {}
@@ -5391,11 +5042,6 @@ snapshots:
   is-docker@2.2.1: {}
 
   is-docker@3.0.0: {}
-
-  is-expression@4.0.0:
-    dependencies:
-      acorn: 7.4.1
-      object-assign: 4.1.1
 
   is-extglob@2.1.1: {}
 
@@ -5442,15 +5088,6 @@ snapshots:
 
   is-primitive@3.0.1: {}
 
-  is-promise@2.2.2: {}
-
-  is-regex@1.2.1:
-    dependencies:
-      call-bound: 1.0.4
-      gopd: 1.2.0
-      has-tostringtag: 1.0.2
-      hasown: 2.0.4
-
   is-relative@0.1.3: {}
 
   is-wsl@2.2.0:
@@ -5482,17 +5119,9 @@ snapshots:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.1
 
-  jake@10.9.4:
-    dependencies:
-      async: 3.2.6
-      filelist: 1.0.6
-      picocolors: 1.1.1
-
   jiti@2.6.1: {}
 
   jiti@2.7.0: {}
-
-  js-stringify@1.0.2: {}
 
   js-tokens@10.0.0: {}
 
@@ -5545,11 +5174,6 @@ snapshots:
       lodash.once: 4.1.1
       ms: 2.1.3
       semver: 7.8.5
-
-  jstransformer@1.0.0:
-    dependencies:
-      is-promise: 2.2.2
-      promise: 7.3.1
 
   jszip@3.10.1:
     dependencies:
@@ -5760,8 +5384,6 @@ snapshots:
 
   marky@1.3.0: {}
 
-  math-intrinsics@1.1.0: {}
-
   mdurl@2.0.0: {}
 
   merge2@1.4.1: {}
@@ -5953,10 +5575,6 @@ snapshots:
     dependencies:
       brace-expansion: 1.1.16
 
-  minimatch@5.1.9:
-    dependencies:
-      brace-expansion: 2.1.2
-
   minimist@1.2.8: {}
 
   mlly@1.8.2:
@@ -5993,8 +5611,6 @@ snapshots:
   nanospinner@1.2.2:
     dependencies:
       picocolors: 1.1.1
-
-  neo-async@2.6.2: {}
 
   nerdbank-gitversioning@3.10.91: {}
 
@@ -6040,8 +5656,6 @@ snapshots:
       pathe: 2.0.3
       tinyexec: 1.2.4
 
-  object-assign@4.1.1: {}
-
   obug@2.1.3: {}
 
   ofetch@1.5.1:
@@ -6053,10 +5667,6 @@ snapshots:
   ohash@2.0.11: {}
 
   on-exit-leak-free@2.1.2: {}
-
-  once@1.4.0:
-    dependencies:
-      wrappy: 1.0.2
 
   onetime@7.0.0:
     dependencies:
@@ -6203,10 +5813,6 @@ snapshots:
     dependencies:
       make-error: 1.3.6
 
-  promise@7.3.1:
-    dependencies:
-      asap: 2.0.6
-
   prompts@2.4.2:
     dependencies:
       kleur: 3.0.3
@@ -6225,73 +5831,6 @@ snapshots:
       listr2: 10.2.2
       ofetch: 1.5.1
       zod: 4.4.3
-
-  pug-attrs@3.0.0:
-    dependencies:
-      constantinople: 4.0.1
-      js-stringify: 1.0.2
-      pug-runtime: 3.0.1
-
-  pug-code-gen@3.0.4:
-    dependencies:
-      constantinople: 4.0.1
-      doctypes: 1.1.0
-      js-stringify: 1.0.2
-      pug-attrs: 3.0.0
-      pug-error: 2.1.0
-      pug-runtime: 3.0.1
-      void-elements: 3.1.0
-      with: 7.0.2
-
-  pug-error@2.1.0: {}
-
-  pug-filters@4.0.0:
-    dependencies:
-      constantinople: 4.0.1
-      jstransformer: 1.0.0
-      pug-error: 2.1.0
-      pug-walk: 2.0.0
-      resolve: 1.22.12
-
-  pug-lexer@5.0.1:
-    dependencies:
-      character-parser: 2.2.0
-      is-expression: 4.0.0
-      pug-error: 2.1.0
-
-  pug-linker@4.0.0:
-    dependencies:
-      pug-error: 2.1.0
-      pug-walk: 2.0.0
-
-  pug-load@3.0.0:
-    dependencies:
-      object-assign: 4.1.1
-      pug-walk: 2.0.0
-
-  pug-parser@6.0.0:
-    dependencies:
-      pug-error: 2.1.0
-      token-stream: 1.0.0
-
-  pug-runtime@3.0.1: {}
-
-  pug-strip-comments@2.0.0:
-    dependencies:
-      pug-error: 2.1.0
-
-  pug-walk@2.0.0: {}
-
-  pug@3.0.4:
-    dependencies:
-      pug-code-gen: 3.0.4
-      pug-filters: 4.0.0
-      pug-lexer: 5.0.1
-      pug-linker: 4.0.0
-      pug-load: 3.0.0
-      pug-parser: 6.0.0
-      pug-runtime: 3.0.1
-      pug-strip-comments: 2.0.0
 
   punycode.js@2.3.1: {}
 
@@ -6630,8 +6169,6 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
-  token-stream@1.0.0: {}
-
   tree-kill@1.2.2: {}
 
   tsdown@0.22.7(@typescript/native-preview@7.0.0-dev.20260707.2)(typescript@7.0.2)(unrun@0.3.1):
@@ -6695,9 +6232,6 @@ snapshots:
 
   ufo@1.6.4: {}
 
-  uglify-js@3.19.3:
-    optional: true
-
   uhyphen@0.2.0: {}
 
   unconfig-core@7.5.0:
@@ -6759,8 +6293,6 @@ snapshots:
   unrun@0.3.1:
     dependencies:
       rolldown: 1.1.5
-
-  unxhr@1.2.0: {}
 
   update-notifier@7.3.1:
     dependencies:
@@ -6841,8 +6373,6 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  void-elements@3.1.0: {}
-
   warehouse@6.0.0:
     dependencies:
       bluebird: 3.7.2
@@ -6916,15 +6446,6 @@ snapshots:
 
   winreg@0.0.12: {}
 
-  with@7.0.2:
-    dependencies:
-      '@babel/parser': 7.29.7
-      '@babel/types': 7.29.7
-      assert-never: 1.4.0
-      babel-walk: 3.0.0-canary-5
-
-  wordwrap@1.0.0: {}
-
   wrap-ansi@10.0.0:
     dependencies:
       ansi-styles: 6.2.3
@@ -6942,8 +6463,6 @@ snapshots:
       ansi-styles: 6.2.3
       string-width: 7.2.0
       strip-ansi: 7.2.0
-
-  wrappy@1.0.2: {}
 
   wsl-utils@0.3.1:
     dependencies:
@@ -7031,16 +6550,6 @@ snapshots:
   yargs-parser@21.1.1: {}
 
   yargs-parser@22.0.0: {}
-
-  yargs@17.3.1:
-    dependencies:
-      cliui: 7.0.4
-      escalade: 3.2.0
-      get-caller-file: 2.0.5
-      require-directory: 2.1.1
-      string-width: 4.2.3
-      y18n: 5.0.8
-      yargs-parser: 21.1.1
 
   yargs@17.7.3:
     dependencies:

--- a/src/public/lib/hexo-renderer-asciidoc/CHANGELOG.md
+++ b/src/public/lib/hexo-renderer-asciidoc/CHANGELOG.md
@@ -15,12 +15,61 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+> [!WARNING]
+> The current `4.0.0-beta` line is a major change from 3.x. Programmatic users
+> must update to the new async contract before adopting it.
+
 ### Added
 
 ### Changed
 
 - Migrate the project repository to the `hcoona/three` monorepo and update
   documentation links accordingly.
+- Begin the `4.0.0-beta` major line by moving the runtime dependency from
+  `asciidoctor` 3.0.4 to exact `@asciidoctor/core` 4.0.4 / Asciidoctor.js 4.0.4.
+- Change the public renderer contract from `string` to `Promise<string>`.
+  Programmatic consumers must `await renderer(...)`.
+- Register Hexo renderers for `.ad`, `.adoc`, and `.asciidoc` asynchronously.
+  `renderSync` is unsupported for AsciiDoc input and may leave content
+  unrendered instead of throwing.
+- Stop setting `source-highlighter=html-pipeline`. Under the public renderer's
+  controlled `safe: server` options, source-defined selection is ignored and
+  Asciidoctor's default output is used. The internal highlighter recognizes the
+  supported marker shapes for compatibility, but the API does not expose
+  arbitrary highlighter configuration.
+- Restrict static highlighting to the direct Asciidoctor
+  `div.listingblock > div.content > pre > code` structure. Version 3 could also
+  rewrite passthrough or otherwise noncanonical `pre.highlight` blocks; version
+  4 leaves those blocks unchanged.
+- Publish native ESM and CommonJS entrypoints, with matching declarations, while
+  preserving the package-root default and named exports.
+- Clarify the filesystem and trust boundary: conversion omits `base_dir`, so
+  includes resolve from conversion-time `process.cwd()`; `data.path` and the
+  Hexo site root are not used as `base_dir`; `safe: server` still permits local
+  includes; symlinks can cross assumed directory boundaries; and raw HTML
+  remains unsanitized. The renderer requires trusted input and an isolated or
+  sandboxed working directory with no secrets.
+
+### Migration notes
+
+- Continue to require Node.js `>=20.19.0`; this major change does not raise the
+  existing minimum.
+- Update any direct renderer usage to `await renderer(...)`.
+- Use Hexo’s async render paths; do not rely on `renderSync` for AsciiDoc
+  inputs.
+- Do not rely on a document-level `:source-highlighter: html-pipeline` setting:
+  the public renderer ignores it under the controlled `safe: server` options
+  and exposes no highlighter configuration. Public rendering uses
+  Asciidoctor 4's default output.
+- If you relied on version 3 to highlight passthrough or noncanonical
+  `pre.highlight` HTML, migrate it to an AsciiDoc listing/source block that
+  produces the direct `div.listingblock > div.content > pre > code` structure,
+  or highlight and maintain that passthrough HTML yourself. Verify the generated
+  site before upgrading because version 4 will not rewrite those blocks.
+- Review any include-heavy workflow that previously assumed `data.path` or the
+  Hexo site root acted as `base_dir`; relative includes continue to follow the
+  conversion-time current working directory instead. That directory is not a
+  jail, and an HTML sanitizer cannot prevent file-content disclosure.
 
 ### Deprecated
 
@@ -30,13 +79,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Do not render untrusted AsciiDoc. Use only trusted input in an isolated or
+  sandboxed working directory containing no secrets. `safe: server` and output
+  sanitization are not substitutes for that isolation.
+
+## [3.1.0-beta.11.g3f78566] - 2025-12-22
+
+### Maintenance
+
+- Adjust the repository descriptions in `package.json`.
+
+## [3.1.0-beta.10.g19c6f08] - 2025-12-22
+
+### Maintenance
+
+- Rename `ChangeLog.md` to `CHANGELOG.md`.
+
 ## [3.0.0] - 2025-11-17
 
 > [!WARNING]
-> This is a development pre-release built from the `main` branch.
-> Behaviour may still change before a stable 3.0.0 release.
->
-> This build also **drops support for Node.js versions lower than 20.19.0**
+> Version 3.0.0 **drops support for Node.js versions lower than 20.19.0**
 > and changes the project license. Treat it as a breaking change if you rely
 > on older Node.js versions or on the previous ISC license.
 

--- a/src/public/lib/hexo-renderer-asciidoc/README.md
+++ b/src/public/lib/hexo-renderer-asciidoc/README.md
@@ -10,7 +10,7 @@
 [![Node support](https://img.shields.io/node/v/hexo-renderer-asciidoc.svg?logo=node.js)](package.json)
 [![License: LGPL-3.0-or-later](https://img.shields.io/badge/license-LGPL--3.0--or--later-0a76d5.svg)](LICENSE)
 
-Add first-class [AsciiDoc](https://asciidoc.org/) support to Hexo. This repository branch documents the upcoming 4.x beta migration, which uses `@asciidoctor/core` / Asciidoctor.js 4.0.4, returns `Promise<string>`, registers the Hexo renderer asynchronously, re-highlights recognized listing blocks with fixed `hexo-util.highlight` options, and encodes literal braces before returning the resulting HTML to Hexo.
+Add first-class [AsciiDoc](https://asciidoc.org/) support to Hexo. This repository branch documents the 4.x migration, which uses `@asciidoctor/core` / Asciidoctor.js 4.0.4, returns `Promise<string>`, registers the Hexo renderer asynchronously, re-highlights recognized listing blocks with fixed `hexo-util.highlight` options, and encodes literal braces before returning the resulting HTML to Hexo.
 
 ## Rendering contract
 
@@ -32,21 +32,28 @@ Add first-class [AsciiDoc](https://asciidoc.org/) support to Hexo. This reposito
 | Node.js    | 20.19.0         |
 | Hexo       | 8.0.0           |
 
-This repository branch documents the upcoming 4.x beta migration. As of July 22,
-2026, npm publishes only stable v3 on the `latest` dist-tag; no v4 prerelease or
-`beta` dist-tag is available yet. Do not install the unqualified package to test
-these v4 behaviors, because it resolves to v3. Before publication, contributors
-and testers must use the clean-checkout build and local-link example workflow
-below.
+Published-prerelease users should first confirm the published dist-tags:
 
-Once a v4 prerelease is published under the `beta` dist-tag, consumers will
-install it with the package manager that matches their Hexo project:
+```bash
+npm view hexo-renderer-asciidoc dist-tags
+```
+
+When the output lists the explicitly published `beta` dist-tag, install it with
+the package manager that matches the Hexo project:
 
 ```bash
 npm install hexo-renderer-asciidoc@beta --save
 # or
 pnpm add hexo-renderer-asciidoc@beta
 ```
+
+The unqualified package may still resolve to stable v3 until v4 becomes
+`latest`; do not use it to test v4. Testers of an unpublished candidate must
+use the checkout instructions and evidence from the authoritative migration PR
+or prerelease announcement. That source must designate the immutable candidate
+SHA and the acceptance evidence/check URLs. Do not infer a candidate from
+default `main`, an arbitrary ref, or this README. This README intentionally
+cannot designate or authenticate a future candidate.
 
 Once installed, Hexo automatically pipes `.ad`, `.adoc`, and `.asciidoc` files through this renderer, no extra glue code is required.
 
@@ -65,9 +72,17 @@ For AsciiDoc content, this package still uses its own static highlighting pass a
 
 ## Example Hexo site
 
-A self-contained demo lives at `examples/hexo-site`. It links to the local package via `link:../..`, so every change you make to the renderer is reflected after you rebuild the parent package.
+A source-tree contributor fixture lives at `examples/hexo-site`. It links to the
+local package via `link:../..` and is not included as a runnable site in the
+installed package.
 
 If you cloned the monorepo, the demo lives under `src/public/lib/hexo-renderer-asciidoc/examples/hexo-site` from the repository root.
+
+For an already independently verified and trusted source checkout, follow
+[`examples/hexo-site/README.md`](examples/hexo-site/README.md). Reviewers of an
+unpublished candidate must use the checkout instructions and acceptance
+evidence designated by the authoritative migration PR or prerelease
+announcement, as described above.
 
 > [!NOTE]
 > The sample site is intentionally outside the root pnpm workspace. From the repository root, follow the exact `pnpm --dir ...` sequence in `examples/hexo-site/README.md`; it builds the parent package before installing and generating the example. After that setup, either keep using `pnpm --dir src/public/lib/hexo-renderer-asciidoc/examples/hexo-site ...` from the root or `cd` into that directory and run its scripts directly. Its `pnpm-workspace.yaml` and lockfile keep those dependencies isolated.

--- a/src/public/lib/hexo-renderer-asciidoc/README.md
+++ b/src/public/lib/hexo-renderer-asciidoc/README.md
@@ -10,13 +10,20 @@
 [![Node support](https://img.shields.io/node/v/hexo-renderer-asciidoc.svg?logo=node.js)](package.json)
 [![License: LGPL-3.0-or-later](https://img.shields.io/badge/license-LGPL--3.0--or--later-0a76d5.svg)](LICENSE)
 
-Add first-class [AsciiDoc](https://asciidoc.org/) support to Hexo. The renderer piggybacks on [asciidoctor.js](https://www.npmjs.com/package/asciidoctor) 3.x, swaps Asciidoctor’s code blocks with Hexo’s static highlighter, and escapes template delimiters so the resulting HTML can flow back through Hexo safely.
+Add first-class [AsciiDoc](https://asciidoc.org/) support to Hexo. This repository branch documents the upcoming 4.x beta migration, which uses `@asciidoctor/core` / Asciidoctor.js 4.0.4, returns `Promise<string>`, registers the Hexo renderer asynchronously, re-highlights recognized listing blocks with fixed `hexo-util.highlight` options, and encodes literal braces before returning the resulting HTML to Hexo.
 
-## Security defaults
+## Rendering contract
 
-- The renderer runs Asciidoctor in `safe: 'server'` mode, which blocks shelling out and limits file access to the site root.
-- Output HTML is **not** sanitized beyond encoding `{` / `}`; treat your AsciiDoc sources as trusted or run Hexo through an additional sanitizer (DOMPurify, OWASP Java HTML Sanitizer, etc.) before publishing user-generated content.
-- Code blocks are re-highlighted via `hexo-util` so they inherit whatever theme/config you enable in `_config.yml`.
+- `renderer(data)` returns `Promise<string>`. Programmatic callers must use `await renderer(...)`.
+- Hexo registration is asynchronous for `.ad`, `.adoc`, and `.asciidoc`. Use `hexo.render.render(...)` or other async Hexo paths.
+- `renderSync` is unsupported for AsciiDoc input. If you force a synchronous Hexo path, Hexo may leave the source unrendered instead of throwing.
+- The renderer runs Asciidoctor with `doctype: 'article'`, `safe: 'server'`, and `to_file: false`.
+- The renderer does **not** set `base_dir`, so includes resolve from the conversion-time `process.cwd()`. `RendererData.path` and the Hexo site root are not used as `base_dir`.
+- This renderer is **not safe for untrusted AsciiDoc**. `safe: 'server'` still permits local includes under these current-working-directory semantics, and symlink targets can escape an assumed directory boundary. The current working directory is not a jail. Render only trusted input, from an isolated or sandboxed working directory that contains no secrets.
+- After highlighting, the renderer globally encodes every literal `{` / `}` in the generated HTML as `&#123;` / `&#125;`. This prevents downstream Hexo tag or template interpretation where applicable. Browsers decode numeric character references in ordinary HTML text and attribute values for display or use, but HTML raw-text elements such as `<script>` and `<style>` do not decode them: the references remain literal source text and can alter or break embedded JavaScript or CSS. Raw HTML remains unsanitized, so this package is not suitable for untrusted input. An HTML sanitizer cannot prevent an AsciiDoc include from disclosing file contents.
+- Static highlighting is limited to the direct `div.listingblock > div.content > pre > code` chain. The renderer does **not** rewrite arbitrary passthrough `<pre><code>` content.
+- The package does not set `source-highlighter=html-pipeline`. With the public renderer's controlled `safe: 'server'` options, a source-defined document setting is ignored, so public rendering uses Asciidoctor's default output. The internal highlighter recognizes the supported default and html-pipeline marker shapes for compatibility, but this API exposes no way to configure arbitrary highlighter options.
+- The highlighting bridge always uses fixed `hexo-util.highlight` options: `autoDetect: false`, `gutter: false`, and `wrap: false`.
 
 ## Requirements & installation
 
@@ -25,19 +32,27 @@ Add first-class [AsciiDoc](https://asciidoc.org/) support to Hexo. The renderer 
 | Node.js    | 20.19.0         |
 | Hexo       | 8.0.0           |
 
-Install from npm (choose the package manager that matches your Hexo project):
+This repository branch documents the upcoming 4.x beta migration. As of July 22,
+2026, npm publishes only stable v3 on the `latest` dist-tag; no v4 prerelease or
+`beta` dist-tag is available yet. Do not install the unqualified package to test
+these v4 behaviors, because it resolves to v3. Before publication, contributors
+and testers must use the clean-checkout build and local-link example workflow
+below.
+
+Once a v4 prerelease is published under the `beta` dist-tag, consumers will
+install it with the package manager that matches their Hexo project:
 
 ```bash
-npm install hexo-renderer-asciidoc --save
+npm install hexo-renderer-asciidoc@beta --save
 # or
-pnpm add hexo-renderer-asciidoc
+pnpm add hexo-renderer-asciidoc@beta
 ```
 
 Once installed, Hexo automatically pipes `.ad`, `.adoc`, and `.asciidoc` files through this renderer, no extra glue code is required.
 
 ### Minimal Hexo configuration
 
-AsciiDoc posts reuse Hexo’s regular highlighting settings. A typical `_config.yml` looks like this:
+The renderer does not require renderer-specific `_config.yml` settings. A typical site still keeps Hexo’s normal highlight assets enabled:
 
 ```yml
 highlight:
@@ -46,67 +61,94 @@ highlight:
   wrap: false
 ```
 
-Keep `highlight.enable` turned on even if you never write Markdown; the renderer calls the same helper under the hood to keep code blocks consistent with the theme.
+For AsciiDoc content, this package still uses its own static highlighting pass after conversion. It does not forward arbitrary Hexo highlight configuration; it always uses `autoDetect: false`, `gutter: false`, and `wrap: false` for recognized AsciiDoc listing blocks.
 
 ## Example Hexo site
 
-A self-contained demo lives at `examples/hexo-site`. It links to the local workspace via `link:../..`, so every change you make to the renderer is reflected instantly.
+A self-contained demo lives at `examples/hexo-site`. It links to the local package via `link:../..`, so every change you make to the renderer is reflected after you rebuild the parent package.
 
 If you cloned the monorepo, the demo lives under `src/public/lib/hexo-renderer-asciidoc/examples/hexo-site` from the repository root.
 
-```bash
-cd examples/hexo-site
-pnpm install
-pnpm dev
-```
-
 > [!NOTE]
-> The sample site is intentionally outside the root pnpm workspace. Always run pnpm commands from inside `examples/hexo-site` so Hexo’s dependencies stay isolated. Its `pnpm-workspace.yaml` and lockfile must remain in that folder when you copy the demo elsewhere.
+> The sample site is intentionally outside the root pnpm workspace. From the repository root, follow the exact `pnpm --dir ...` sequence in `examples/hexo-site/README.md`; it builds the parent package before installing and generating the example. After that setup, either keep using `pnpm --dir src/public/lib/hexo-renderer-asciidoc/examples/hexo-site ...` from the root or `cd` into that directory and run its scripts directly. Its `pnpm-workspace.yaml` and lockfile keep those dependencies isolated.
 
-Browse `examples/hexo-site/source/` for end-to-end samples of admonitions, callouts, audio/video embeds, and other constructs covered by the test suite.
+Browse `examples/hexo-site/source/` for the maintained posts and page that exercise headings, lists, a table of renderer defaults, and highlighted source listings. The broader constructs listed below are covered by doctests, not by this example site.
 
 ## Feature highlights
 
 - **AsciiDoc parity.** Snapshot-style doctests (`test/doctest/*.test.ts`) mirror sections from the Asciidoctor user manual so features such as admonitions, description lists, colists, inline UI macros, and complex tables stay stable between releases.
-- **Zero-config Hexo integration.** `src/hexo/register.ts` wires the renderer for `.ad`, `.adoc`, and `.asciidoc` extensions with synchronous semantics so Hexo’s asset pipeline can stream results as soon as they are available.
-- **Static highlighting bridge.** `src/core/highlight.ts` walks every `<pre class="highlight">` block produced by Asciidoctor and re-renders it with `hexo-util.highlight`, ensuring your Hexo theme powers the final markup (including languages not known to Asciidoctor’s built-in highlighters).
-- **Template safety.** `src/core/sanitize.ts` encodes `{` / `}` characters before returning control to Hexo so they are not interpreted as Nunjucks placeholders.
+- **Async Hexo integration.** `src/hexo/register.ts` wires the renderer for `.ad`, `.adoc`, and `.asciidoc` extensions with asynchronous semantics (`sync: false`) so Hexo awaits conversion.
+- **Static highlighting bridge.** `src/core/highlight.ts` rewrites only recognized Asciidoctor listing blocks and re-renders them with `hexo-util.highlight`, preserving the package’s fixed `autoDetect: false`, `gutter: false`, and `wrap: false` options.
+- **Brace encoding.** After highlighting, `src/core/sanitize.ts` globally encodes every literal `{` / `}` in the generated HTML as `&#123;` / `&#125;`. Browsers decode numeric character references in ordinary HTML text and attribute values, but HTML raw-text elements such as `<script>` and `<style>` do not; the literal references can alter or break embedded JavaScript or CSS. Raw HTML remains unsanitized, so this package is not suitable for untrusted input.
 - **Tested in Hexo.** `test/hexo.integration.test.ts` spins up a real Hexo instance to guarantee the renderer continues to work with Hexo’s official API.
 
 ## Programmatic usage
 
 The default export is the pure renderer function. You can reuse it in custom build scripts or other static-site setups:
 
+ES modules:
+
 ```ts
 import renderer from 'hexo-renderer-asciidoc';
 
-const html = renderer({ text: '== Custom pipeline ==' });
+const html = await renderer({ text: '== Custom pipeline ==' });
 ```
 
-Hexo users rarely need this, but it is handy for local testing or for wiring the renderer into other tools.
+CommonJS returns a module namespace object; destructure its default export rather than calling the object:
+
+```js
+const { default: renderer, registerRenderer } = require('hexo-renderer-asciidoc');
+
+async function main() {
+  const html = await renderer({ text: '== Custom pipeline ==' });
+  console.log(html);
+}
+
+main().catch(console.error);
+```
+
+The named `renderer` export is the same function as `default`; `registerRenderer` is available for explicit Hexo registration.
+
+Hexo users rarely need this, but it is handy for local testing or for wiring the renderer into other tools. Because the renderer is asynchronous, `renderSync` is not a supported integration path.
 
 ## Development workflow
+
+Run every command in this section from the repository root.
 
 ### Toolchain bootstrap
 
 ```bash
+mise trust          # Trust this repository's mise configuration.
 mise install        # Install pinned versions of Node, pnpm, hk, etc.
-pnpm install        # Install workspace dependencies
-hk install          # Register git hooks (lint, format, tests)
+mise exec -- pnpm install
+mise exec -- hk install
 ```
 
 ### Common scripts
 
-| Command           | Purpose                                                             |
-| ----------------- | ------------------------------------------------------------------- |
-| `pnpm lint`       | Run Biome for JS/TS/JSON and Markdownlint/Prettier for docs.        |
-| `pnpm format`     | Apply the same formatters with `--write`.                           |
-| `pnpm typecheck`  | Run `tsgo --noEmit` for strict type safety.                         |
-| `pnpm test`       | Execute the entire Vitest suite (including doctests + integration). |
-| `pnpm test:watch` | Rerun the impacted tests in watch mode.                             |
-| `pnpm test-cov`   | Generate text + LCOV coverage via V8.                               |
-| `pnpm build`      | Bundle `src/` with `tsdown` into the publishable `dist/`.           |
-| `hk check`        | Execute every hook (lint, format, typos, tests) exactly like CI.    |
+| Command                                                                                       | Purpose                                                                              |
+| --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| `mise exec -- pnpm --dir src/public/lib/hexo-renderer-asciidoc run lint`                      | Run Biome lint and check Markdown formatting with Prettier.                          |
+| `mise exec -- pnpm --dir src/public/lib/hexo-renderer-asciidoc run format`                    | Check Biome formatting, then write Markdown formatting with Prettier.                |
+| `mise exec -- pnpm --dir src/public/lib/hexo-renderer-asciidoc exec biome format --write .`   | Apply Biome formatting fixes explicitly.                                             |
+| `mise exec -- pnpm --dir src/public/lib/hexo-renderer-asciidoc run typecheck`                 | Run `tsgo --noEmit` for strict type safety.                                          |
+| `mise exec -- pnpm --dir src/public/lib/hexo-renderer-asciidoc run test`                      | Execute the entire Vitest suite (including doctests + integration).                  |
+| `mise exec -- pnpm --dir src/public/lib/hexo-renderer-asciidoc run test:watch`                | Rerun the impacted tests in watch mode.                                              |
+| `mise exec -- pnpm --dir src/public/lib/hexo-renderer-asciidoc run test-cov`                  | Generate text + LCOV coverage via V8.                                                |
+| `mise exec -- pnpm --dir src/public/lib/hexo-renderer-asciidoc run build`                     | Bundle `src/` with `tsdown` into the publishable `dist/`.                            |
+| `mise exec -- pnpm --dir src/public/lib/hexo-renderer-asciidoc exec nbgv get-version -f json` | Read the package version calculated by NBGV.                                         |
+| `mise exec -- hk check`                                                                       | Run the root-configured linters, format checks, typo checks, and config-sync checks. |
+
+The install and HK commands above are repository-level operations; the remaining commands are package-scoped while still being invoked from the repository root. HK provides the repository hook/check gate for linters, formatters, typo checks, and configuration checks. Tests, type checks, builds, and package probes are separate commands and CI jobs.
+
+From a clean checkout, build `dist/` successfully before creating a local package tarball:
+
+```bash
+mise exec -- pnpm --dir src/public/lib/hexo-renderer-asciidoc run build
+mise exec -- pnpm --dir src/public/lib/hexo-renderer-asciidoc pack
+```
+
+`prepublishOnly` runs `pnpm run build` during publishing, but neither npm nor pnpm pack invokes `prepublishOnly`; a clean local pack therefore still requires the explicit build above. `prepack` prepares package metadata but does not build `dist/`, and `postpack` restores the placeholder version afterward.
 
 ### Source layout overview
 
@@ -124,19 +166,21 @@ hk install          # Register git hooks (lint, format, tests)
 Run all doctests while iterating on Asciidoctor upgrades:
 
 ```bash
-pnpm test --filter Doctest
+mise exec -- pnpm --dir src/public/lib/hexo-renderer-asciidoc exec vitest run test/doctest
 ```
 
-### Release checklist
+### Release guidance
 
-1. `pnpm typecheck && pnpm test` – add/adjust fixtures if coverage drops.
-2. `pnpm build` – refresh `dist/` via `tsdown`.
-3. Update `ChangeLog.md` and bump the semver in `package.json`.
-4. `pnpm publish` – the `prepublishOnly` hook rebuilds automatically, and `scripts/npm-readme.cjs` swaps the npm README before the tarball is packed.
+1. Update `CHANGELOG.md` with the consumer-facing release notes.
+2. Manage the release line with `version.json`, not `package.json`. Keep `package.json` checked in as `0.0.0-placeholder`.
+3. From the repository root, check out the target commit and run `mise exec -- pnpm --dir src/public/lib/hexo-renderer-asciidoc exec nbgv get-version -f json`. Use its `NpmPackageVersion` value as the release version; any manual workflow version input must exactly equal it.
+4. Use the root workflow entrypoints `.github/workflows/official.yml` or `.github/workflows/buddy.yml` for release orchestration.
+5. Do **not** manually bump `package.json` or run package-local `pnpm publish`. For a normal local `pnpm pack`, first run the explicit package build shown above; packing does not build `dist/`. The pack lifecycle then has `prepack` temporarily stamp the NBGV version and `postpack` run `version:reset` to restore `0.0.0-placeholder`.
+6. The real release-build workflow has different lifecycle behavior in its ephemeral checkout: it manually runs `prepack` once, then official/public `both` mode packs the GPR tarball followed by the npmjs tarball with two `npm pack --ignore-scripts` commands, while Buddy `gpr-only` mode runs one such command and produces only the GPR tarball. Neither mode invokes `postpack` or `version:reset`, and neither needs to reset its disposable checkout. The local validation harness models official/public `both` mode and separately runs cleanup because it reuses its checkout. Do not change or bypass this workflow.
 
 ## Continuous integration
 
-- The monorepo CI workflow runs linting, type checks, Vitest, and the production build on Node 20.19 / 20.x / 22.x / 24.x: https://github.com/hcoona/three/actions/workflows/ci.yml
+- The monorepo CI runs HK validation in its validation job. Separate Node matrix jobs run type checks, Vitest, the production build, and packed-artifact validation on Node 20.19 / 20.x / 22.x / 24.x: https://github.com/hcoona/three/actions/workflows/ci.yml
 - CodeQL scanning lives in the monorepo as well: https://github.com/hcoona/three/actions/workflows/codeql.yml
 
 ## License

--- a/src/public/lib/hexo-renderer-asciidoc/README.npm.md
+++ b/src/public/lib/hexo-renderer-asciidoc/README.npm.md
@@ -5,7 +5,7 @@
 
 # hexo-renderer-asciidoc
 
-Add native [AsciiDoc](https://asciidoc.org/) rendering to Hexo using [asciidoctor.js](https://www.npmjs.com/package/asciidoctor). The plugin registers itself for `.ad`, `.adoc`, and `.asciidoc` inputs and reuses Hexo’s built-in syntax highlighter so your theme keeps full control over code blocks.
+Add native [AsciiDoc](https://asciidoc.org/) rendering to Hexo using `@asciidoctor/core` / Asciidoctor.js 4.0.4. The plugin auto-registers asynchronous renderers for `.ad`, `.adoc`, and `.asciidoc`, re-highlights recognized AsciiDoc listing blocks with Hexo-compatible markup, and encodes literal `{` / `}` before returning HTML to Hexo.
 
 ## Requirements
 
@@ -14,10 +14,20 @@ Add native [AsciiDoc](https://asciidoc.org/) rendering to Hexo using [asciidocto
 
 ## Installation
 
+This repository branch documents the upcoming 4.x beta migration. As of July 22,
+2026, npm publishes only stable v3 on the `latest` dist-tag; no v4 prerelease or
+`beta` dist-tag is available yet. Do not install the unqualified package to test
+these v4 behaviors, because it resolves to v3. Before publication, contributors
+and testers must use the clean repository checkout, build, and local-link example
+workflow below.
+
+Once a v4 prerelease is published under the `beta` dist-tag, consumers will
+install it with:
+
 ```bash
-npm install hexo-renderer-asciidoc --save
+npm install hexo-renderer-asciidoc@beta --save
 # or
-pnpm add hexo-renderer-asciidoc
+pnpm add hexo-renderer-asciidoc@beta
 ```
 
 After installing, Hexo picks up the renderer automatically. There is nothing to configure or register manually.
@@ -25,16 +35,36 @@ After installing, Hexo picks up the renderer automatically. There is nothing to 
 ## Usage
 
 1. Drop AsciiDoc sources (e.g., `hello-world.adoc`) anywhere under your Hexo site’s `source/` directory.
-2. Keep Hexo’s highlighter enabled in `_config.yml` so AsciiDoc code blocks inherit your theme:
+2. Run `hexo generate`, `hexo server`, or any other async Hexo command as usual.
+3. If you call the renderer yourself, `await` it:
 
-   ```yml
-   highlight:
-     enable: true
+   ES modules:
+
+   ```ts
+   import renderer from 'hexo-renderer-asciidoc';
+
+   const html = await renderer({ text: '== Hello from AsciiDoc ==' });
    ```
 
-3. Run `hexo generate`, `hexo server`, or any other Hexo command as usual.
+   CommonJS returns a module namespace object, so destructure its default export:
 
-The renderer does not add extra `_config.yml` sections. Feature toggles such as admonitions, callouts, or TOCs are handled directly by standard AsciiDoc attributes in your documents.
+   ```js
+   const { default: renderer, registerRenderer } = require('hexo-renderer-asciidoc');
+
+   async function main() {
+     const html = await renderer({ text: '== Hello from AsciiDoc ==' });
+     console.log(html);
+   }
+
+   main().catch(console.error);
+   ```
+
+   The named `renderer` export is the same function as `default`; `registerRenderer` supports explicit Hexo registration.
+
+The renderer does not add renderer-specific `_config.yml` sections. Feature toggles such as admonitions, callouts, or TOCs are handled directly by standard AsciiDoc attributes in your documents.
+
+> [!IMPORTANT]
+> `renderer(...)` returns `Promise<string>`. Hexo async render paths work normally, but `renderSync` is unsupported for AsciiDoc input. If you force a synchronous path, Hexo may leave the source unrendered instead of throwing.
 
 ### Example site
 
@@ -42,19 +72,28 @@ Need a ready-made playground? Clone the GitHub repository and open `examples/hex
 
 ```bash
 git clone https://github.com/hcoona/three.git
-cd three/src/public/lib/hexo-renderer-asciidoc/examples/hexo-site
-pnpm install
+cd three
+mise trust
+mise exec -- pnpm install --frozen-lockfile
+mise exec -- pnpm --dir src/public/lib/hexo-renderer-asciidoc run build
+mise exec -- pnpm --dir src/public/lib/hexo-renderer-asciidoc/examples/hexo-site install --frozen-lockfile
+mise exec -- pnpm --dir src/public/lib/hexo-renderer-asciidoc/examples/hexo-site run generate
+cd src/public/lib/hexo-renderer-asciidoc/examples/hexo-site
 pnpm dev
 ```
 
-That sample Hexo project depends on the local workspace via `link:../..`, so edits to the renderer are reflected immediately. Browse `examples/hexo-site/source/` to see how admonitions, callouts, audio/video embeds, and tables render end-to-end.
+That sample Hexo project depends on the local package via `link:../..`, so a fresh package build is required before the example is installed or generated from a clean checkout. The maintained posts and page exercise headings, lists, a table of renderer defaults, and highlighted source listings.
 
 ## Behavior summary
 
-- Runs Asciidoctor with `doctype: article`, `safe: server`, and `source-highlighter=html-pipeline` so external macros and system calls stay disabled by default.
-- Re-renders `<pre class="highlight">` blocks with `hexo-util.highlight`, matching whatever highlighting theme you configure in `_config.yml`.
-- Encodes literal `{` / `}` characters to keep Hexo’s Nunjucks renderer from treating output as template placeholders.
-- Does **not** sanitize arbitrary HTML. If you accept user-submitted AsciiDoc, run the generated HTML through an additional sanitizer before publishing.
+- Uses exact runtime dependency `@asciidoctor/core` 4.0.4 and awaits Asciidoctor.js 4 conversion before any post-processing.
+- Registers `.ad`, `.adoc`, and `.asciidoc` with Hexo as asynchronous renderers.
+- Runs Asciidoctor with `doctype: article`, `safe: server`, and `to_file: false`. It does **not** set `base_dir`, so includes resolve from the conversion-time `process.cwd()`. `data.path` and the Hexo site root are not used as `base_dir`.
+- Is **not safe for untrusted AsciiDoc**. `safe: server` still permits local includes under these current-working-directory semantics, and symlink targets can escape an assumed directory boundary. The current working directory is not a jail. Render only trusted input, from an isolated or sandboxed working directory that contains no secrets.
+- Does not set `source-highlighter=html-pipeline`. With the public renderer's controlled `safe: server` options, a source-defined document setting is ignored, so rendering uses Asciidoctor's default output. The internal highlighter recognizes the supported default and html-pipeline marker shapes for compatibility, but this API exposes no way to configure arbitrary highlighter options.
+- Re-renders only the recognized direct listing-block chain `div.listingblock > div.content > pre > code` with `hexo-util.highlight`, using fixed options `autoDetect: false`, `gutter: false`, and `wrap: false`.
+- After highlighting, globally encodes every literal `{` / `}` in the generated HTML as `&#123;` / `&#125;` to prevent downstream Hexo tag or template interpretation where applicable. Browsers decode numeric character references in ordinary HTML text and attribute values for display or use, but HTML raw-text elements such as `<script>` and `<style>` do not decode them: the references remain literal source text and can alter or break embedded JavaScript or CSS.
+- Does **not** sanitize arbitrary HTML, so this package is not suitable for untrusted input. An HTML sanitizer cannot prevent an AsciiDoc include from disclosing file contents.
 
 ## License
 

--- a/src/public/lib/hexo-renderer-asciidoc/README.npm.md
+++ b/src/public/lib/hexo-renderer-asciidoc/README.npm.md
@@ -14,21 +14,27 @@ Add native [AsciiDoc](https://asciidoc.org/) rendering to Hexo using `@asciidoct
 
 ## Installation
 
-This repository branch documents the upcoming 4.x beta migration. As of July 22,
-2026, npm publishes only stable v3 on the `latest` dist-tag; no v4 prerelease or
-`beta` dist-tag is available yet. Do not install the unqualified package to test
-these v4 behaviors, because it resolves to v3. Before publication, contributors
-and testers must use the clean repository checkout, build, and local-link example
-workflow below.
+Published-prerelease users should first confirm the published dist-tags:
 
-Once a v4 prerelease is published under the `beta` dist-tag, consumers will
-install it with:
+```bash
+npm view hexo-renderer-asciidoc dist-tags
+```
+
+When the output lists the explicitly published `beta` dist-tag, install it with:
 
 ```bash
 npm install hexo-renderer-asciidoc@beta --save
 # or
 pnpm add hexo-renderer-asciidoc@beta
 ```
+
+The unqualified package may still resolve to stable v3 until v4 becomes
+`latest`; do not use it to test v4. Testers of an unpublished candidate must
+use the checkout instructions and evidence from the authoritative migration PR
+or prerelease announcement. That source must designate the immutable candidate
+SHA and the acceptance evidence/check URLs. Do not infer a candidate from
+default `main`, an arbitrary ref, or this README. This README intentionally
+cannot designate or authenticate a future candidate.
 
 After installing, Hexo picks up the renderer automatically. There is nothing to configure or register manually.
 
@@ -68,21 +74,15 @@ The renderer does not add renderer-specific `_config.yml` sections. Feature togg
 
 ### Example site
 
-Need a ready-made playground? Clone the GitHub repository and open `examples/hexo-site`:
+The example is a source-tree contributor fixture that depends on the local
+package via `link:../..`; it is not included as a runnable site in the installed
+package. For an already independently verified and trusted source checkout,
+follow `src/public/lib/hexo-renderer-asciidoc/examples/hexo-site/README.md`. Reviewers of an unpublished candidate
+must use the checkout instructions and acceptance evidence designated by the
+authoritative migration PR or prerelease announcement, as described above.
 
-```bash
-git clone https://github.com/hcoona/three.git
-cd three
-mise trust
-mise exec -- pnpm install --frozen-lockfile
-mise exec -- pnpm --dir src/public/lib/hexo-renderer-asciidoc run build
-mise exec -- pnpm --dir src/public/lib/hexo-renderer-asciidoc/examples/hexo-site install --frozen-lockfile
-mise exec -- pnpm --dir src/public/lib/hexo-renderer-asciidoc/examples/hexo-site run generate
-cd src/public/lib/hexo-renderer-asciidoc/examples/hexo-site
-pnpm dev
-```
-
-That sample Hexo project depends on the local package via `link:../..`, so a fresh package build is required before the example is installed or generated from a clean checkout. The maintained posts and page exercise headings, lists, a table of renderer defaults, and highlighted source listings.
+Published-package users can instead create a regular Hexo site and install the
+explicit `@beta` package as described in [Installation](#installation).
 
 ## Behavior summary
 

--- a/src/public/lib/hexo-renderer-asciidoc/examples/hexo-site/README.md
+++ b/src/public/lib/hexo-renderer-asciidoc/examples/hexo-site/README.md
@@ -8,20 +8,43 @@
 This folder contains a self-contained Hexo site that consumes the local
 `hexo-renderer-asciidoc` package via a link dependency. Use it to test the
 renderer end-to-end without publishing to npm. It is **not** part of the root
-pnpm workspace so that its Hexo dependencies stay isolated—always run pnpm
-commands from inside `examples/hexo-site`.
+pnpm workspace so that its Hexo dependencies stay isolated—run its pnpm
+commands from `examples/hexo-site` or target that directory with `pnpm --dir`.
 
 ## Prerequisites
 
+- [mise](https://mise.jdx.dev/) installed
 - Node.js 20.19.0 or newer (matching the main project requirements)
 - pnpm 10.x (already pinned in the repo)
 
-## Usage
+## Clean-checkout setup and generation
 
-Install dependencies and start the Hexo server from inside this folder:
+The example links to the parent package's generated `dist/` files. From the
+repository root, run this exact sequence so the parent package is built before
+the example is installed or generated:
+
+<!-- linked-example-validation-sequence:start -->
 
 ```bash
-pnpm install
+mise trust
+mise exec -- pnpm install --frozen-lockfile
+mise exec -- pnpm --dir src/public/lib/hexo-renderer-asciidoc run build
+mise exec -- pnpm --dir src/public/lib/hexo-renderer-asciidoc/examples/hexo-site install --frozen-lockfile
+mise exec -- pnpm --dir src/public/lib/hexo-renderer-asciidoc/examples/hexo-site run generate
+```
+
+<!-- linked-example-validation-sequence:end -->
+
+Skipping the parent-package build can leave Hexo unable to load the linked
+renderer; Hexo may still exit successfully while reporting that `.adoc` files
+have no renderer.
+
+## Usage
+
+After completing the clean-checkout setup, start the Hexo server from inside
+this folder:
+
+```bash
 pnpm dev
 ```
 

--- a/src/public/lib/hexo-renderer-asciidoc/examples/hexo-site/README.md
+++ b/src/public/lib/hexo-renderer-asciidoc/examples/hexo-site/README.md
@@ -8,8 +8,11 @@
 This folder contains a self-contained Hexo site that consumes the local
 `hexo-renderer-asciidoc` package via a link dependency. Use it to test the
 renderer end-to-end without publishing to npm. It is **not** part of the root
-pnpm workspace so that its Hexo dependencies stay isolated—run its pnpm
-commands from `examples/hexo-site` or target that directory with `pnpm --dir`.
+pnpm workspace so that its Hexo dependencies stay isolated. The clean-checkout
+sequence below targets it from the repository root with `pnpm --dir`; after
+setup, you may instead `cd` into this directory and run its scripts directly.
+Hexo auto-discovers the plugin and registers it asynchronously for `.ad`, `.adoc`,
+and `.asciidoc`.
 
 ## Prerequisites
 
@@ -39,20 +42,32 @@ Skipping the parent-package build can leave Hexo unable to load the linked
 renderer; Hexo may still exit successfully while reporting that `.adoc` files
 have no renderer.
 
+If you call the package directly in your own scripts while experimenting with
+this demo, remember that `renderer(...)` returns `Promise<string>`. `renderSync`
+is unsupported for AsciiDoc input.
+
 ## Usage
 
-After completing the clean-checkout setup, start the Hexo server from inside
-this folder:
+After completing the root-invoked clean-checkout setup, either start the Hexo
+server from the repository root:
 
 ```bash
+mise exec -- pnpm --dir src/public/lib/hexo-renderer-asciidoc/examples/hexo-site run dev
+```
+
+or change into the example directory and run the equivalent local command:
+
+```bash
+cd src/public/lib/hexo-renderer-asciidoc/examples/hexo-site
 pnpm dev
 ```
 
-Then open <http://localhost:4000> to browse the site rendered from AsciiDoc
-sources. Modify the posts under `source/_posts/*.adoc` to experiment with
-renderer features.
+Then open <http://localhost:4000> to browse the site. Its authored AsciiDoc
+source page and posts use this renderer; Hexo generates index, archive,
+category, tag, and theme pages separately. Modify the posts under
+`source/_posts/*.adoc` to experiment with renderer features.
 
-To generate the static site without running a server:
+To generate again from inside the example directory:
 
 ```bash
 pnpm generate
@@ -60,9 +75,9 @@ pnpm generate
 
 ## Structure
 
-- `_config.yml` – Minimal Hexo configuration with the stock `landscape` theme
-  and Hexo's built-in highlighter enabled. No extra AsciiDoc overrides are
-  declared so the sample stays truthful to the renderer's defaults.
+- `_config.yml` – Minimal Hexo configuration with the `minimalism` theme and
+  Hexo's built-in highlighter enabled. The renderer still applies its own fixed
+  static-highlighting pass only to recognized AsciiDoc listing blocks.
 - `source/_posts/` – Sample AsciiDoc posts referenced on the home page.
 - `source/about/` – Example standalone page describing how the demo links to
   the local renderer build.
@@ -70,5 +85,31 @@ pnpm generate
   to treat this folder as its own workspace and capture the resolved Hexo
   dependency tree. Keep them checked in so `pnpm install` remains local.
 
-All Markup content uses the `.adoc` extension so Hexo routes every page
-through `hexo-renderer-asciidoc`.
+Every authored source page and post in this example uses the `.adoc` extension,
+so Hexo routes those source files through `hexo-renderer-asciidoc`. Hexo's
+generated index, archive, category, tag, and theme pages are not renderer
+inputs.
+
+## Behavior notes
+
+- The package uses `@asciidoctor/core` 4.0.4 and awaits conversion before
+  post-processing.
+- Includes resolve from the conversion-time current working directory because
+  the renderer does not pass `base_dir`; neither `data.path` nor the Hexo site
+  root changes that behavior.
+- This renderer is **not safe for untrusted AsciiDoc**. `safe: server` still
+  permits local includes, and symlink targets can escape an assumed directory
+  boundary. The current working directory is not a jail. Use only trusted input
+  in an isolated or sandboxed working directory containing no secrets.
+- The package does not set `source-highlighter=html-pipeline`. The controlled
+  public options ignore a document-level setting and use Asciidoctor's default
+  output. The internal highlighter recognizes supported marker shapes only for
+  compatibility; this API exposes no arbitrary highlighter configuration.
+- After highlighting, the renderer globally encodes every literal brace in the
+  generated HTML as `&#123;` or `&#125;`. Browsers decode numeric character
+  references in ordinary HTML text and attribute values for display or use, but
+  HTML raw-text elements such as `<script>` and `<style>` do not: the references
+  remain literal source text and can alter or break embedded JavaScript or CSS.
+  Raw HTML remains unsanitized, so this package is not suitable for untrusted
+  input. Sanitizing output markup cannot prevent an include from disclosing file
+  contents.

--- a/src/public/lib/hexo-renderer-asciidoc/examples/hexo-site/_config.yml
+++ b/src/public/lib/hexo-renderer-asciidoc/examples/hexo-site/_config.yml
@@ -4,8 +4,8 @@
 title: Hexo + AsciiDoc demo
 subtitle: Example Hexo site for hexo-renderer-asciidoc
 description: >-
-  A tiny Hexo blog that renders every page from AsciiDoc sources using the
-  local hexo-renderer-asciidoc package.
+  A tiny Hexo blog whose authored AsciiDoc source pages and posts use the local
+  hexo-renderer-asciidoc package.
 author: Hexo Renderer Maintainers
 language: en
 timezone: UTC
@@ -27,8 +27,9 @@ category_dir: categories
 
 highlight:
   enable: true
-  # Hexo's built-in highlighter powers non-AsciiDoc assets; the renderer applies
-  # its own static highlighting to AsciiDoc posts after conversion.
+  # Hexo's built-in highlighter powers non-AsciiDoc assets. This renderer applies
+  # its own fixed static-highlighting pass only to recognized AsciiDoc listing
+  # blocks, using autoDetect: false, gutter: false, and wrap: false.
 
 server:
   host: 0.0.0.0

--- a/src/public/lib/hexo-renderer-asciidoc/examples/hexo-site/source/_posts/hello-from-asciidoc.adoc
+++ b/src/public/lib/hexo-renderer-asciidoc/examples/hexo-site/source/_posts/hello-from-asciidoc.adoc
@@ -1,6 +1,3 @@
-// Copyright 2015 Shuai Zhang
-// SPDX-License-Identifier: LGPL-3.0-or-later WITH LGPL-3.0-linking-exception
-
 ---
 title: Meet hexo-renderer-asciidoc
 date: 2025-11-17 12:00:00
@@ -10,6 +7,9 @@ tags:
   - introduction
   - asciidoc
 ---
+// Copyright 2015 Shuai Zhang
+// SPDX-License-Identifier: LGPL-3.0-or-later WITH LGPL-3.0-linking-exception
+
 = Meet `hexo-renderer-asciidoc`
 :toc: macro
 

--- a/src/public/lib/hexo-renderer-asciidoc/examples/hexo-site/source/_posts/hello-from-asciidoc.adoc
+++ b/src/public/lib/hexo-renderer-asciidoc/examples/hexo-site/source/_posts/hello-from-asciidoc.adoc
@@ -14,47 +14,67 @@ tags:
 :toc: macro
 
 This demo blog exists to showcase how the renderer plugs AsciiDoc into Hexo 8.
-Every page you are reading—including this one—is rendered by the exact same
-code that ships to npm.
+Every authored AsciiDoc source page and post in this example—including this
+one—is rendered by the linked local build from this repository branch. Hexo
+generates index, archive, category, tag, and theme pages separately.
 
 == Why this renderer
 
-* Converts `.ad`, `.adoc`, and `.asciidoc` sources with Asciidoctor 3.0.4 using
-  `doctype=article` and `safe=server`.
-* Re-runs Hexo's static syntax highlighter so code blocks look identical to the
-  Markdown pipeline.
-* Escapes `{` / `}` pairs before returning HTML to Hexo, preventing theme
-  helpers from misinterpreting template expressions.
+* Converts `.ad`, `.adoc`, and `.asciidoc` sources with `@asciidoctor/core`
+  4.0.4 using `doctype=article`, `safe=server`, and `to_file=false`.
+* Registers asynchronously with Hexo, so normal Hexo rendering awaits the
+  renderer and programmatic callers must `await renderer(...)`.
+* Re-runs Hexo's static syntax highlighter only for recognized AsciiDoc listing
+  blocks, then encodes every literal `{` / `}` as a numeric character reference
+  before returning HTML to Hexo.
 
 == How to wire it into your site
 
-. Add the dependency inside your Hexo project:
+This repository branch documents the upcoming 4.x beta migration. As of July 22,
+2026, npm publishes only stable v3 on the `latest` dist-tag; no v4 prerelease or
+`beta` dist-tag is available yet. Do not install the unqualified package to test
+the v4 behavior, because it resolves to v3. Until a v4 prerelease is published,
+use the clean-checkout build and local-link workflow in
+<<_what_this_example_proves>>.
+
+. Once a v4 prerelease is published under the `beta` dist-tag, add it inside your
+  Hexo project:
 +
 [source,bash]
 ----
-pnpm add hexo-renderer-asciidoc
+pnpm add hexo-renderer-asciidoc@beta
 ----
 . Restart Hexo. The framework auto-discovers renderers and routes the supported
-  extensions through this package—no extra configuration necessary.
+  extensions through this package asynchronously—no extra registration code is
+  necessary.
+. If you call the renderer directly, use `await renderer(...)`. `renderSync` is
+  unsupported for AsciiDoc input.
 . Keep your posts under `source/_posts/*.adoc` and Hexo will take care of the
   rest.
 
 == What this example proves
 
-This repository depends on `hexo-renderer-asciidoc` via a local `link:` dependency.
-When you run the commands below inside `examples/hexo-site`, Hexo executes the
-fresh TypeScript build from the monorepo root, so you can iterate on the
-renderer and the demo simultaneously.
-
-[source,bash]
-----
-pnpm install
-pnpm dev
-----
+This repository depends on `hexo-renderer-asciidoc` via a local `link:`
+dependency. From a clean clone, first follow the exact build/install/generate
+sequence in `examples/hexo-site/README.md`. After that, you can run `pnpm dev`
+inside `examples/hexo-site` and iterate on the renderer and the demo
+simultaneously.
 
 Open <http://localhost:4000> and inspect the generated HTML via the browser dev
-tools—you will see that the renderer already ships pre-highlighted code blocks
-and sanitized markup.
+tools—you will see that recognized listing blocks are already pre-highlighted.
+After highlighting, the renderer globally encodes every literal brace in the
+generated HTML as `&#123;` or `&#125;`. Browsers decode numeric character
+references in ordinary HTML text and attribute values for display or use, but
+HTML raw-text elements such as `<script>` and `<style>` do not: the references
+remain literal source text and can alter or break embedded JavaScript or CSS.
+Raw HTML remains unsanitized, so this package is not suitable for untrusted
+input.
+
+This renderer is *not safe for untrusted AsciiDoc*. `safe=server` still permits
+local includes from the conversion-time current working directory, and symlink
+targets can escape an assumed directory boundary. That directory is not a jail.
+Render only trusted input in an isolated or sandboxed working directory with no
+secrets. Sanitizing output markup cannot prevent file-content disclosure.
 
 == Key defaults to remember
 
@@ -67,9 +87,27 @@ and sanitized markup.
 | Doctype
 | `article`
 
-| Source highlighter
-| `html-pipeline` + Hexo's `hexo-util.highlight`
+| Source highlighter default
+| Asciidoctor default output; document-level `html-pipeline` is ignored
+
+| Highlight scope
+| direct `div.listingblock > div.content > pre > code` only
+
+| Include base directory
+| conversion-time `process.cwd()`
 |===
 
-Need a different behaviour? Fork the renderer, tweak `src/core/asciidoctor.ts`,
-and re-run `pnpm build` before pointing your Hexo site to the new bundle.
+The internal highlighter recognizes supported default and html-pipeline marker
+shapes for compatibility, but the public API cannot configure arbitrary
+highlighter options.
+
+Need different behavior? Fork the renderer and tweak `src/core/asciidoctor.ts`.
+To rebuild the linked parent package and then regenerate this example, stay at
+the repository root and run:
+
+[source,bash]
+----
+mise exec -- pnpm --dir src/public/lib/hexo-renderer-asciidoc run build
+mise exec -- pnpm --dir src/public/lib/hexo-renderer-asciidoc/examples/hexo-site run generate
+xdg-open src/public/lib/hexo-renderer-asciidoc/examples/hexo-site/public/index.html
+----

--- a/src/public/lib/hexo-renderer-asciidoc/examples/hexo-site/source/_posts/renderer-tour.adoc
+++ b/src/public/lib/hexo-renderer-asciidoc/examples/hexo-site/source/_posts/renderer-tour.adoc
@@ -1,6 +1,3 @@
-// Copyright 2015 Shuai Zhang
-// SPDX-License-Identifier: LGPL-3.0-or-later WITH LGPL-3.0-linking-exception
-
 ---
 title: Renderer pipeline tour
 date: 2025-11-17 12:05:00
@@ -9,6 +6,9 @@ categories:
 tags:
   - walkthrough
 ---
+// Copyright 2015 Shuai Zhang
+// SPDX-License-Identifier: LGPL-3.0-or-later WITH LGPL-3.0-linking-exception
+
 = Renderer pipeline tour
 :sectnums:
 

--- a/src/public/lib/hexo-renderer-asciidoc/examples/hexo-site/source/_posts/renderer-tour.adoc
+++ b/src/public/lib/hexo-renderer-asciidoc/examples/hexo-site/source/_posts/renderer-tour.adoc
@@ -17,45 +17,76 @@ Want to see what happens between your `.adoc` file and the HTML that lands in
 
 == Step 1 – Asciidoctor conversion
 
-The plugin bootstraps Asciidoctor once and reuses it for every render. Each
-call runs `convert()` with:
+Each render awaits the named `convert()` API from `@asciidoctor/core` 4.0.4.
+Every call uses:
 
 * `doctype=article`
 * `safe=server`
-* `source-highlighter=html-pipeline`
+* `to_file=false`
 
-Those defaults match Hexo's static hosting assumptions while keeping dangerous
-macros disabled.
+The renderer does not pass `base_dir`, so relative includes resolve from the
+conversion-time current working directory. `data.path` and the Hexo site root
+do not change that behavior.
+
+This renderer is *not safe for untrusted AsciiDoc*. `safe=server` still permits
+local includes, and symlink targets can escape an assumed directory boundary.
+The current working directory is not a jail. Render only trusted input in an
+isolated or sandboxed working directory containing no secrets.
 
 == Step 2 – Static highlighting
 
-After Asciidoctor returns HTML, we pass every `<pre><code>` block through
-`hexo-util.highlight`. That keeps code fences visually consistent with the rest
-of the Hexo ecosystem even though the source language is AsciiDoc.
+After Asciidoctor returns HTML, the package rewrites only the recognized direct
+listing-block chain `div.listingblock > div.content > pre > code`. That keeps
+code fences visually consistent with the rest of the Hexo ecosystem without
+rewriting arbitrary passthrough `<pre><code>` HTML.
+
+The highlighter path uses fixed options:
+
+* `autoDetect=false`
+* `gutter=false`
+* `wrap=false`
+
+The package does not set `source-highlighter=html-pipeline`. The public
+renderer's controlled `safe=server` options ignore a document-level setting and
+use Asciidoctor's default output. Its internal highlighter recognizes the
+supported default and html-pipeline marker shapes for compatibility, but this
+API exposes no arbitrary highlighter configuration.
 
 [source,typescript]
 ----
 import renderer from 'hexo-renderer-asciidoc';
 
-const html = renderer({ text: '== Sample ==' });
-// html already contains Hexo-flavoured <figure class="highlight"> wrappers
+const html = await renderer({ text: '== Sample ==' });
+// html already contains syntax-highlighted listing-block markup
 ----
 
-== Step 3 – Curly brace sanitisation
+== Step 3 – Curly brace escaping
 
-Hexo themes (including the default `landscape`) use `pass:[{% helper %}]` syntax. To
-prevent fragment re-processing, we escape any literal `{` or `}` sequences that
-survive Asciidoctor. You can confirm this by viewing page source—the braces in
-inline code samples become HTML entities until Hexo finishes rendering.
+After highlighting, the renderer globally encodes every literal `{` and `}` in
+the generated HTML as `&#123;` and `&#125;`. This prevents downstream Hexo tag
+or template interpretation where applicable. Browsers decode numeric character
+references in ordinary HTML text and attribute values for display or use, but
+HTML raw-text elements such as `<script>` and `<style>` do not: the references
+remain literal source text and can alter or break embedded JavaScript or CSS.
+
+Raw HTML remains unsanitized, so this package is *not suitable for untrusted
+input*. Sanitizing output markup cannot prevent an include from disclosing file
+contents.
 
 == Verifying the pipeline locally
 
+After completing the root-invoked clean-checkout setup documented in
+`examples/hexo-site/README.md`, stay at the repository root and run:
+
 [source,bash]
 ----
-pnpm generate
-xdg-open public/index.html
+mise exec -- pnpm --dir src/public/lib/hexo-renderer-asciidoc run build
+mise exec -- pnpm --dir src/public/lib/hexo-renderer-asciidoc/examples/hexo-site run generate
+xdg-open src/public/lib/hexo-renderer-asciidoc/examples/hexo-site/public/index.html
 ----
 
 Inspect the resulting markup and you'll see the three stages above reflected
-verbatim. Adjust the renderer under `src/core/` and regenerate to watch the
-output evolve.
+verbatim. After adjusting the parent renderer under `src/core/`, rerun the
+parent-package build before regenerating the example with the commands above.
+If you script the package directly instead of going through Hexo, remember that
+`renderSync` is unsupported and `renderer(...)` must be awaited.

--- a/src/public/lib/hexo-renderer-asciidoc/examples/hexo-site/source/about/index.adoc
+++ b/src/public/lib/hexo-renderer-asciidoc/examples/hexo-site/source/about/index.adoc
@@ -13,23 +13,56 @@ This static page explains how the sample Hexo site consumes the renderer.
 
 * Showcase the `hexo-renderer-asciidoc` integration without publishing to npm.
 * Provide ready-to-edit `.adoc` sources for posts _and_ pages.
-* Demonstrate Hexo's default theme + highlight pipeline with zero extra tweaks.
+* Demonstrate Hexo's async renderer registration and listing-block highlighting
+  with zero renderer-specific configuration.
 
 == How it works
 
-. `package.json` points `hexo-renderer-asciidoc` to the repository root via a
+. `package.json` points `hexo-renderer-asciidoc` to the parent package via a
   local `link:` dependency.
-. Run `pnpm install` **inside `examples/hexo-site`**. The example intentionally
-  stays out of the main pnpm workspace so it can pin its own Hexo toolchain.
-. Hexo discovers the renderer automatically and wires it as the handler for
-  `.ad`, `.adoc`, and `.asciidoc` files.
+. From a clean checkout, first follow the exact build/install/generate sequence
+  in `examples/hexo-site/README.md` so the linked `dist/` files exist before
+  Hexo installs or generates the site.
+. Run `pnpm install` **inside `examples/hexo-site`** for later local-only
+  changes. The example intentionally stays out of the main pnpm workspace so it
+  can pin its own Hexo toolchain.
+. Hexo discovers the renderer automatically, registers `.ad`, `.adoc`, and
+  `.asciidoc` asynchronously, and awaits the renderer during normal async site
+  generation.
 
-== Customising
+== Customizing
 
-The renderer currently ships a fixed Asciidoctor configuration (`doctype`
-`article`, `safe` `server`, `source-highlighter` `html-pipeline`). If you need
-different attributes, fork the package, tweak `src/core/asciidoctor.ts`, and
-publish or link your build the same way this example does.
+The renderer currently ships a fixed Asciidoctor configuration:
+
+* `doctype=article`
+* `safe=server`
+* `to_file=false`
+
+It does **not** set `base_dir`, so includes resolve from the conversion-time
+current working directory. `data.path` and the Hexo site root do not change
+that behavior.
+
+This renderer is *not safe for untrusted AsciiDoc*. `safe=server` still permits
+local includes, and symlink targets can escape an assumed directory boundary.
+The current working directory is not a jail. Render only trusted input in an
+isolated or sandboxed working directory containing no secrets.
+
+The package does not set `source-highlighter=html-pipeline`. The public
+renderer's controlled `safe=server` options ignore a document-level setting and
+use Asciidoctor's default output. It re-highlights recognized direct
+listing-block structures with fixed `hexo-util.highlight` options
+(`autoDetect: false`, `gutter: false`, `wrap: false`). Its internal highlighter
+recognizes the supported marker shapes for compatibility, but this API exposes
+no arbitrary highlighter configuration.
+
+After highlighting, the renderer globally encodes every literal brace in the
+generated HTML as `&#123;` or `&#125;`. Browsers decode numeric character
+references in ordinary HTML text and attribute values for display or use, but
+HTML raw-text elements such as `<script>` and `<style>` do not: the references
+remain literal source text and can alter or break embedded JavaScript or CSS.
+Raw HTML remains unsanitized, so this package is not suitable for untrusted
+input. Sanitizing output markup cannot prevent an include from disclosing file
+contents.
 
 Need a different Hexo theme? Install it with `pnpm add <theme>` inside the
 example folder and update `_config.yml` accordingly.

--- a/src/public/lib/hexo-renderer-asciidoc/examples/hexo-site/source/about/index.adoc
+++ b/src/public/lib/hexo-renderer-asciidoc/examples/hexo-site/source/about/index.adoc
@@ -1,10 +1,10 @@
-// Copyright 2015 Shuai Zhang
-// SPDX-License-Identifier: LGPL-3.0-or-later WITH LGPL-3.0-linking-exception
-
 ---
 title: About this demo
 date: 2025-11-17 12:10:00
 ---
+// Copyright 2015 Shuai Zhang
+// SPDX-License-Identifier: LGPL-3.0-or-later WITH LGPL-3.0-linking-exception
+
 = About this demo site
 
 This static page explains how the sample Hexo site consumes the renderer.

--- a/src/public/lib/hexo-renderer-asciidoc/package.json
+++ b/src/public/lib/hexo-renderer-asciidoc/package.json
@@ -4,7 +4,7 @@
   "description": "Asciidoc renderer plugin for hexo",
   "type": "module",
   "main": "./dist/index.cjs",
-  "types": "./dist/index.d.cts",
+  "types": "./dist/index.d.ts",
   "files": [
     "dist",
     "README.md",
@@ -27,7 +27,10 @@
     "hooks:check": "hk check",
     "hooks:fix": "hk fix",
     "typecheck": "tsgo --noEmit",
-    "build": "tsdown",
+    "build": "tsdown && node ./scripts/normalize-dist.mjs",
+    "validate:packed-artifact": "node ./scripts/validate-packed-artifact.mjs",
+    "validate:release-pack": "node ./scripts/validate-release-pack.mjs",
+    "validate:linked-example": "node ./scripts/validate-linked-example.mjs",
     "prepublishOnly": "pnpm run build",
     "version:stamp": "node ./scripts/nbgv-version.mjs stamp",
     "version:reset": "node ./scripts/nbgv-version.mjs reset",
@@ -81,10 +84,15 @@
   },
   "exports": {
     ".": {
-      "types": "./dist/index.d.cts",
-      "require": "./dist/index.cjs",
-      "import": "./dist/index.cjs",
-      "default": "./dist/index.cjs"
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      },
+      "default": "./dist/index.js"
     }
   }
 }

--- a/src/public/lib/hexo-renderer-asciidoc/package.json
+++ b/src/public/lib/hexo-renderer-asciidoc/package.json
@@ -60,7 +60,7 @@
     "hexo": ">=8.0.0"
   },
   "dependencies": {
-    "asciidoctor": "3.0.4",
+    "@asciidoctor/core": "4.0.4",
     "cheerio": "^1.2.0",
     "entities": "^8.0.0",
     "hexo-util": "^4.0.0"

--- a/src/public/lib/hexo-renderer-asciidoc/scripts/normalize-dist.mjs
+++ b/src/public/lib/hexo-renderer-asciidoc/scripts/normalize-dist.mjs
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2015 Shuai Zhang
+ * SPDX-License-Identifier: LGPL-3.0-or-later WITH LGPL-3.0-linking-exception
+ */
+
+import { existsSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+const packageRoot = path.resolve(import.meta.dirname, '..');
+const distDirectory = path.join(packageRoot, 'dist');
+
+const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const renameIfPresent = (fromRelativePath, toRelativePath) => {
+  const fromPath = path.join(distDirectory, fromRelativePath);
+  if (!existsSync(fromPath)) {
+    return;
+  }
+  renameSync(fromPath, path.join(distDirectory, toRelativePath));
+};
+
+const rewriteSourceMapComment = (relativePath, fromValue, toValue) => {
+  const filePath = path.join(distDirectory, relativePath);
+  if (!existsSync(filePath)) {
+    return;
+  }
+  const contents = readFileSync(filePath, 'utf8').replace(fromValue, toValue);
+  writeFileSync(filePath, contents, 'utf8');
+};
+
+const rewriteSourceMapMetadata = (relativePath, fromValue, toValue) => {
+  const filePath = path.join(distDirectory, relativePath);
+  if (!existsSync(filePath)) {
+    return;
+  }
+  const contents = readFileSync(filePath, 'utf8');
+  const sourceMap = JSON.parse(contents);
+  if (sourceMap.file !== fromValue && sourceMap.file !== toValue) {
+    throw new Error(`${relativePath} unexpectedly targets ${sourceMap.file}.`);
+  }
+  sourceMap.file = toValue;
+  writeFileSync(filePath, `${JSON.stringify(sourceMap)}${contents.endsWith('\n') ? '\n' : ''}`, 'utf8');
+};
+
+const removeRuntimeSourceMap = (relativePath) => {
+  const filePath = path.join(distDirectory, relativePath);
+  if (!existsSync(filePath)) {
+    return;
+  }
+  rmSync(filePath, { force: true });
+};
+
+renameIfPresent('index.mjs', 'index.js');
+renameIfPresent('index.d.mts', 'index.d.ts');
+renameIfPresent('index.d.mts.map', 'index.d.ts.map');
+
+rewriteSourceMapComment(
+  'index.js',
+  new RegExp(`(?:\\r\\n|\\r|\\n)?${escapeRegExp('//# sourceMappingURL=index.mjs.map')}(?:\\r\\n|\\r|\\n)?$`, 'u'),
+  '',
+);
+rewriteSourceMapComment('index.d.ts', '//# sourceMappingURL=index.d.mts.map', '//# sourceMappingURL=index.d.ts.map');
+rewriteSourceMapMetadata('index.d.ts.map', 'index.d.mts', 'index.d.ts');
+
+removeRuntimeSourceMap('index.mjs.map');

--- a/src/public/lib/hexo-renderer-asciidoc/scripts/sync-licenses.mjs
+++ b/src/public/lib/hexo-renderer-asciidoc/scripts/sync-licenses.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+
 /**
  * Copyright 2015 Shuai Zhang
  * SPDX-License-Identifier: LGPL-3.0-or-later WITH LGPL-3.0-linking-exception
@@ -9,7 +10,8 @@
  * and removes them afterward so that they do not stay tracked in git.
  */
 
-import { cp, mkdir, readFile, rename, rm, stat, writeFile } from 'node:fs/promises';
+import { randomUUID } from 'node:crypto';
+import { cp, lstat, mkdir, readFile, readlink, rename, rm, rmdir, symlink, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -17,6 +19,7 @@ const moduleDir = path.dirname(fileURLToPath(import.meta.url));
 const packageRoot = path.resolve(moduleDir, '..');
 
 const BACKUP_SUFFIX = '.sync-licenses-backup';
+const BACKUP_DIRECTORY = path.join(packageRoot, '.sync-licenses-backups');
 const STATE_FILE = path.join(packageRoot, '.sync-licenses-state.json');
 
 /**
@@ -35,7 +38,7 @@ const LICENSE_ITEMS = [
 
 async function pathExists(entryPath) {
   try {
-    await stat(entryPath);
+    await lstat(entryPath);
     return true;
   } catch (error) {
     if (error && error.code === 'ENOENT') {
@@ -45,9 +48,9 @@ async function pathExists(entryPath) {
   }
 }
 
-async function tryStat(entryPath) {
+async function tryLstat(entryPath) {
   try {
-    return await stat(entryPath);
+    return await lstat(entryPath);
   } catch (error) {
     if (error && error.code === 'ENOENT') {
       return null;
@@ -58,7 +61,47 @@ async function tryStat(entryPath) {
 
 async function ensureParentDir(filePath) {
   const parent = path.dirname(filePath);
-  await mkdir(parent, { recursive: true });
+  const relativeParent = path.relative(packageRoot, parent);
+  let current = packageRoot;
+  for (const segment of relativeParent.split(path.sep).filter(Boolean)) {
+    current = path.join(current, segment);
+    const currentStat = await tryLstat(current);
+    if (!currentStat) {
+      await mkdir(current);
+      continue;
+    }
+    if (currentStat.isSymbolicLink()) {
+      throw new Error(`Refusing to follow symlinked package parent path ${path.relative(packageRoot, current)}.`);
+    }
+    if (!currentStat.isDirectory()) {
+      throw new Error(`Package parent path ${path.relative(packageRoot, current)} is not a directory.`);
+    }
+  }
+}
+
+async function assertSafeParentPath(filePath) {
+  const relativePath = path.relative(packageRoot, filePath);
+  if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+    throw new Error(`Refusing path outside package root: ${filePath}.`);
+  }
+
+  let current = packageRoot;
+  for (const segment of path
+    .dirname(relativePath)
+    .split(path.sep)
+    .filter((entry) => entry && entry !== '.')) {
+    current = path.join(current, segment);
+    const currentStat = await tryLstat(current);
+    if (!currentStat) {
+      return;
+    }
+    if (currentStat.isSymbolicLink()) {
+      throw new Error(`Refusing to follow symlinked package parent path ${path.relative(packageRoot, current)}.`);
+    }
+    if (!currentStat.isDirectory()) {
+      throw new Error(`Package parent path ${path.relative(packageRoot, current)} is not a directory.`);
+    }
+  }
 }
 
 async function findMonorepoRoot(startDir) {
@@ -91,83 +134,226 @@ function logError(message) {
 async function copyEntry(entry) {
   const source = path.join(monorepoRoot, entry.source);
   const target = path.join(packageRoot, entry.target);
-  const sourceStat = await tryStat(source);
+  const sourceStat = await tryLstat(source);
   if (!sourceStat) {
     throw new Error(`Cannot find "${entry.source}" in monorepo root (${monorepoRoot}).`);
   }
 
   await ensureParentDir(target);
+  await assertSafeParentPath(target);
   await rm(target, { recursive: true, force: true });
+  if (sourceStat.isSymbolicLink()) {
+    await symlink(await readlink(source), target);
+    return;
+  }
   if (sourceStat.isDirectory()) {
-    await cp(source, target, { recursive: true });
+    await cp(source, target, { recursive: true, verbatimSymlinks: true });
     return;
   }
 
-  await cp(source, target);
+  await cp(source, target, { verbatimSymlinks: true });
+}
+
+async function preflightSource(entry) {
+  const source = path.join(monorepoRoot, entry.source);
+  const sourceStat = await tryLstat(source);
+  if (!sourceStat) {
+    throw new Error(`Cannot find "${entry.source}" in monorepo root (${monorepoRoot}).`);
+  }
 }
 
 async function removeEntry(entry) {
   const target = path.join(packageRoot, entry);
+  await assertSafeParentPath(target);
   await rm(target, { recursive: true, force: true });
 }
 
-async function backupTargetIfNeeded(targetRelativePath) {
+async function planBackupIfNeeded(targetRelativePath) {
   const target = path.join(packageRoot, targetRelativePath);
-  const targetStat = await tryStat(target);
+  const targetStat = await tryLstat(target);
   if (!targetStat) {
     return null;
   }
 
-  const backup = `${target}${BACKUP_SUFFIX}`;
-  const backupStat = await tryStat(backup);
-  if (backupStat) {
-    throw new Error(
-      `Found an existing backup (${path.relative(packageRoot, backup)}). ` +
-        'A previous run likely did not finish. Run "postpack" to restore, ' +
-        'or delete the backup manually if you know what you are doing.',
-    );
-  }
-  await ensureParentDir(backup);
-  await rename(target, backup);
+  const backupName = `${targetRelativePath.replaceAll(path.sep, '__')}${BACKUP_SUFFIX}`;
+  const backup = path.join(BACKUP_DIRECTORY, backupName);
   return path.relative(packageRoot, backup);
 }
 
-async function restoreBackupIfNeeded(targetRelativePath, backupRelativePath) {
+async function backupTarget(targetRelativePath, backupRelativePath) {
   if (!backupRelativePath) {
     return;
   }
 
   const target = path.join(packageRoot, targetRelativePath);
   const backup = path.join(packageRoot, backupRelativePath);
-  const backupStat = await tryStat(backup);
+  await ensureParentDir(backup);
+  await assertSafeParentPath(target);
+  await assertSafeParentPath(backup);
+  await rename(target, backup);
+}
+
+async function restoreBackupIfNeeded(targetRelativePath, backupRelativePath) {
+  if (!backupRelativePath) {
+    return false;
+  }
+
+  const target = path.join(packageRoot, targetRelativePath);
+  const backup = path.join(packageRoot, backupRelativePath);
+  await assertSafeParentPath(target);
+  await assertSafeParentPath(backup);
+  const backupStat = await tryLstat(backup);
   if (!backupStat) {
-    return;
+    return false;
   }
 
   await rm(target, { recursive: true, force: true });
   await ensureParentDir(target);
-  await rename(backup, target);
+  await assertSafeParentPath(target);
+  await cp(backup, target, { recursive: backupStat.isDirectory(), verbatimSymlinks: true });
+  return true;
 }
 
 async function writeState(state) {
-  await writeFile(STATE_FILE, JSON.stringify(state, null, 2), 'utf8');
+  const temporaryStateFile = path.join(packageRoot, `.sync-licenses-state-${randomUUID()}.tmp`);
+  try {
+    await writeFile(temporaryStateFile, JSON.stringify(state, null, 2), { encoding: 'utf8', flag: 'wx' });
+    await rename(temporaryStateFile, STATE_FILE);
+  } finally {
+    await rm(temporaryStateFile, { force: true });
+  }
 }
 
 async function readState() {
-  const raw = await readFile(STATE_FILE, 'utf8').catch(() => null);
-  if (!raw) {
-    return null;
+  const stateStat = await tryLstat(STATE_FILE);
+  if (stateStat?.isSymbolicLink() || (stateStat && !stateStat.isFile())) {
+    throw new Error(`State file (${path.relative(packageRoot, STATE_FILE)}) is not a regular file. Refusing cleanup.`);
   }
-
+  let raw;
+  try {
+    raw = await readFile(STATE_FILE, 'utf8');
+  } catch (error) {
+    if (error && error.code === 'ENOENT') {
+      throw new Error(`State file (${path.relative(packageRoot, STATE_FILE)}) is missing. Refusing cleanup.`, {
+        cause: error,
+      });
+    }
+    throw new Error(`State file (${path.relative(packageRoot, STATE_FILE)}) cannot be read. Refusing cleanup.`, {
+      cause: error,
+    });
+  }
   try {
     return JSON.parse(raw);
-  } catch {
-    return null;
+  } catch (error) {
+    throw new Error(`State file (${path.relative(packageRoot, STATE_FILE)}) is not valid JSON. Refusing cleanup.`, {
+      cause: error,
+    });
   }
 }
 
+function isPlainObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function assertExactKeys(value, expectedKeys, location) {
+  const actualKeys = Object.keys(value).sort();
+  const sortedExpectedKeys = [...expectedKeys].sort();
+  if (
+    actualKeys.length !== sortedExpectedKeys.length ||
+    actualKeys.some((key, index) => key !== sortedExpectedKeys[index])
+  ) {
+    throw new Error(`State file ${location} must contain exactly these fields: ${sortedExpectedKeys.join(', ')}.`);
+  }
+}
+
+function validateState(state) {
+  const invalidState = (message) =>
+    new Error(`State file (${path.relative(packageRoot, STATE_FILE)}) is invalid: ${message} Refusing cleanup.`);
+  if (!isPlainObject(state)) {
+    throw invalidState('the root value must be an object.');
+  }
+  try {
+    assertExactKeys(state, ['version', 'createdBackupDirectory', 'createdDirectories', 'items'], 'root object');
+  } catch (error) {
+    throw invalidState(error.message);
+  }
+  if (![1, 2].includes(state.version)) {
+    throw invalidState(`unsupported version ${JSON.stringify(state.version)}; expected version 1 or 2.`);
+  }
+  if (typeof state.createdBackupDirectory !== 'boolean') {
+    throw invalidState('createdBackupDirectory must be a boolean.');
+  }
+  if (!Array.isArray(state.createdDirectories)) {
+    throw invalidState('createdDirectories must be an array.');
+  }
+  if (!Array.isArray(state.items)) {
+    throw invalidState('items must be an array.');
+  }
+
+  const allowedTargets = new Set(LICENSE_ITEMS.map((item) => item.target));
+  const allowedCreatedDirectories = new Set(
+    LICENSE_ITEMS.map((item) => path.dirname(item.target)).filter((directory) => directory !== '.'),
+  );
+  const seenCreatedDirectories = new Set();
+  for (const createdDirectory of state.createdDirectories) {
+    if (typeof createdDirectory !== 'string' || !allowedCreatedDirectories.has(createdDirectory)) {
+      throw invalidState(`unexpected or unsafe created directory ${JSON.stringify(createdDirectory)}.`);
+    }
+    if (seenCreatedDirectories.has(createdDirectory)) {
+      throw invalidState(`duplicate created directory ${JSON.stringify(createdDirectory)}.`);
+    }
+    seenCreatedDirectories.add(createdDirectory);
+  }
+
+  const seenTargets = new Set();
+  for (const [index, item] of state.items.entries()) {
+    if (!isPlainObject(item)) {
+      throw invalidState(`items[${index}] must be an object.`);
+    }
+    try {
+      assertExactKeys(
+        item,
+        state.version === 1 ? ['target', 'backup'] : ['target', 'backup', 'completed'],
+        `items[${index}]`,
+      );
+    } catch (error) {
+      throw invalidState(error.message);
+    }
+    if (typeof item.target !== 'string' || !allowedTargets.has(item.target)) {
+      throw invalidState(`unexpected or unsafe target ${JSON.stringify(item.target)}.`);
+    }
+    if (seenTargets.has(item.target)) {
+      throw invalidState(`duplicate target ${JSON.stringify(item.target)}.`);
+    }
+    seenTargets.add(item.target);
+
+    const expectedCurrentBackup = path.relative(
+      packageRoot,
+      path.join(BACKUP_DIRECTORY, `${item.target.replaceAll(path.sep, '__')}${BACKUP_SUFFIX}`),
+    );
+    const expectedLegacyBackup = `${item.target}${BACKUP_SUFFIX}`;
+    if (item.backup !== null && item.backup !== expectedCurrentBackup && item.backup !== expectedLegacyBackup) {
+      throw invalidState(`unexpected or unsafe backup path ${JSON.stringify(item.backup)}.`);
+    }
+    if (item.backup === expectedCurrentBackup && state.createdBackupDirectory !== true) {
+      throw invalidState('createdBackupDirectory must be true when an item records a managed backup.');
+    }
+    if (state.version === 2 && typeof item.completed !== 'boolean') {
+      throw invalidState(`items[${index}].completed must be a boolean.`);
+    }
+  }
+  if (state.version === 1) {
+    return {
+      ...state,
+      version: 2,
+      items: state.items.map((item) => ({ ...item, completed: false })),
+    };
+  }
+  return state;
+}
+
 async function handlePrepack() {
-  const existingState = await tryStat(STATE_FILE);
+  const existingState = await tryLstat(STATE_FILE);
   if (existingState) {
     throw new Error(
       `Found an existing state file (${path.relative(packageRoot, STATE_FILE)}). ` +
@@ -176,50 +362,124 @@ async function handlePrepack() {
     );
   }
 
+  const existingBackupDirectory = await tryLstat(BACKUP_DIRECTORY);
+  const legacyBackupPaths = LICENSE_ITEMS.map((item) => path.join(packageRoot, `${item.target}${BACKUP_SUFFIX}`));
+  const existingLegacyBackup = (
+    await Promise.all(legacyBackupPaths.map(async (backupPath) => ((await tryLstat(backupPath)) ? backupPath : null)))
+  ).find(Boolean);
+  if (existingBackupDirectory || existingLegacyBackup) {
+    const backupPath = existingLegacyBackup ?? BACKUP_DIRECTORY;
+    throw new Error(
+      `Found existing backup data (${path.relative(packageRoot, backupPath)}). ` +
+        'A previous run likely did not finish. Run "postpack" only when its state file is present; ' +
+        'otherwise preserve or recover the backup manually.',
+    );
+  }
+
+  // Finish the complete preflight before writing state or touching package data.
+  await Promise.all(LICENSE_ITEMS.map((item) => preflightSource(item)));
+  await Promise.all(LICENSE_ITEMS.map((item) => assertSafeParentPath(path.join(packageRoot, item.target))));
+  const backupPlans = [];
+  for (const item of LICENSE_ITEMS) {
+    const backup = await planBackupIfNeeded(item.target);
+    backupPlans.push(backup);
+  }
+  const createdDirectories = [];
+  for (const item of LICENSE_ITEMS) {
+    const parent = path.dirname(item.target);
+    if (parent !== '.' && !(await tryLstat(path.join(packageRoot, parent)))) {
+      createdDirectories.push(parent);
+    }
+  }
+
+  // All preflight checks passed; now write the initial (empty) state file.
   const state = {
-    version: 1,
+    version: 2,
+    createdBackupDirectory: backupPlans.some(Boolean),
+    createdDirectories: [...new Set(createdDirectories)],
     items: [],
   };
+  await writeState(state);
 
-  for (const item of LICENSE_ITEMS) {
-    const backup = await backupTargetIfNeeded(item.target);
-    await copyEntry(item);
-    state.items.push({ target: item.target, backup });
+  for (let index = 0; index < LICENSE_ITEMS.length; index += 1) {
+    const item = LICENSE_ITEMS[index];
+    const backup = backupPlans[index];
+    state.items.push({ target: item.target, backup, completed: false });
     await writeState(state);
+    await backupTarget(item.target, backup);
+    await copyEntry(item);
   }
   log('Copied shared license artifacts into package root.');
 }
 
 async function handlePostpack() {
-  const state = await readState();
+  // Validate the complete state before any path can be removed, replaced, or rewritten.
+  const state = validateState(await readState());
 
-  // Best-effort cleanup even if the state file is missing.
-  if (!state || !Array.isArray(state.items)) {
-    logError(
-      `State file (${path.relative(packageRoot, STATE_FILE)}) is missing or invalid. ` +
-        'Performing best-effort cleanup without touching the package LICENSE.',
-    );
-
-    for (const item of LICENSE_ITEMS) {
-      if (item.target === 'LICENSE') {
-        continue;
-      }
-      await removeEntry(item.target);
+  const cleanupErrors = [];
+  for (const item of state.items) {
+    if (item.completed) {
+      continue;
     }
-
-    // Remove the LICENSES directory if we created it and it is empty.
-    await rm(path.join(packageRoot, 'LICENSES'), { force: true, recursive: false }).catch(() => {});
-    log('Removed temporary shared license artifacts after packaging.');
-    return;
+    try {
+      if (!item.backup) {
+        await removeEntry(item.target);
+      } else {
+        const restored = await restoreBackupIfNeeded(item.target, item.backup);
+        if (!restored) {
+          throw new Error(
+            `Recorded backup for ${item.target} is missing; preserved the current target and state file.`,
+          );
+        }
+      }
+      item.completed = true;
+      try {
+        await writeState(state);
+      } catch (error) {
+        item.completed = false;
+        cleanupErrors.push(error);
+      }
+    } catch (error) {
+      cleanupErrors.push(error);
+    }
   }
 
   for (const item of state.items) {
-    await removeEntry(item.target);
-    await restoreBackupIfNeeded(item.target, item.backup);
+    if (!item.completed || !item.backup) {
+      continue;
+    }
+    try {
+      const backup = path.join(packageRoot, item.backup);
+      await assertSafeParentPath(backup);
+      await rm(backup, { recursive: true, force: true });
+    } catch (error) {
+      cleanupErrors.push(error);
+    }
+  }
+
+  for (const createdDirectory of [...state.createdDirectories].reverse()) {
+    try {
+      await rmdir(path.join(packageRoot, createdDirectory));
+    } catch (error) {
+      if (!error || !['ENOENT', 'ENOTEMPTY', 'EEXIST'].includes(error.code)) {
+        cleanupErrors.push(error);
+      }
+    }
+  }
+  if (state.createdBackupDirectory === true) {
+    try {
+      await rmdir(BACKUP_DIRECTORY);
+    } catch (error) {
+      if (!error || !['ENOENT', 'ENOTEMPTY', 'EEXIST'].includes(error.code)) {
+        cleanupErrors.push(error);
+      }
+    }
+  }
+  if (cleanupErrors.length > 0) {
+    throw new AggregateError(cleanupErrors, 'One or more recorded license cleanup operations failed.');
   }
 
   await rm(STATE_FILE, { force: true });
-  await rm(path.join(packageRoot, 'LICENSES'), { force: true, recursive: false }).catch(() => {});
   log('Removed temporary shared license artifacts after packaging.');
 }
 

--- a/src/public/lib/hexo-renderer-asciidoc/scripts/validate-linked-example.mjs
+++ b/src/public/lib/hexo-renderer-asciidoc/scripts/validate-linked-example.mjs
@@ -1,0 +1,231 @@
+/**
+ * Copyright 2015 Shuai Zhang
+ * SPDX-License-Identifier: LGPL-3.0-or-later WITH LGPL-3.0-linking-exception
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import {
+  assert,
+  captureCleanupFailure,
+  capturePathStates,
+  createCommandRunner,
+  createEvidenceRecorder,
+  injectValidationFault,
+  MONOREPO_ROOT,
+  PACKAGE_ROOT,
+  parseArgs,
+  removePath,
+  restorePathStates,
+  sha256File,
+  throwValidationFailures,
+  verifyDistInventory,
+} from './validation-utils.mjs';
+
+const EXAMPLE_ROOT = path.join(PACKAGE_ROOT, 'examples', 'hexo-site');
+const DIST_DIRECTORY = path.join(PACKAGE_ROOT, 'dist');
+const README_PATH = path.join(EXAMPLE_ROOT, 'README.md');
+const EXAMPLE_RESTORED_PATHS = ['package.json', 'pnpm-lock.yaml'];
+const EXAMPLE_GENERATED_PATHS = ['node_modules', 'public', 'db.json', '.cache'];
+const PACKAGE_RELATIVE_PATH = path.relative(MONOREPO_ROOT, PACKAGE_ROOT).replaceAll(path.sep, '/');
+const EXAMPLE_RELATIVE_PATH = path.relative(MONOREPO_ROOT, EXAMPLE_ROOT).replaceAll(path.sep, '/');
+const EXPECTED_DOCUMENTED_COMMANDS = [
+  'mise trust',
+  'mise exec -- pnpm install --frozen-lockfile',
+  `mise exec -- pnpm --dir ${PACKAGE_RELATIVE_PATH} run build`,
+  `mise exec -- pnpm --dir ${EXAMPLE_RELATIVE_PATH} install --frozen-lockfile`,
+  `mise exec -- pnpm --dir ${EXAMPLE_RELATIVE_PATH} run generate`,
+];
+const DOCUMENTED_COMMAND_ARGUMENTS = [
+  ['mise', ['trust']],
+  ['mise', ['exec', '--', 'pnpm', 'install', '--frozen-lockfile']],
+  ['mise', ['exec', '--', 'pnpm', '--dir', PACKAGE_RELATIVE_PATH, 'run', 'build']],
+  ['mise', ['exec', '--', 'pnpm', '--dir', EXAMPLE_RELATIVE_PATH, 'install', '--frozen-lockfile']],
+  ['mise', ['exec', '--', 'pnpm', '--dir', EXAMPLE_RELATIVE_PATH, 'run', 'generate']],
+];
+const PLUGIN_LOAD_FAILURE =
+  /No renderer found for file:.*\.adoc|Plugin load failed:\s*hexo-renderer-asciidoc|(?:failed|unable) to load.*hexo-renderer-asciidoc|Cannot find module.*dist\/index/isu;
+const RAW_ASCIIDOC = /= Meet `hexo-renderer-asciidoc`|= About this demo site|:toc: macro|== Goals/u;
+
+const readDocumentedCommands = () => {
+  const readme = readFileSync(README_PATH, 'utf8');
+  const match =
+    /<!-- linked-example-validation-sequence:start -->\s*```bash\s*([\s\S]*?)\s*```\s*<!-- linked-example-validation-sequence:end -->/u.exec(
+      readme,
+    );
+  assert(match, 'Example README is missing the linked-example validation sequence.');
+  return match[1]
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .filter(Boolean);
+};
+
+const runDocumentedCommand = (runner, index, label) => {
+  const [command, commandArgs] = DOCUMENTED_COMMAND_ARGUMENTS[index];
+  return runner.runResult(command, commandArgs, {
+    cwd: MONOREPO_ROOT,
+    label,
+  });
+};
+
+const removeExampleGeneratedPaths = () => {
+  for (const generatedPath of EXAMPLE_GENERATED_PATHS) {
+    removePath(path.join(EXAMPLE_ROOT, generatedPath));
+  }
+};
+
+const readOutputIfPresent = (outputPath) => (existsSync(outputPath) ? readFileSync(outputPath, 'utf8') : '');
+
+const main = () => {
+  const args = parseArgs(process.argv.slice(2));
+  const evidenceDirectory = args.get('--evidence-dir');
+  const repositoryRoot = path.resolve(args.get('--repository-root') ?? MONOREPO_ROOT);
+  const sessionRoot = path.resolve(args.get('--session-root') ?? evidenceDirectory ?? repositoryRoot);
+  const evidencePathOptions = { repositoryRoot, sessionRoot };
+  let recorder;
+  let runner;
+  let initialExampleState;
+  let initialGeneratedState;
+  let initialDistState;
+  let operationError;
+  const cleanupErrors = [];
+  try {
+    recorder = createEvidenceRecorder(evidenceDirectory, evidencePathOptions);
+    runner = createCommandRunner(evidenceDirectory, undefined, evidencePathOptions);
+    initialExampleState = capturePathStates(EXAMPLE_ROOT, EXAMPLE_RESTORED_PATHS);
+    injectValidationFault('linked-example:after-example-state');
+    initialGeneratedState = capturePathStates(EXAMPLE_ROOT, EXAMPLE_GENERATED_PATHS);
+    initialDistState = capturePathStates(PACKAGE_ROOT, ['dist']);
+    for (const generatedPath of EXAMPLE_GENERATED_PATHS) {
+      assert(
+        initialGeneratedState[generatedPath].type === 'missing',
+        `Example ${generatedPath} must be absent before linked-example validation.`,
+      );
+    }
+
+    const documentedCommands = readDocumentedCommands();
+    assert(
+      JSON.stringify(documentedCommands) === JSON.stringify(EXPECTED_DOCUMENTED_COMMANDS),
+      `Example README command sequence differs from validation: ${JSON.stringify(documentedCommands)}.`,
+    );
+
+    removePath(DIST_DIRECTORY);
+    assert(!existsSync(DIST_DIRECTORY), 'dist/ must be absent before the linked-example package build.');
+
+    // Negative control: trust the clean checkout, then use the example commands with the parent build omitted.
+    const negativeTrust = runner.runResult('mise', ['trust'], {
+      cwd: MONOREPO_ROOT,
+      label: 'negative-mise-trust',
+    });
+    assert(negativeTrust.exitCode === 0, 'Negative-control mise trust failed.');
+    const negativeInstall = runner.runResult(
+      'mise',
+      ['exec', '--', 'pnpm', '--dir', EXAMPLE_RELATIVE_PATH, 'install', '--frozen-lockfile'],
+      { cwd: MONOREPO_ROOT, label: 'negative-example-install-without-parent-build' },
+    );
+    assert(negativeInstall.exitCode === 0, 'Negative-control example install failed before Hexo could be tested.');
+    const negativeGenerate = runner.runResult(
+      'mise',
+      ['exec', '--', 'pnpm', '--dir', EXAMPLE_RELATIVE_PATH, 'run', 'generate'],
+      { cwd: MONOREPO_ROOT, label: 'negative-example-generate-without-parent-build' },
+    );
+    const negativeIndex = readOutputIfPresent(path.join(EXAMPLE_ROOT, 'public', 'index.html'));
+    const negativeAbout = readOutputIfPresent(path.join(EXAMPLE_ROOT, 'public', 'about', 'index.html'));
+    const negativeOutput = `${negativeGenerate.stdout}\n${negativeGenerate.stderr}`;
+    const negativePluginLoadFailure = PLUGIN_LOAD_FAILURE.test(negativeOutput);
+    const negativeRawAsciidoc = RAW_ASCIIDOC.test(`${negativeIndex}\n${negativeAbout}`);
+    const negativeMissingRenderedOutput =
+      !negativeIndex.includes('Meet hexo-renderer-asciidoc') ||
+      !negativeAbout.includes('hexo-renderer-asciidoc integration');
+    assert(
+      negativeGenerate.exitCode !== 0 ||
+        negativePluginLoadFailure ||
+        negativeRawAsciidoc ||
+        negativeMissingRenderedOutput,
+      'Hexo unexpectedly rendered the linked AsciiDoc example without the documented parent-package build.',
+    );
+    assert(
+      negativePluginLoadFailure || negativeRawAsciidoc,
+      'Negative-control output did not expose a plugin-load failure or raw AsciiDoc.',
+    );
+    removeExampleGeneratedPaths();
+    assert(!existsSync(DIST_DIRECTORY), 'Negative control unexpectedly built the parent package.');
+
+    // Execute the README sequence verbatim and in order after restoring clean generated state.
+    const trust = runDocumentedCommand(runner, 0, 'documented-mise-trust');
+    assert(trust.exitCode === 0, `${documentedCommands[0]} failed with exit code ${trust.exitCode}.`);
+    const rootInstall = runDocumentedCommand(runner, 1, 'documented-root-frozen-install');
+    assert(rootInstall.exitCode === 0, `${documentedCommands[1]} failed with exit code ${rootInstall.exitCode}.`);
+    const buildResult = runDocumentedCommand(runner, 2, 'documented-parent-package-build');
+    assert(buildResult.exitCode === 0, `${documentedCommands[2]} failed with exit code ${buildResult.exitCode}.`);
+    const distFiles = verifyDistInventory(DIST_DIRECTORY);
+
+    const exampleInstall = runDocumentedCommand(runner, 3, 'documented-example-frozen-install');
+    assert(exampleInstall.exitCode === 0, `${documentedCommands[3]} failed with exit code ${exampleInstall.exitCode}.`);
+    const exampleGenerate = runDocumentedCommand(runner, 4, 'documented-example-generate');
+    assert(
+      exampleGenerate.exitCode === 0,
+      `${documentedCommands[4]} failed with exit code ${exampleGenerate.exitCode}.`,
+    );
+
+    const expectedPages = [
+      path.join(EXAMPLE_ROOT, 'public', 'index.html'),
+      path.join(EXAMPLE_ROOT, 'public', 'about', 'index.html'),
+    ];
+    for (const page of expectedPages) {
+      assert(existsSync(page), `Example output is missing ${path.relative(EXAMPLE_ROOT, page)}.`);
+    }
+    const indexHtml = readFileSync(expectedPages[0], 'utf8');
+    const aboutHtml = readFileSync(expectedPages[1], 'utf8');
+    assert(indexHtml.includes('AsciiDoc'), 'Example home page does not contain the expected AsciiDoc marker.');
+    assert(aboutHtml.includes('hexo-renderer-asciidoc'), 'Example about page does not contain the package marker.');
+    assert(!indexHtml.includes('[object Promise]'), 'Example home page leaked [object Promise].');
+    assert(!aboutHtml.includes('[object Promise]'), 'Example about page leaked [object Promise].');
+    assert(
+      !PLUGIN_LOAD_FAILURE.test(`${exampleGenerate.stdout}\n${exampleGenerate.stderr}`),
+      'Documented example generation reported a renderer plugin-load failure.',
+    );
+    assert(!RAW_ASCIIDOC.test(indexHtml), 'Example home page contains raw AsciiDoc.');
+    assert(!RAW_ASCIIDOC.test(aboutHtml), 'Example about page contains raw AsciiDoc.');
+
+    const summary = {
+      commands: runner.commands,
+      documentedCommands,
+      negativeControl: {
+        generateExitCode: negativeGenerate.exitCode,
+        missingRenderedOutput: negativeMissingRenderedOutput,
+        pluginLoadFailure: negativePluginLoadFailure,
+        rawAsciidoc: negativeRawAsciidoc,
+      },
+      setup: {
+        distAbsentBeforeBuild: true,
+        distFiles,
+        freshBuildCommand: documentedCommands[2],
+      },
+      outputs: expectedPages.map((page) => ({
+        path: path.relative(EXAMPLE_ROOT, page),
+        sha256: sha256File(page),
+      })),
+    };
+    recorder.writeJson('results/linked-example-summary.json', summary);
+    process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+  } catch (error) {
+    operationError = error;
+  } finally {
+    if (initialGeneratedState) {
+      captureCleanupFailure(cleanupErrors, () => restorePathStates(EXAMPLE_ROOT, initialGeneratedState));
+    }
+    if (initialExampleState) {
+      captureCleanupFailure(cleanupErrors, () => {
+        restorePathStates(EXAMPLE_ROOT, initialExampleState);
+        injectValidationFault('linked-example:after-example-state-cleanup');
+      });
+    }
+    if (initialDistState) {
+      captureCleanupFailure(cleanupErrors, () => restorePathStates(PACKAGE_ROOT, initialDistState));
+    }
+  }
+  throwValidationFailures(operationError, cleanupErrors, 'Linked-example validation or cleanup failed.');
+};
+
+main();

--- a/src/public/lib/hexo-renderer-asciidoc/scripts/validate-packed-artifact.mjs
+++ b/src/public/lib/hexo-renderer-asciidoc/scripts/validate-packed-artifact.mjs
@@ -1,0 +1,896 @@
+/**
+ * Copyright 2015 Shuai Zhang
+ * SPDX-License-Identifier: LGPL-3.0-or-later WITH LGPL-3.0-linking-exception
+ */
+
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import {
+  assert,
+  captureCleanupFailure,
+  capturePathStates,
+  collectTarballLicenseChecks,
+  createCommandRunner,
+  createEvidenceRecorder,
+  createFixturePackageJson,
+  createTempDirectory,
+  EXPECTED_ROOT_DIST_FILES,
+  findCommandRecord,
+  getPackEnvironment,
+  injectValidationFault,
+  lexistsSync,
+  listDirectoryFiles,
+  MONOREPO_ROOT,
+  OPTIONAL_ROOT_DIST_FILES,
+  PACK_LIFECYCLE_PATHS,
+  PACKAGE_ROOT,
+  PLACEHOLDER_VERSION,
+  parseArgs,
+  pathStatesEqual,
+  ROOT_LICENSE_ITEMS,
+  readInstalledTypescriptVersion,
+  readJsonFile,
+  readTarEntries,
+  readTarEntryBuffer,
+  readTarEntryText,
+  removePath,
+  requireExactPnpmVersion,
+  restorePathStates,
+  sha256Buffer,
+  sha256File,
+  throwValidationFailures,
+  verifyDeclarationMapContents,
+  verifyDistInventory,
+  verifyExactTarInventory,
+  verifyPackCleanup,
+  writeJsonFile,
+  writeTextFile,
+} from './validation-utils.mjs';
+
+const DIST_DIRECTORY = path.join(PACKAGE_ROOT, 'dist');
+const README_NPM_PATH = path.join(PACKAGE_ROOT, 'README.npm.md');
+const PACKAGE_JSON_PATH = path.join(PACKAGE_ROOT, 'package.json');
+const PROBE_DOCUMENT = `== Packed Artifact ==
+
+This document proves the packed ESM and CommonJS entry points stay aligned.
+
+Marker for Artifact.
+
+[source,javascript]
+----
+const value = { nested: true };
+----
+`;
+
+const createEsmRuntimeProbe =
+  () => `import packageDefault, { registerRenderer, renderer } from 'hexo-renderer-asciidoc';
+const sample = ${JSON.stringify(PROBE_DOCUMENT)};
+const registrations = [];
+const registerResult = registerRenderer({
+  extend: {
+    renderer: {
+      register(...args) {
+        registrations.push(args);
+      },
+    },
+  },
+});
+const outputs = {
+  default: await packageDefault({ text: sample }),
+  named: await renderer({ text: sample }),
+  registered: await Promise.all(
+    registrations.map(async ([extension, outputFormat, registeredRenderer, sync]) => ({
+      extension,
+      html: await registeredRenderer({ text: sample }),
+      outputFormat,
+      rendererIsNamed: registeredRenderer === renderer,
+      sync,
+    })),
+  ),
+};
+process.stdout.write(
+  JSON.stringify({
+    defaultEqualsNamed: packageDefault === renderer,
+    defaultType: typeof packageDefault,
+    registerRendererType: typeof registerRenderer,
+    registerResultIsUndefined: registerResult === undefined,
+    rendererType: typeof renderer,
+    outputs,
+  }),
+);
+`;
+
+const createCjsRuntimeProbe = () => `const pkg = require('hexo-renderer-asciidoc');
+const sample = ${JSON.stringify(PROBE_DOCUMENT)};
+const registrations = [];
+const registerResult = pkg.registerRenderer({
+  extend: {
+    renderer: {
+      register(...args) {
+        registrations.push(args);
+      },
+    },
+  },
+});
+(async () => {
+  process.stdout.write(
+    JSON.stringify({
+      defaultEqualsNamed: pkg.default === pkg.renderer,
+      defaultType: typeof pkg.default,
+      keys: Object.keys(pkg).sort(),
+      registerRendererType: typeof pkg.registerRenderer,
+      registerResultIsUndefined: registerResult === undefined,
+      rendererType: typeof pkg.renderer,
+      outputs: {
+        default: await pkg.default({ text: sample }),
+        named: await pkg.renderer({ text: sample }),
+        registered: await Promise.all(
+          registrations.map(async ([extension, outputFormat, registeredRenderer, sync]) => ({
+            extension,
+            html: await registeredRenderer({ text: sample }),
+            outputFormat,
+            rendererIsNamed: registeredRenderer === pkg.renderer,
+            sync,
+          })),
+        ),
+      },
+    }),
+  );
+})();
+`;
+
+const createEsmTypesProbe = () => `import renderer, {
+  registerRenderer,
+  renderer as namedRenderer,
+  type Hexo,
+  type Renderer,
+  type RendererData,
+  type RendererLocals,
+} from 'hexo-renderer-asciidoc';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
+    ? (<T>() => T extends B ? 1 : 2) extends (<T>() => T extends A ? 1 : 2)
+      ? true
+      : false
+    : false;
+type Expect<T extends true> = T;
+
+const data: RendererData = { text: '== Bundler ==' };
+const locals: RendererLocals = {};
+const promise = renderer(data, locals);
+const namedPromise = namedRenderer(data, locals);
+
+type _DefaultPromise = Expect<Equal<typeof promise, Promise<string>>>;
+type _NamedPromise = Expect<Equal<typeof namedPromise, Promise<string>>>;
+type _RegisterRendererReturn = Expect<Equal<ReturnType<typeof registerRenderer>, void>>;
+
+const typedRenderer: Renderer = renderer;
+declare const hexo: Hexo;
+registerRenderer(hexo);
+void typedRenderer;
+void promise;
+void namedPromise;
+`;
+
+const createCjsTypesProbe = () => `import plugin = require('hexo-renderer-asciidoc');
+import type { Hexo, Renderer, RendererData, RendererLocals } from 'hexo-renderer-asciidoc';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
+    ? (<T>() => T extends B ? 1 : 2) extends (<T>() => T extends A ? 1 : 2)
+      ? true
+      : false
+    : false;
+type Expect<T extends true> = T;
+
+const data: RendererData = { text: '== CommonJS ==' };
+const locals: RendererLocals = {};
+const promise = plugin.default(data, locals);
+const namedPromise = plugin.renderer(data, locals);
+
+type _DefaultPromise = Expect<Equal<typeof promise, Promise<string>>>;
+type _NamedPromise = Expect<Equal<typeof namedPromise, Promise<string>>>;
+type _RegisterRendererReturn = Expect<Equal<ReturnType<typeof plugin.registerRenderer>, void>>;
+
+const typedRenderer: Renderer = plugin.renderer;
+declare const hexo: Hexo;
+plugin.registerRenderer(hexo);
+void typedRenderer;
+void promise;
+void namedPromise;
+`;
+
+const createTsconfig = (moduleKind, moduleResolution, includePath) =>
+  `${JSON.stringify(
+    {
+      compilerOptions: {
+        module: moduleKind,
+        moduleResolution,
+        noEmit: true,
+        strict: true,
+        target: 'ES2022',
+        verbatimModuleSyntax: true,
+      },
+      include: [includePath],
+    },
+    null,
+    2,
+  )}\n`;
+
+const createHexoConfig = () => `title: packed-artifact-fixture
+url: https://example.test
+root: /
+theme: false
+highlight:
+  enable: true
+  line_number: false
+  wrap: false
+`;
+
+const createHexoSource = (extension) => `---
+layout: false
+---
+== Packed ${extension} ==
+
+Marker for ${extension}.
+
+[source,javascript]
+----
+const value = { extension: '${extension}' };
+----
+`;
+
+const createHexoLoadProbe = () => `import Hexo from 'hexo';
+import { createRequire } from 'node:module';
+
+const readRoute = (stream) =>
+  new Promise((resolve, reject) => {
+    const chunks = [];
+    stream.on('data', (chunk) => {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk)));
+    });
+    stream.on('error', reject);
+    stream.on('end', () => {
+      resolve(Buffer.concat(chunks).toString('utf8'));
+    });
+  });
+
+const require = createRequire(import.meta.url);
+const pluginPath = require.resolve('hexo-renderer-asciidoc');
+const hexo = new Hexo(process.cwd(), { debug: false, silent: true });
+const errors = [];
+hexo.log.error = (...args) => {
+  errors.push(args.map((value) => String(value)).join(' '));
+};
+await hexo.init();
+const renderable = {
+  ad: hexo.render.isRenderable('packed-ad/index.ad'),
+  adoc: hexo.render.isRenderable('packed-adoc/index.adoc'),
+  asciidoc: hexo.render.isRenderable('packed-asciidoc/index.asciidoc'),
+};
+await hexo.load();
+const renderableAfterLoad = {
+  ad: hexo.render.isRenderable('packed-ad/index.ad'),
+  adoc: hexo.render.isRenderable('packed-adoc/index.adoc'),
+  asciidoc: hexo.render.isRenderable('packed-asciidoc/index.asciidoc'),
+};
+const routes = {};
+for (const route of ['packed-ad/index.html', 'packed-adoc/index.html', 'packed-asciidoc/index.html']) {
+  const stream = hexo.route.get(route);
+  routes[route] = stream ? await readRoute(stream) : null;
+}
+await hexo.loadPlugin(pluginPath);
+const renderableAfterManualLoad = {
+  ad: hexo.render.isRenderable('packed-ad/index.ad'),
+  adoc: hexo.render.isRenderable('packed-adoc/index.adoc'),
+  asciidoc: hexo.render.isRenderable('packed-asciidoc/index.asciidoc'),
+};
+await hexo.exit();
+process.stdout.write(JSON.stringify({ errors, pluginPath, renderable, renderableAfterLoad, renderableAfterManualLoad, routes }));
+`;
+
+const TYPE_PROBE_DEFINITIONS = [
+  {
+    key: 'modernEsmBundler',
+    label: 'types-probe-esm',
+    tsconfigPath: 'probes/tsconfig.esm.json',
+    sourceFile: 'types-esm.ts',
+    mode: 'modern-esm-bundler',
+    module: 'ESNext',
+    moduleResolution: 'Bundler',
+    exactAssertions: [
+      'default renderer(data, locals) infers Promise<string>',
+      'named renderer(data, locals) infers Promise<string>',
+      'registerRenderer(...) returns void',
+      'Hexo, Renderer, RendererData, and RendererLocals import successfully',
+    ],
+  },
+  {
+    key: 'node16',
+    label: 'types-probe-node16',
+    tsconfigPath: 'probes/tsconfig.node16.json',
+    sourceFile: 'types-cjs.cts',
+    mode: 'commonjs-compatible',
+    module: 'Node16',
+    moduleResolution: 'Node16',
+    exactAssertions: [
+      'CommonJS default renderer(data, locals) infers Promise<string>',
+      'CommonJS named renderer(data, locals) infers Promise<string>',
+      'plugin.registerRenderer(...) returns void',
+      'Hexo, Renderer, RendererData, and RendererLocals import successfully',
+    ],
+  },
+  {
+    key: 'nodeNext',
+    label: 'types-probe-nodenext',
+    tsconfigPath: 'probes/tsconfig.nodenext.json',
+    sourceFile: 'types-cjs.cts',
+    mode: 'commonjs-compatible',
+    module: 'NodeNext',
+    moduleResolution: 'NodeNext',
+    exactAssertions: [
+      'CommonJS default renderer(data, locals) infers Promise<string>',
+      'CommonJS named renderer(data, locals) infers Promise<string>',
+      'plugin.registerRenderer(...) returns void',
+      'Hexo, Renderer, RendererData, and RendererLocals import successfully',
+    ],
+  },
+];
+
+const createLoadMarkerWrappers = (installedPackageRoot) => {
+  const distDirectory = path.join(installedPackageRoot, 'dist');
+  const markerLog = path.join(installedPackageRoot, '.load-markers.log');
+  const esmPath = path.join(distDirectory, 'index.js');
+  const esmOriginalPath = path.join(distDirectory, 'index.original.js');
+  const cjsPath = path.join(distDirectory, 'index.cjs');
+  const cjsOriginalPath = path.join(distDirectory, 'index.original.cjs');
+
+  renameSync(esmPath, esmOriginalPath);
+  renameSync(cjsPath, cjsOriginalPath);
+
+  writeFileSync(
+    esmPath,
+    `import { appendFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+const markerLog = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', '.load-markers.log');
+appendFileSync(markerLog, 'esm\\n');
+export * from './index.original.js';
+export { default } from './index.original.js';
+`,
+    'utf8',
+  );
+  writeFileSync(
+    cjsPath,
+    `const { appendFileSync } = require('node:fs');
+const path = require('node:path');
+appendFileSync(path.join(__dirname, '..', '.load-markers.log'), 'cjs\\n');
+module.exports = require('./index.original.cjs');
+`,
+    'utf8',
+  );
+  return markerLog;
+};
+
+const validateRenderedHtml = (html, extension) => {
+  assert(html.includes(`Packed ${extension}`), `Missing heading marker for ${extension}.`);
+  assert(html.includes(`Marker for ${extension}.`), `Missing body marker for ${extension}.`);
+  assert(html.includes('<code class="highlight javascript">'), `Missing highlighted code block for ${extension}.`);
+  assert(html.includes('&#123;'), `Missing escaped opening brace for ${extension}.`);
+  assert(html.includes('&#125;'), `Missing escaped closing brace for ${extension}.`);
+  assert(!html.includes('[object Promise]'), `Rendered HTML leaked [object Promise] for ${extension}.`);
+};
+
+const main = () => {
+  const args = parseArgs(process.argv.slice(2));
+  const evidenceDirectory = args.get('--evidence-dir');
+  const repositoryRoot = path.resolve(args.get('--repository-root') ?? MONOREPO_ROOT);
+  const sessionRoot = path.resolve(args.get('--session-root') ?? evidenceDirectory ?? repositoryRoot);
+  const evidencePathOptions = { repositoryRoot, sessionRoot };
+  const providedTarballPath = args.get('--tarball-path');
+  const providedReadmeSourcePath = args.get('--readme-source-path');
+  let operationError;
+  let summary;
+  let recorder;
+  let runner;
+  let pnpmVersion;
+  let typescriptVersion;
+  let tempRoot;
+  let artifactsDirectory;
+  let consumerDirectory;
+  let initialLifecycleState;
+  let initialDistState;
+  let initialPackageJson;
+  let initialReadme;
+  let initialReadmeNpm;
+  let normalPackCleanupVerified = providedTarballPath !== undefined;
+  const cleanupErrors = [];
+  try {
+    recorder = createEvidenceRecorder(evidenceDirectory, evidencePathOptions);
+    runner = createCommandRunner(evidenceDirectory, undefined, evidencePathOptions);
+    pnpmVersion = requireExactPnpmVersion();
+    typescriptVersion = readInstalledTypescriptVersion();
+    tempRoot = createTempDirectory('hexo-renderer-asciidoc-pack-');
+    injectValidationFault('packed-artifact:after-temp-directory');
+    artifactsDirectory = path.join(tempRoot, 'artifacts');
+    consumerDirectory = path.join(tempRoot, 'consumer');
+    initialLifecycleState = capturePathStates(PACKAGE_ROOT, PACK_LIFECYCLE_PATHS);
+    initialDistState = capturePathStates(PACKAGE_ROOT, ['dist']);
+    initialPackageJson = readFileSync(PACKAGE_JSON_PATH);
+    initialReadme = readFileSync(path.join(PACKAGE_ROOT, 'README.md'));
+    initialReadmeNpm = existsSync(README_NPM_PATH) ? readFileSync(README_NPM_PATH) : undefined;
+    mkdirSync(artifactsDirectory, { recursive: true });
+    mkdirSync(consumerDirectory, { recursive: true });
+
+    let distFiles = [];
+    let tarballPath = providedTarballPath ? path.resolve(providedTarballPath) : '';
+    let performedFreshBuild = false;
+    let packMode = 'provided-tarball';
+    if (providedTarballPath) {
+      assert(existsSync(tarballPath), `Provided tarball does not exist: ${tarballPath}`);
+    } else {
+      runner.run('pnpm', ['run', 'test'], { label: 'candidate-tests' });
+      runner.run('pnpm', ['run', 'typecheck'], { label: 'candidate-typecheck' });
+      removePath(DIST_DIRECTORY);
+      assert(!existsSync(DIST_DIRECTORY), 'dist/ must be absent before the fresh validation build.');
+      runner.run('pnpm', ['run', 'build'], { label: 'build-fresh' });
+      distFiles = verifyDistInventory(DIST_DIRECTORY);
+      performedFreshBuild = true;
+      packMode = 'pnpm-pack';
+
+      const packEnvironment = getPackEnvironment();
+      runner.run('pnpm', ['pack', '--pack-destination', artifactsDirectory], {
+        env: packEnvironment,
+        label: 'pnpm-pack',
+      });
+
+      const tarballs = listDirectoryFiles(artifactsDirectory).filter((entry) => entry.endsWith('.tgz'));
+      assert(tarballs.length === 1, `Expected one pnpm tarball, found ${tarballs.length}.`);
+      tarballPath = path.join(artifactsDirectory, tarballs[0]);
+      verifyPackCleanup({
+        expectedLifecycleState: initialLifecycleState,
+        expectedPackageJson: initialPackageJson,
+        expectedReadme: initialReadme,
+        expectedReadmeNpm: initialReadmeNpm,
+      });
+      normalPackCleanupVerified = true;
+    }
+    const tarballHash = sha256File(tarballPath);
+
+    const tarEntries = readTarEntries(tarballPath);
+    const packedManifest = JSON.parse(readTarEntryText(tarballPath, 'package/package.json'));
+    const packedReadme = readTarEntryBuffer(tarballPath, 'package/README.md');
+    const packedChangelog = readTarEntryBuffer(tarballPath, 'package/CHANGELOG.md');
+    const repositoryReadme = readFileSync(
+      providedReadmeSourcePath ? path.resolve(providedReadmeSourcePath) : README_NPM_PATH,
+    );
+    const repositoryChangelog = readFileSync(path.join(PACKAGE_ROOT, 'CHANGELOG.md'));
+    const packedDistFiles = tarEntries
+      .filter((entry) => entry.startsWith('package/dist/'))
+      .map((entry) => entry.slice('package/dist/'.length))
+      .filter((entry) => entry.length > 0 && !entry.includes('/'))
+      .sort();
+    if (!performedFreshBuild) {
+      distFiles = packedDistFiles;
+    }
+    assert(Buffer.compare(packedReadme, repositoryReadme) === 0, 'Packed README.md does not byte-match README.npm.md.');
+    assert(
+      Buffer.compare(packedChangelog, repositoryChangelog) === 0,
+      'Packed CHANGELOG.md does not byte-match the package CHANGELOG.md.',
+    );
+    assert(!tarEntries.includes('package/README.npm.md'), 'README.npm.md must not be published.');
+    verifyExactTarInventory(
+      tarEntries,
+      [
+        'package/package.json',
+        'package/README.md',
+        'package/CHANGELOG.md',
+        ...ROOT_LICENSE_ITEMS.map((licenseItem) => `package/${licenseItem}`),
+        ...EXPECTED_ROOT_DIST_FILES.map((distFile) => `package/dist/${distFile}`),
+      ],
+      OPTIONAL_ROOT_DIST_FILES.map((distFile) => `package/dist/${distFile}`),
+    );
+    for (const distFile of EXPECTED_ROOT_DIST_FILES) {
+      assert(tarEntries.includes(`package/dist/${distFile}`), `Tarball is missing dist/${distFile}.`);
+    }
+    // Nested dist entries (paths containing '/') are forbidden.
+    const nestedTarDistEntries = tarEntries
+      .filter((entry) => entry.startsWith('package/dist/'))
+      .map((entry) => entry.slice('package/dist/'.length))
+      .filter((entry) => entry.length > 0 && entry.includes('/'));
+    assert(
+      nestedTarDistEntries.length === 0,
+      `Unexpected nested dist entries in tarball: ${nestedTarDistEntries.join(', ')}`,
+    );
+    for (const optionalDistFile of OPTIONAL_ROOT_DIST_FILES) {
+      if (distFiles.includes(optionalDistFile)) {
+        assert(
+          tarEntries.includes(`package/dist/${optionalDistFile}`),
+          `Tarball is missing optional dist/${optionalDistFile}.`,
+        );
+        const declarationName = optionalDistFile.slice(0, -'.map'.length);
+        verifyDeclarationMapContents(
+          readTarEntryBuffer(tarballPath, `package/dist/${declarationName}`),
+          readTarEntryBuffer(tarballPath, `package/dist/${optionalDistFile}`),
+          declarationName,
+          optionalDistFile,
+        );
+      }
+    }
+    const unexpectedPackedDistFiles = packedDistFiles.filter(
+      (file) => !EXPECTED_ROOT_DIST_FILES.includes(file) && !OPTIONAL_ROOT_DIST_FILES.includes(file),
+    );
+    assert(
+      unexpectedPackedDistFiles.length === 0,
+      `Unexpected dist artifacts in tarball: ${unexpectedPackedDistFiles.join(', ')}`,
+    );
+    const licenseChecks = collectTarballLicenseChecks(tarballPath, MONOREPO_ROOT);
+    for (const licenseCheck of licenseChecks) {
+      assert(tarEntries.includes(`package/${licenseCheck.path}`), `Tarball is missing ${licenseCheck.path}.`);
+      assert(licenseCheck.byteEqual, `Packed ${licenseCheck.path} does not byte-match monorepo root.`);
+    }
+    const forbiddenTarballEntries = tarEntries.filter(
+      (entry) =>
+        /^package\/(?:src|test|tests|node_modules)\//.test(entry) ||
+        /(?:fixture|fixtures|tmp|temp)/.test(entry) ||
+        /(?:sync-licenses-backup|npm-backup)/.test(entry),
+    );
+    assert(forbiddenTarballEntries.length === 0, `Unexpected tarball entries: ${forbiddenTarballEntries.join(', ')}`);
+
+    assert(packedManifest.main === './dist/index.cjs', 'Packed main must stay on the CommonJS artifact.');
+    assert(
+      packedManifest.version !== PLACEHOLDER_VERSION,
+      'Packed version must be the non-placeholder version stamped by prepack/NBGV.',
+    );
+    assert(packedManifest.types === './dist/index.d.ts', 'Packed types must point at the ESM declarations.');
+    assert(packedManifest.engines?.node === '>=20.19.0', 'Packed engines.node must remain >=20.19.0.');
+    assert(
+      packedManifest.dependencies?.['@asciidoctor/core'] === '4.0.4',
+      'Packed dependency @asciidoctor/core must be 4.0.4.',
+    );
+    assert(!('asciidoctor' in (packedManifest.dependencies ?? {})), 'Packed manifest must not depend on asciidoctor.');
+    assert(
+      packedManifest.exports?.['.']?.import?.default === './dist/index.js',
+      'exports.import.default must point to dist/index.js.',
+    );
+    assert(
+      packedManifest.exports?.['.']?.import?.types === './dist/index.d.ts',
+      'exports.import.types must point to dist/index.d.ts.',
+    );
+    assert(
+      packedManifest.exports?.['.']?.require?.default === './dist/index.cjs',
+      'exports.require.default must point to dist/index.cjs.',
+    );
+    assert(
+      packedManifest.exports?.['.']?.require?.types === './dist/index.d.cts',
+      'exports.require.types must point to dist/index.d.cts.',
+    );
+    assert(
+      packedManifest.exports?.['.']?.default === './dist/index.js',
+      'exports.default must point to dist/index.js.',
+    );
+
+    const fixturePackageJson = createFixturePackageJson(
+      providedTarballPath ? `file:${tarballPath}` : `file:../artifacts/${path.basename(tarballPath)}`,
+      typescriptVersion,
+    );
+    writeJsonFile(path.join(consumerDirectory, 'package.json'), fixturePackageJson);
+    recorder.writeJson('inputs/packed-consumer.package.json', fixturePackageJson);
+    runner.run('pnpm', ['install', '--lockfile-only', '--ignore-scripts'], {
+      cwd: consumerDirectory,
+      label: 'consumer-install-lockfile-only',
+    });
+    const consumerLockPath = path.join(consumerDirectory, 'pnpm-lock.yaml');
+    const consumerLock = readFileSync(consumerLockPath);
+    recorder.writeBuffer('inputs/packed-consumer.pnpm-lock.yaml', consumerLock);
+    runner.run('pnpm', ['install', '--frozen-lockfile', '--ignore-scripts'], {
+      cwd: consumerDirectory,
+      label: 'consumer-install-frozen',
+    });
+    const resolvedGraph = JSON.parse(
+      runner.run('pnpm', ['list', '--json', '--depth', 'Infinity'], {
+        cwd: consumerDirectory,
+        label: 'consumer-resolved-graph',
+      }),
+    );
+
+    const installedPackageRoot = path.join(consumerDirectory, 'node_modules', 'hexo-renderer-asciidoc');
+    const probesDirectory = path.join(consumerDirectory, 'probes');
+    mkdirSync(probesDirectory, { recursive: true });
+    const probeFiles = {
+      'runtime-esm.mjs': createEsmRuntimeProbe(),
+      'runtime-cjs.cjs': createCjsRuntimeProbe(),
+      'types-esm.ts': createEsmTypesProbe(),
+      'types-cjs.cts': createCjsTypesProbe(),
+      'hexo-load.mjs': createHexoLoadProbe(),
+      'tsconfig.esm.json': createTsconfig('ESNext', 'Bundler', 'types-esm.ts'),
+      'tsconfig.node16.json': createTsconfig('Node16', 'Node16', 'types-cjs.cts'),
+      'tsconfig.nodenext.json': createTsconfig('NodeNext', 'NodeNext', 'types-cjs.cts'),
+    };
+    for (const [fileName, content] of Object.entries(probeFiles)) {
+      const targetPath = path.join(probesDirectory, fileName);
+      writeTextFile(targetPath, content);
+      recorder.writeText(path.posix.join('inputs', 'probes', fileName), content);
+    }
+
+    for (const typeProbe of TYPE_PROBE_DEFINITIONS) {
+      runner.run('pnpm', ['exec', 'tsc', '--project', typeProbe.tsconfigPath], {
+        cwd: consumerDirectory,
+        label: typeProbe.label,
+      });
+    }
+
+    writeTextFile(path.join(consumerDirectory, '_config.yml'), createHexoConfig());
+    for (const extension of ['ad', 'adoc', 'asciidoc']) {
+      const sourceDirectory = path.join(consumerDirectory, 'source', `packed-${extension}`);
+      mkdirSync(sourceDirectory, { recursive: true });
+      writeTextFile(path.join(sourceDirectory, `index.${extension}`), createHexoSource(extension));
+    }
+    const hexoProbe = JSON.parse(
+      runner.run('node', [path.join('probes', 'hexo-load.mjs')], {
+        cwd: consumerDirectory,
+        label: 'hexo-load',
+      }),
+    );
+
+    const markerLogPath = createLoadMarkerWrappers(installedPackageRoot);
+    removePath(markerLogPath);
+    const esmProbe = JSON.parse(
+      runner.run('node', [path.join('probes', 'runtime-esm.mjs')], {
+        cwd: consumerDirectory,
+        label: 'runtime-probe-esm',
+      }),
+    );
+    const esmMarkers = existsSync(markerLogPath)
+      ? readFileSync(markerLogPath, 'utf8').trim().split('\n').filter(Boolean)
+      : [];
+    removePath(markerLogPath);
+    const cjsProbe = JSON.parse(
+      runner.run('node', [path.join('probes', 'runtime-cjs.cjs')], {
+        cwd: consumerDirectory,
+        label: 'runtime-probe-cjs',
+      }),
+    );
+    const cjsMarkers = existsSync(markerLogPath)
+      ? readFileSync(markerLogPath, 'utf8').trim().split('\n').filter(Boolean)
+      : [];
+
+    assert(esmProbe.defaultType === 'function', 'ESM default import must be callable.');
+    assert(esmProbe.rendererType === 'function', 'ESM named renderer must be callable.');
+    assert(esmProbe.registerRendererType === 'function', 'ESM registerRenderer must be callable.');
+    assert(esmProbe.defaultEqualsNamed === true, 'ESM default export must equal the named renderer.');
+    assert(esmProbe.registerResultIsUndefined === true, 'registerRenderer must return void in ESM.');
+    assert(
+      JSON.stringify(esmMarkers) === JSON.stringify(['esm']),
+      `ESM import delegated to CommonJS: ${esmMarkers.join(', ')}`,
+    );
+    assert(cjsProbe.defaultType === 'function', 'CommonJS default export must be callable.');
+    assert(cjsProbe.rendererType === 'function', 'CommonJS named renderer must be callable.');
+    assert(cjsProbe.registerRendererType === 'function', 'CommonJS registerRenderer must be callable.');
+    assert(cjsProbe.defaultEqualsNamed === true, 'CommonJS default export must equal the named renderer.');
+    assert(cjsProbe.registerResultIsUndefined === true, 'registerRenderer must return void in CommonJS.');
+    assert(
+      JSON.stringify(cjsProbe.keys) === JSON.stringify(['default', 'registerRenderer', 'renderer']),
+      `Unexpected CommonJS export keys: ${cjsProbe.keys.join(', ')}`,
+    );
+    assert(
+      JSON.stringify(cjsMarkers) === JSON.stringify(['cjs']),
+      `CommonJS probe did not load index.cjs directly: ${cjsMarkers.join(', ')}`,
+    );
+    assert(esmProbe.outputs.default === esmProbe.outputs.named, 'ESM default and named outputs diverged.');
+    assert(cjsProbe.outputs.default === cjsProbe.outputs.named, 'CommonJS default and named outputs diverged.');
+    assert(esmProbe.outputs.default === cjsProbe.outputs.default, 'ESM and CommonJS outputs diverged.');
+    for (const output of [
+      esmProbe.outputs.default,
+      esmProbe.outputs.named,
+      cjsProbe.outputs.default,
+      cjsProbe.outputs.named,
+    ]) {
+      assert(typeof output === 'string', 'Expected string HTML output.');
+      validateRenderedHtml(output, 'Artifact');
+    }
+    for (const registration of [...esmProbe.outputs.registered, ...cjsProbe.outputs.registered]) {
+      assert(registration.outputFormat === 'html', 'Registered renderer output format must be html.');
+      assert(registration.rendererIsNamed === true, 'Registered renderer must reference the public renderer function.');
+      assert(registration.sync === false, 'Registered renderer must be asynchronous.');
+      validateRenderedHtml(registration.html, 'Artifact');
+    }
+
+    const publicPages = {};
+    for (const extension of ['ad', 'adoc', 'asciidoc']) {
+      assert(hexoProbe.renderable[extension] === true, `Hexo did not auto-discover .${extension} as renderable.`);
+      const routePath = `packed-${extension}/index.html`;
+      const html = hexoProbe.routes[routePath];
+      assert(typeof html === 'string', `Hexo did not generate output for .${extension}.`);
+      validateRenderedHtml(html, extension);
+      publicPages[extension] = {
+        path: routePath,
+        sha256: sha256Buffer(Buffer.from(html, 'utf8')),
+      };
+    }
+    const typeProbes = Object.fromEntries(
+      TYPE_PROBE_DEFINITIONS.map((typeProbe) => {
+        const commandRecord = findCommandRecord(runner.commands, typeProbe.label);
+        return [
+          typeProbe.key,
+          {
+            command: commandRecord.rendered,
+            exactAssertions: typeProbe.exactAssertions,
+            exitCode: commandRecord.exitCode,
+            label: commandRecord.label,
+            mode: typeProbe.mode,
+            module: typeProbe.module,
+            moduleResolution: typeProbe.moduleResolution,
+            outcome: commandRecord.exitCode === 0 ? 'passed' : 'failed',
+            sourceFile: typeProbe.sourceFile,
+          },
+        ];
+      }),
+    );
+
+    summary = {
+      cleanup: undefined,
+      candidateChecks: {
+        tests: providedTarballPath ? 'not-run-for-provided-tarball' : 'passed',
+        typecheck: providedTarballPath ? 'not-run-for-provided-tarball' : 'passed',
+      },
+      commands: runner.commands,
+      consumer: {
+        fixtureLockSha256: sha256File(consumerLockPath),
+        fixtureManifest: fixturePackageJson,
+        resolvedGraph,
+      },
+      dist: {
+        files: distFiles,
+        freshBuildPerformed: performedFreshBuild,
+        requiredFiles: EXPECTED_ROOT_DIST_FILES,
+        optionalFiles: OPTIONAL_ROOT_DIST_FILES.filter((file) => distFiles.includes(file)),
+      },
+      node: process.version,
+      packedArtifact: {
+        dependencyVersion: packedManifest.dependencies?.['@asciidoctor/core'],
+        engines: packedManifest.engines,
+        exports: packedManifest.exports,
+        inventory: tarEntries,
+        licenseChecks,
+        main: packedManifest.main,
+        mode: packMode,
+        name: packedManifest.name,
+        sha256: tarballHash,
+        version: packedManifest.version,
+      },
+      probes: {
+        commonjs: cjsProbe,
+        esm: esmProbe,
+        hexo: hexoProbe,
+        publicPages,
+        typeProbes,
+      },
+      pnpmVersion,
+      typescriptVersion,
+      worktreePackageJsonVersion: readJsonFile(PACKAGE_JSON_PATH).version,
+    };
+  } catch (error) {
+    operationError = error;
+  } finally {
+    let emergencyRestoreAttempted = false;
+    if (operationError !== undefined && initialLifecycleState) {
+      emergencyRestoreAttempted = true;
+      captureCleanupFailure(cleanupErrors, () => restorePathStates(PACKAGE_ROOT, initialLifecycleState));
+    }
+    if (initialDistState) {
+      captureCleanupFailure(cleanupErrors, () => restorePathStates(PACKAGE_ROOT, initialDistState));
+    }
+    let finalLifecycleState;
+    let finalDistState;
+    let finalPackageJsonBytes;
+    let finalReadmeBytes;
+    let finalReadmeNpmBytes;
+    if (initialLifecycleState) {
+      captureCleanupFailure(cleanupErrors, () => {
+        finalLifecycleState = capturePathStates(PACKAGE_ROOT, PACK_LIFECYCLE_PATHS);
+      });
+    }
+    if (initialDistState) {
+      captureCleanupFailure(cleanupErrors, () => {
+        finalDistState = capturePathStates(PACKAGE_ROOT, ['dist']);
+      });
+    }
+    if (initialPackageJson) {
+      captureCleanupFailure(cleanupErrors, () => {
+        finalPackageJsonBytes = readFileSync(PACKAGE_JSON_PATH);
+      });
+    }
+    if (initialReadme) {
+      captureCleanupFailure(cleanupErrors, () => {
+        finalReadmeBytes = readFileSync(path.join(PACKAGE_ROOT, 'README.md'));
+      });
+    }
+    if (initialReadmeNpm) {
+      captureCleanupFailure(cleanupErrors, () => {
+        finalReadmeNpmBytes = readFileSync(README_NPM_PATH);
+      });
+    }
+    if (tempRoot) {
+      captureCleanupFailure(cleanupErrors, () => {
+        removePath(tempRoot);
+        injectValidationFault('packed-artifact:after-temp-cleanup');
+      });
+    }
+    let cleanup;
+    captureCleanupFailure(cleanupErrors, () => {
+      cleanup = {
+        distStateRestored:
+          initialDistState && finalDistState ? pathStatesEqual(initialDistState, finalDistState) : null,
+        emergencyRestoreAttempted,
+        lifecycleStateRestored:
+          initialLifecycleState && finalLifecycleState
+            ? pathStatesEqual(initialLifecycleState, finalLifecycleState)
+            : null,
+        normalPackCleanupVerified,
+        packageJsonRestored: finalPackageJsonBytes
+          ? Buffer.compare(initialPackageJson, finalPackageJsonBytes) === 0
+          : null,
+        readmeNpmRestored: initialReadmeNpm
+          ? finalReadmeNpmBytes
+            ? Buffer.compare(initialReadmeNpm, finalReadmeNpmBytes) === 0
+            : false
+          : null,
+        readmeRestored: finalReadmeBytes ? Buffer.compare(initialReadme, finalReadmeBytes) === 0 : null,
+        temporaryDirectoryRemovedByHarness: tempRoot ? !lexistsSync(tempRoot) : null,
+      };
+    });
+    if (initialLifecycleState) {
+      captureCleanupFailure(cleanupErrors, () =>
+        assert(
+          cleanup?.lifecycleStateRestored,
+          'Packed-artifact validation did not restore the pack lifecycle state exactly.',
+        ),
+      );
+    }
+    if (initialDistState) {
+      captureCleanupFailure(cleanupErrors, () =>
+        assert(cleanup?.distStateRestored, 'Packed-artifact validation did not restore dist/ exactly.'),
+      );
+    }
+    if (initialPackageJson) {
+      captureCleanupFailure(cleanupErrors, () =>
+        assert(cleanup?.packageJsonRestored, 'Packed-artifact validation did not restore package.json byte-for-byte.'),
+      );
+    }
+    if (initialReadme) {
+      captureCleanupFailure(cleanupErrors, () =>
+        assert(cleanup?.readmeRestored, 'Packed-artifact validation did not restore README.md byte-for-byte.'),
+      );
+    }
+    if (initialReadmeNpm) {
+      captureCleanupFailure(cleanupErrors, () =>
+        assert(cleanup?.readmeNpmRestored, 'Packed-artifact validation did not restore README.npm.md byte-for-byte.'),
+      );
+    }
+    if (tempRoot) {
+      captureCleanupFailure(cleanupErrors, () =>
+        assert(cleanup?.temporaryDirectoryRemovedByHarness, 'Packed-artifact temporary directory was not removed.'),
+      );
+    }
+    if (recorder) {
+      captureCleanupFailure(cleanupErrors, () => recorder.writeJson('results/packed-artifact-cleanup.json', cleanup));
+    }
+    if (summary) {
+      summary.cleanup = cleanup;
+      summary.commands = runner?.commands ?? [];
+      captureCleanupFailure(cleanupErrors, () => {
+        summary.worktreePackageJsonVersion = readJsonFile(PACKAGE_JSON_PATH).version;
+      });
+      if (recorder) {
+        captureCleanupFailure(cleanupErrors, () => recorder.writeJson('results/packed-artifact-summary.json', summary));
+        captureCleanupFailure(cleanupErrors, () => recorder.writeJson('results/evidence-index.json', recorder.writes));
+      }
+      captureCleanupFailure(cleanupErrors, () => process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`));
+    }
+  }
+  throwValidationFailures(operationError, cleanupErrors, 'Packed-artifact validation or lifecycle cleanup failed.');
+};
+
+main();

--- a/src/public/lib/hexo-renderer-asciidoc/scripts/validate-release-pack.mjs
+++ b/src/public/lib/hexo-renderer-asciidoc/scripts/validate-release-pack.mjs
@@ -1,0 +1,647 @@
+/**
+ * Copyright 2015 Shuai Zhang
+ * SPDX-License-Identifier: LGPL-3.0-or-later WITH LGPL-3.0-linking-exception
+ */
+
+import { existsSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
+import path from 'node:path';
+import {
+  assert,
+  captureCleanupFailure,
+  capturePathStates,
+  collectTarballLicenseChecks,
+  createCommandRunner,
+  createEvidenceRecorder,
+  createTempDirectory,
+  EXPECTED_ROOT_DIST_FILES,
+  getPackEnvironment,
+  injectValidationFault,
+  lexistsSync,
+  listDirectoryFiles,
+  MONOREPO_ROOT,
+  OPTIONAL_ROOT_DIST_FILES,
+  PACK_LIFECYCLE_PATHS,
+  PACKAGE_ROOT,
+  PLACEHOLDER_VERSION,
+  parseArgs,
+  pathStatesEqual,
+  ROOT_LICENSE_ITEMS,
+  readJsonFile,
+  readTarEntries,
+  readTarEntryBuffer,
+  readTarEntryText,
+  removePath,
+  requireExactPnpmVersion,
+  restorePathStates,
+  runPlain,
+  sha256Buffer,
+  sha256File,
+  throwValidationFailures,
+  verifyDistInventory,
+  verifyExactTarInventory,
+  verifyPackCleanup,
+} from './validation-utils.mjs';
+
+const PACKAGE_JSON_PATH = path.join(PACKAGE_ROOT, 'package.json');
+const README_NPM_PATH = path.join(PACKAGE_ROOT, 'README.npm.md');
+const DIST_DIRECTORY = path.join(PACKAGE_ROOT, 'dist');
+const PREPARE_NPM_PUBLISH_SCRIPT = path.join(MONOREPO_ROOT, 'eng', 'scripts', 'prepare_npm_publish.py');
+const EXPECTED_SCOPE = '@hcoona';
+
+const verifyTarballCommon = (tarballPath, expectedName, expectedVersion, expectedReadmeBytes) => {
+  const entries = readTarEntries(tarballPath);
+  const manifest = JSON.parse(readTarEntryText(tarballPath, 'package/package.json'));
+  assert(manifest.name === expectedName, `Unexpected packed name for ${path.basename(tarballPath)}: ${manifest.name}`);
+  assert(
+    manifest.version === expectedVersion,
+    `Unexpected packed version for ${path.basename(tarballPath)}: ${manifest.version}; expected ${expectedVersion}.`,
+  );
+  assert(manifest.main === './dist/index.cjs', 'Packed main must stay on dist/index.cjs.');
+  assert(
+    manifest.dependencies?.['@asciidoctor/core'] === '4.0.4',
+    'Packed dependency @asciidoctor/core must remain 4.0.4.',
+  );
+  assert(!('asciidoctor' in (manifest.dependencies ?? {})), 'Packed manifest must not depend on asciidoctor.');
+  assert(!entries.includes('package/README.npm.md'), 'README.npm.md must not be published.');
+  verifyExactTarInventory(
+    entries,
+    [
+      'package/package.json',
+      'package/README.md',
+      'package/CHANGELOG.md',
+      ...ROOT_LICENSE_ITEMS.map((licenseItem) => `package/${licenseItem}`),
+      ...EXPECTED_ROOT_DIST_FILES.map((distFile) => `package/dist/${distFile}`),
+    ],
+    OPTIONAL_ROOT_DIST_FILES.map((distFile) => `package/dist/${distFile}`),
+  );
+  const distFiles = entries
+    .filter((entry) => entry.startsWith('package/dist/'))
+    .map((entry) => entry.slice('package/dist/'.length))
+    .filter((entry) => entry.length > 0 && !entry.includes('/'))
+    .sort();
+  // Nested dist entries (paths containing '/') are forbidden.
+  const nestedDistEntries = entries
+    .filter((entry) => entry.startsWith('package/dist/'))
+    .map((entry) => entry.slice('package/dist/'.length))
+    .filter((entry) => entry.length > 0 && entry.includes('/'));
+  assert(nestedDistEntries.length === 0, `Unexpected nested dist entries: ${nestedDistEntries.join(', ')}`);
+  for (const distFile of EXPECTED_ROOT_DIST_FILES) {
+    assert(entries.includes(`package/dist/${distFile}`), `Packed artifact is missing dist/${distFile}.`);
+  }
+  const unexpectedDistFiles = distFiles.filter(
+    (file) => !EXPECTED_ROOT_DIST_FILES.includes(file) && !OPTIONAL_ROOT_DIST_FILES.includes(file),
+  );
+  assert(unexpectedDistFiles.length === 0, `Unexpected dist artifacts: ${unexpectedDistFiles.join(', ')}`);
+  const forbiddenEntries = entries.filter(
+    (entry) =>
+      /^package\/(?:src|test|tests|node_modules)\//.test(entry) ||
+      /(?:fixture|fixtures|tmp|temp)/.test(entry) ||
+      /(?:sync-licenses-backup|npm-backup)/.test(entry),
+  );
+  assert(forbiddenEntries.length === 0, `Unexpected packaged entries: ${forbiddenEntries.join(', ')}`);
+  const licenseChecks = collectTarballLicenseChecks(tarballPath, MONOREPO_ROOT);
+  for (const licenseCheck of licenseChecks) {
+    assert(entries.includes(`package/${licenseCheck.path}`), `Packed artifact is missing ${licenseCheck.path}.`);
+    assert(licenseCheck.byteEqual, `Packed ${licenseCheck.path} does not byte-match the monorepo root.`);
+  }
+  assert(
+    Buffer.compare(readTarEntryBuffer(tarballPath, 'package/README.md'), expectedReadmeBytes) === 0,
+    'Packed README.md does not byte-match README.npm.md.',
+  );
+  assert(
+    Buffer.compare(
+      readTarEntryBuffer(tarballPath, 'package/CHANGELOG.md'),
+      readFileSync(path.join(PACKAGE_ROOT, 'CHANGELOG.md')),
+    ) === 0,
+    'Packed CHANGELOG.md does not byte-match the package CHANGELOG.md.',
+  );
+  return {
+    distFiles,
+    entries,
+    forbiddenEntries,
+    licenseChecks,
+    manifest,
+    sha256: sha256File(tarballPath),
+  };
+};
+
+const verifyEquivalentTarballContent = (gprTarballPath, npmjsTarballPath, gprSummary, npmjsSummary) => {
+  assert(
+    JSON.stringify(gprSummary.entries) === JSON.stringify(npmjsSummary.entries),
+    'GPR and npmjs tarball inventories differ.',
+  );
+  const normalizedGprManifest = { ...gprSummary.manifest, name: npmjsSummary.manifest.name };
+  assert(
+    JSON.stringify(normalizedGprManifest) === JSON.stringify(npmjsSummary.manifest),
+    'GPR and npmjs package manifests differ beyond the expected package name.',
+  );
+  for (const entry of gprSummary.entries) {
+    if (entry === 'package/package.json') {
+      continue;
+    }
+    assert(
+      Buffer.compare(readTarEntryBuffer(gprTarballPath, entry), readTarEntryBuffer(npmjsTarballPath, entry)) === 0,
+      `GPR and npmjs tarball content differs at ${entry}.`,
+    );
+  }
+  return {
+    identicalEntries: gprSummary.entries.length - 1,
+    inventoryEqual: true,
+    manifestsEqualExceptName: true,
+  };
+};
+
+const main = () => {
+  const args = parseArgs(process.argv.slice(2));
+  const evidenceDirectory = args.get('--evidence-dir');
+  const repositoryRoot = path.resolve(args.get('--repository-root') ?? MONOREPO_ROOT);
+  const sessionRoot = path.resolve(args.get('--session-root') ?? evidenceDirectory ?? repositoryRoot);
+  const evidencePathOptions = { repositoryRoot, sessionRoot };
+  const candidateSha = args.get('--candidate-sha') ?? process.env.CANDIDATE_SHA ?? process.env.EXPECTED_CANDIDATE_SHA;
+  let recorder;
+  let runner;
+  let initialHeadSha;
+  let initialWorktreeStatus;
+  let initialPackageJson;
+  let initialReadme;
+  let initialReadmeNpm;
+  let initialLifecycleState;
+  let initialDistState;
+  let tempRoot;
+  let artifactsDirectory;
+  let stateFilePath;
+  let prepackAttempted = false;
+  let postpackCompleted = false;
+  let normalPackCleanupVerified = false;
+  let stampedVersion;
+  let prepackCount = 0;
+  let operationError;
+  let summary;
+  const cleanupErrors = [];
+
+  try {
+    requireExactPnpmVersion();
+    initialHeadSha = runPlain('git', ['rev-parse', 'HEAD'], { cwd: MONOREPO_ROOT }).trim();
+    const initialShallow = runPlain('git', ['rev-parse', '--is-shallow-repository'], {
+      cwd: MONOREPO_ROOT,
+    }).trim();
+    assert(initialShallow === 'false', 'Release-pack validation requires a non-shallow checkout.');
+    if (candidateSha) {
+      assert(initialHeadSha === candidateSha, `Candidate SHA ${candidateSha} does not match HEAD ${initialHeadSha}.`);
+    }
+    initialWorktreeStatus = runPlain(
+      'git',
+      ['status', '--porcelain=v1', '-z', '--untracked-files=all', '--ignore-submodules=none'],
+      {
+        binary: true,
+        cwd: MONOREPO_ROOT,
+      },
+    );
+    assert(
+      initialWorktreeStatus.length === 0,
+      'Release-pack validation requires a clean worktree at start; dirty-checkout evidence is invalid.',
+    );
+    if (evidenceDirectory) {
+      const evidenceRelativePath = path.relative(MONOREPO_ROOT, path.resolve(evidenceDirectory));
+      assert(
+        evidenceRelativePath.startsWith('..') || path.isAbsolute(evidenceRelativePath),
+        'Release-pack evidence must be written outside the candidate worktree.',
+      );
+    }
+    recorder = createEvidenceRecorder(evidenceDirectory, evidencePathOptions);
+    runner = createCommandRunner(evidenceDirectory, undefined, evidencePathOptions);
+    initialPackageJson = readFileSync(PACKAGE_JSON_PATH);
+    initialReadme = readFileSync(path.join(PACKAGE_ROOT, 'README.md'));
+    initialReadmeNpm = readFileSync(README_NPM_PATH);
+    initialLifecycleState = capturePathStates(PACKAGE_ROOT, PACK_LIFECYCLE_PATHS);
+    initialDistState = capturePathStates(PACKAGE_ROOT, ['dist']);
+    tempRoot = createTempDirectory('hexo-renderer-asciidoc-release-pack-');
+    injectValidationFault('release-pack:after-temp-directory');
+    artifactsDirectory = path.join(tempRoot, 'artifacts');
+    stateFilePath = path.join(tempRoot, 'npm-publish-state.json');
+    mkdirSync(artifactsDirectory, { recursive: true });
+    const packEnvironment = getPackEnvironment();
+
+    removePath(DIST_DIRECTORY);
+    assert(!existsSync(DIST_DIRECTORY), 'dist/ must be absent before the fresh release build.');
+    runner.run('pnpm', ['run', 'build'], {
+      label: 'workflow-release-build-fresh',
+      phase: 'existing-release-workflow',
+    });
+    const freshDistFiles = verifyDistInventory(DIST_DIRECTORY);
+
+    prepackAttempted = true;
+    runner.run('pnpm', ['run', 'prepack'], {
+      label: 'workflow-single-prepack',
+      phase: 'existing-release-workflow',
+    });
+    prepackCount += 1;
+    stampedVersion = readJsonFile(PACKAGE_JSON_PATH).version;
+    assert(
+      typeof stampedVersion === 'string' && stampedVersion.length > 0 && stampedVersion !== PLACEHOLDER_VERSION,
+      'The single prepack/NBGV operation did not stamp a non-placeholder package version.',
+    );
+
+    runner.run(
+      'uv',
+      [
+        'run',
+        '--script',
+        PREPARE_NPM_PUBLISH_SCRIPT,
+        '--package-dir',
+        PACKAGE_ROOT,
+        '--scope',
+        EXPECTED_SCOPE.slice(1),
+        '--state-file',
+        stateFilePath,
+      ],
+      { cwd: MONOREPO_ROOT, label: 'workflow-prepare-gpr-name', phase: 'existing-release-workflow' },
+    );
+    runner.run('npm', ['pack', '--ignore-scripts', '--pack-destination', artifactsDirectory], {
+      cwd: PACKAGE_ROOT,
+      env: packEnvironment,
+      label: 'workflow-pack-gpr-ignore-scripts',
+      phase: 'existing-release-workflow',
+    });
+
+    runner.run(
+      'uv',
+      [
+        'run',
+        '--script',
+        PREPARE_NPM_PUBLISH_SCRIPT,
+        '--package-dir',
+        PACKAGE_ROOT,
+        '--state-file',
+        stateFilePath,
+        '--restore',
+      ],
+      { cwd: MONOREPO_ROOT, label: 'workflow-restore-public-name', phase: 'existing-release-workflow' },
+    );
+    runner.run(
+      'node',
+      [
+        '-e',
+        `const fs = require('fs');
+const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+if (pkg.private) {
+  console.error('Error: package.json has "private": true; refusing to produce an npmjs tarball for public publishing.');
+  process.exit(1);
+}`,
+      ],
+      {
+        cwd: PACKAGE_ROOT,
+        label: 'workflow-verify-package-not-private-npmjs',
+        phase: 'existing-release-workflow',
+      },
+    );
+    runner.run('npm', ['pack', '--ignore-scripts', '--pack-destination', artifactsDirectory], {
+      cwd: PACKAGE_ROOT,
+      env: packEnvironment,
+      label: 'workflow-pack-npmjs-ignore-scripts',
+      phase: 'existing-release-workflow',
+    });
+    const releaseWorkflowCommands = runner.commands.filter((command) => command.phase === 'existing-release-workflow');
+    assert(
+      releaseWorkflowCommands.at(-1)?.label === 'workflow-pack-npmjs-ignore-scripts',
+      'The modeled existing release workflow must end after the second npm pack --ignore-scripts.',
+    );
+
+    const tarballs = listDirectoryFiles(artifactsDirectory)
+      .filter((entry) => entry.endsWith('.tgz'))
+      .sort();
+    assert(tarballs.length === 2, `Expected two release tarballs, found ${tarballs.length}.`);
+    const gprTarballPath = path.join(artifactsDirectory, tarballs.find((entry) => entry.startsWith('hcoona-')) ?? '');
+    const npmjsTarballPath = path.join(
+      artifactsDirectory,
+      tarballs.find((entry) => entry.startsWith('hexo-renderer-asciidoc-')) ?? '',
+    );
+    assert(existsSync(gprTarballPath), 'GitHub Packages tarball was not produced.');
+    assert(existsSync(npmjsTarballPath), 'npmjs tarball was not produced.');
+
+    const gprSummary = verifyTarballCommon(
+      gprTarballPath,
+      `${EXPECTED_SCOPE}/hexo-renderer-asciidoc`,
+      stampedVersion,
+      initialReadmeNpm,
+    );
+    const npmjsSummary = verifyTarballCommon(
+      npmjsTarballPath,
+      'hexo-renderer-asciidoc',
+      stampedVersion,
+      initialReadmeNpm,
+    );
+    const contentIdentity = verifyEquivalentTarballContent(gprTarballPath, npmjsTarballPath, gprSummary, npmjsSummary);
+    const npmjsProbeEvidenceDirectory = recorder.directory
+      ? path.join(recorder.directory, 'npmjs-tarball-probe')
+      : undefined;
+    const npmjsProbeArgs = [
+      './scripts/validate-packed-artifact.mjs',
+      '--tarball-path',
+      npmjsTarballPath,
+      '--readme-source-path',
+      path.join(PACKAGE_ROOT, '.README.npm.md.npm-backup'),
+    ];
+    if (npmjsProbeEvidenceDirectory) {
+      npmjsProbeArgs.push('--evidence-dir', npmjsProbeEvidenceDirectory);
+    }
+    npmjsProbeArgs.push('--repository-root', repositoryRoot, '--session-root', sessionRoot);
+    const npmjsProbeSummary = JSON.parse(
+      runner.run('node', npmjsProbeArgs, {
+        cwd: PACKAGE_ROOT,
+        label: 'local-validation-artifact-probe-npmjs',
+        phase: 'local-validation-artifact-validation',
+      }),
+    );
+    assert(
+      npmjsProbeSummary.packedArtifact.sha256 === npmjsSummary.sha256,
+      'npmjs probe must execute against the exact npmjs dry-run tarball.',
+    );
+    assert(
+      npmjsProbeSummary.packedArtifact.version === stampedVersion,
+      'The npmjs consumer probe observed a version other than the single prepack-stamped version.',
+    );
+
+    runner.run('pnpm', ['run', 'postpack'], {
+      label: 'local-validation-harness-cleanup-postpack',
+      phase: 'local-validation-harness-cleanup',
+    });
+    postpackCompleted = true;
+    rmSync(stateFilePath, { force: true });
+    verifyPackCleanup({
+      expectedLifecycleState: initialLifecycleState,
+      expectedPackageJson: initialPackageJson,
+      expectedReadme: initialReadme,
+      expectedReadmeNpm: initialReadmeNpm,
+    });
+    normalPackCleanupVerified = true;
+
+    summary = {
+      build: {
+        distFiles: freshDistFiles,
+        fresh: true,
+      },
+      cleanup: undefined,
+      commands: runner.commands,
+      checkout: {
+        candidateSha: candidateSha ?? null,
+        headSha: initialHeadSha,
+        nonShallow: true,
+        initialWorktreeStatus: [],
+        initialWorktreeStatusSha256: sha256Buffer(initialWorktreeStatus),
+      },
+      contentIdentity,
+      expectedScope: EXPECTED_SCOPE,
+      npmjsPrivateGuard: {
+        label: 'workflow-verify-package-not-private-npmjs',
+        outcome: 'passed',
+      },
+      prepackCount,
+      releaseSequence: {
+        artifactValidation: {
+          contentIdentity: true,
+          inventories: true,
+          licenseBytes: true,
+          npmjsConsumerProbe: true,
+        },
+        commands: releaseWorkflowCommands,
+        endsAfterSecondIgnoreScriptsPack: true,
+        label: 'exact-existing-release-workflow-sequence',
+        postpackIncluded: false,
+      },
+      localValidationHarnessOnly: {
+        cleanupCommandLabel: 'local-validation-harness-cleanup-postpack',
+        label: 'local-validation-harness-only-cleanup-reset-after-release-sequence',
+        postpackInvoked: true,
+      },
+      stampedVersion,
+      tarballs: {
+        gpr: {
+          filename: path.basename(gprTarballPath),
+          ...gprSummary,
+        },
+        npmjs: {
+          filename: path.basename(npmjsTarballPath),
+          ...npmjsSummary,
+          probeSummary: {
+            consumerLockSha256: npmjsProbeSummary.consumer.fixtureLockSha256,
+            node: npmjsProbeSummary.node,
+            packedArtifactSha256: npmjsProbeSummary.packedArtifact.sha256,
+            publicPages: npmjsProbeSummary.probes.publicPages,
+            runtime: {
+              commonjs: {
+                defaultEqualsNamed: npmjsProbeSummary.probes.commonjs.defaultEqualsNamed,
+                keys: npmjsProbeSummary.probes.commonjs.keys,
+              },
+              esm: {
+                defaultEqualsNamed: npmjsProbeSummary.probes.esm.defaultEqualsNamed,
+                defaultType: npmjsProbeSummary.probes.esm.defaultType,
+              },
+            },
+            typeProbes: npmjsProbeSummary.probes.typeProbes,
+            typescriptVersion: npmjsProbeSummary.typescriptVersion,
+          },
+        },
+      },
+    };
+  } catch (error) {
+    operationError = error;
+  } finally {
+    let emergencyRestoreAttempted = false;
+    if (operationError !== undefined) {
+      if (stateFilePath && lexistsSync(stateFilePath) && runner) {
+        emergencyRestoreAttempted = true;
+        captureCleanupFailure(cleanupErrors, () => {
+          runner.run(
+            'uv',
+            [
+              'run',
+              '--script',
+              PREPARE_NPM_PUBLISH_SCRIPT,
+              '--package-dir',
+              PACKAGE_ROOT,
+              '--state-file',
+              stateFilePath,
+              '--restore',
+            ],
+            {
+              cwd: MONOREPO_ROOT,
+              label: 'local-validation-emergency-restore-public-name',
+              phase: 'local-validation-harness-cleanup',
+            },
+          );
+        });
+      }
+      if (stateFilePath) {
+        captureCleanupFailure(cleanupErrors, () => rmSync(stateFilePath, { force: true }));
+      }
+      if (prepackAttempted && !postpackCompleted && runner) {
+        emergencyRestoreAttempted = true;
+        captureCleanupFailure(cleanupErrors, () => {
+          runner.run('pnpm', ['run', 'postpack'], {
+            label: 'local-validation-emergency-postpack',
+            phase: 'local-validation-harness-cleanup',
+          });
+          postpackCompleted = true;
+        });
+      }
+      if (prepackAttempted && runner) {
+        emergencyRestoreAttempted = true;
+        captureCleanupFailure(cleanupErrors, () => {
+          runner.run('pnpm', ['run', 'version:reset'], {
+            label: 'local-validation-emergency-version-reset',
+            phase: 'local-validation-harness-cleanup',
+          });
+        });
+      }
+      if (initialLifecycleState) {
+        emergencyRestoreAttempted = true;
+        captureCleanupFailure(cleanupErrors, () => restorePathStates(PACKAGE_ROOT, initialLifecycleState));
+      }
+    }
+    if (initialDistState) {
+      captureCleanupFailure(cleanupErrors, () => restorePathStates(PACKAGE_ROOT, initialDistState));
+    }
+    if (tempRoot) {
+      captureCleanupFailure(cleanupErrors, () => {
+        removePath(tempRoot);
+        injectValidationFault('release-pack:after-temp-cleanup');
+      });
+    }
+
+    let finalPackageJson;
+    let finalReadme;
+    let finalReadmeNpm;
+    let finalLifecycleState;
+    let finalDistState;
+    let finalHeadSha;
+    let finalShallow;
+    let finalWorktreeStatus;
+    if (initialPackageJson) {
+      captureCleanupFailure(cleanupErrors, () => {
+        finalPackageJson = readFileSync(PACKAGE_JSON_PATH);
+      });
+    }
+    if (initialReadme) {
+      captureCleanupFailure(cleanupErrors, () => {
+        finalReadme = readFileSync(path.join(PACKAGE_ROOT, 'README.md'));
+      });
+    }
+    if (initialReadmeNpm) {
+      captureCleanupFailure(cleanupErrors, () => {
+        finalReadmeNpm = readFileSync(README_NPM_PATH);
+      });
+    }
+    if (initialLifecycleState) {
+      captureCleanupFailure(cleanupErrors, () => {
+        finalLifecycleState = capturePathStates(PACKAGE_ROOT, PACK_LIFECYCLE_PATHS);
+      });
+    }
+    if (initialDistState) {
+      captureCleanupFailure(cleanupErrors, () => {
+        finalDistState = capturePathStates(PACKAGE_ROOT, ['dist']);
+      });
+    }
+    if (initialHeadSha) {
+      captureCleanupFailure(cleanupErrors, () => {
+        finalHeadSha = runPlain('git', ['rev-parse', 'HEAD'], { cwd: MONOREPO_ROOT }).trim();
+      });
+      captureCleanupFailure(cleanupErrors, () => {
+        finalShallow = runPlain('git', ['rev-parse', '--is-shallow-repository'], {
+          cwd: MONOREPO_ROOT,
+        }).trim();
+      });
+      captureCleanupFailure(cleanupErrors, () => {
+        finalWorktreeStatus = runPlain(
+          'git',
+          ['status', '--porcelain=v1', '-z', '--untracked-files=all', '--ignore-submodules=none'],
+          {
+            binary: true,
+            cwd: MONOREPO_ROOT,
+          },
+        );
+      });
+    }
+
+    let cleanupSummary;
+    captureCleanupFailure(cleanupErrors, () => {
+      cleanupSummary = {
+        cleanAtEnd: finalWorktreeStatus ? finalWorktreeStatus.length === 0 : null,
+        distStateRestored:
+          initialDistState && finalDistState ? pathStatesEqual(initialDistState, finalDistState) : null,
+        emergencyRestoreAttempted,
+        finalWorktreeStatusSha256: finalWorktreeStatus ? sha256Buffer(finalWorktreeStatus) : null,
+        headRestored: initialHeadSha && finalHeadSha ? finalHeadSha === initialHeadSha : null,
+        lifecycleStateRestored:
+          initialLifecycleState && finalLifecycleState
+            ? pathStatesEqual(initialLifecycleState, finalLifecycleState)
+            : null,
+        nonShallow: finalShallow ? finalShallow === 'false' : null,
+        normalPackCleanupVerified,
+        packageJsonRestored:
+          initialPackageJson && finalPackageJson ? Buffer.compare(initialPackageJson, finalPackageJson) === 0 : null,
+        postpackCompleted,
+        readmeNpmRestored:
+          initialReadmeNpm && finalReadmeNpm ? Buffer.compare(initialReadmeNpm, finalReadmeNpm) === 0 : null,
+        readmeRestored: initialReadme && finalReadme ? Buffer.compare(initialReadme, finalReadme) === 0 : null,
+        stateFileRemoved: stateFilePath ? !lexistsSync(stateFilePath) : null,
+        temporaryDirectoryRemoved: tempRoot ? !lexistsSync(tempRoot) : null,
+      };
+    });
+    for (const [condition, message] of [
+      [initialHeadSha ? cleanupSummary?.headRestored : true, 'Release-pack validation changed HEAD.'],
+      [initialDistState ? cleanupSummary?.distStateRestored : true, 'Release-pack validation did not restore dist/.'],
+      [initialHeadSha ? cleanupSummary?.nonShallow : true, 'Release-pack validation ended in a shallow checkout.'],
+      [
+        initialLifecycleState ? cleanupSummary?.lifecycleStateRestored : true,
+        'Release-pack lifecycle paths were not restored exactly.',
+      ],
+      [initialPackageJson ? cleanupSummary?.packageJsonRestored : true, 'package.json was not restored byte-for-byte.'],
+      [initialReadme ? cleanupSummary?.readmeRestored : true, 'README.md was not restored byte-for-byte.'],
+      [initialReadmeNpm ? cleanupSummary?.readmeNpmRestored : true, 'README.npm.md was not restored byte-for-byte.'],
+      [stateFilePath ? cleanupSummary?.stateFileRemoved : true, 'The npm publish state file was not removed.'],
+      [tempRoot ? cleanupSummary?.temporaryDirectoryRemoved : true, 'The temporary directory was not removed.'],
+      [
+        initialWorktreeStatus ? cleanupSummary?.cleanAtEnd : true,
+        'Release-pack validation requires a clean worktree at end.',
+      ],
+    ]) {
+      captureCleanupFailure(cleanupErrors, () => assert(condition, message));
+    }
+    if (summary) {
+      summary.cleanup = cleanupSummary;
+      summary.commands = runner?.commands ?? [];
+      summary.checkout.finalHeadSha = finalHeadSha;
+      summary.checkout.finalWorktreeStatus = finalWorktreeStatus
+        ? finalWorktreeStatus.toString('utf8').split('\0').filter(Boolean)
+        : null;
+      summary.checkout.finalWorktreeStatusSha256 = finalWorktreeStatus ? sha256Buffer(finalWorktreeStatus) : null;
+      if (recorder) {
+        captureCleanupFailure(cleanupErrors, () => recorder.writeJson('results/release-pack-summary.json', summary));
+      }
+    }
+    if (recorder) {
+      captureCleanupFailure(cleanupErrors, () => {
+        recorder.writeJson('results/release-pack-cleanup.json', cleanupSummary);
+      });
+    }
+    captureCleanupFailure(cleanupErrors, () => {
+      process.stdout.write(
+        `${JSON.stringify(
+          {
+            cleanup: cleanupSummary,
+            commands: runner?.commands ?? [],
+            packageVersion: readJsonFile(PACKAGE_JSON_PATH).version,
+            prepackCount,
+            stampedVersion: stampedVersion ?? null,
+          },
+          null,
+          2,
+        )}\n`,
+      );
+    });
+  }
+  throwValidationFailures(operationError, cleanupErrors, 'Release-pack validation or lifecycle cleanup failed.');
+};
+
+main();

--- a/src/public/lib/hexo-renderer-asciidoc/scripts/validation-utils.mjs
+++ b/src/public/lib/hexo-renderer-asciidoc/scripts/validation-utils.mjs
@@ -1,0 +1,664 @@
+/**
+ * Copyright 2015 Shuai Zhang
+ * SPDX-License-Identifier: LGPL-3.0-or-later WITH LGPL-3.0-linking-exception
+ */
+
+import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import {
+  chmodSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  readlinkSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
+import path from 'node:path';
+
+export const PACKAGE_ROOT = path.resolve(
+  process.env.HEXO_RENDERER_ASCIIDOC_PACKAGE_ROOT ?? path.resolve(import.meta.dirname, '..'),
+);
+export const EXPECTED_HEXO_VERSION = '8.1.2';
+export const EXPECTED_PNPM_VERSION = '10.34.5';
+export const PLACEHOLDER_VERSION = '0.0.0-placeholder';
+export const EXPECTED_ROOT_DIST_FILES = ['index.js', 'index.cjs', 'index.d.ts', 'index.d.cts'];
+export const OPTIONAL_ROOT_DIST_FILES = ['index.d.ts.map', 'index.d.cts.map'];
+export const PACK_LIFECYCLE_PATHS = [
+  'package.json',
+  'README.md',
+  'README.npm.md',
+  '.README.md.npm-backup',
+  '.README.npm.md.npm-backup',
+  'LICENSE',
+  'COPYING',
+  'COPYING.LESSER',
+  'LICENSES',
+  '.sync-licenses-state.json',
+  '.sync-licenses-backups',
+];
+export const ROOT_LICENSE_ITEMS = [
+  'LICENSE',
+  'COPYING',
+  'COPYING.LESSER',
+  path.join('LICENSES', 'LGPL-3.0-linking-exception.txt'),
+];
+
+const MONOREPO_MARKERS = ['pnpm-workspace.yaml', '.git'];
+
+export const assert = (condition, message) => {
+  if (!condition) {
+    throw new Error(message);
+  }
+};
+
+export const lexistsSync = (entryPath) => {
+  try {
+    lstatSync(entryPath);
+    return true;
+  } catch (error) {
+    if (error?.code === 'ENOENT') {
+      return false;
+    }
+    throw error;
+  }
+};
+
+export const injectValidationFault = (point) => {
+  const requestedFaults = (process.env.HEXO_RENDERER_ASCIIDOC_VALIDATION_FAULTS ?? '')
+    .split(',')
+    .map((fault) => fault.trim())
+    .filter(Boolean);
+  if (requestedFaults.includes(point)) {
+    throw new Error(`Injected validation fault: ${point}`);
+  }
+};
+
+export const captureCleanupFailure = (cleanupErrors, operation) => {
+  try {
+    return operation();
+  } catch (error) {
+    cleanupErrors.push(error);
+    return undefined;
+  }
+};
+
+export const throwValidationFailures = (operationError, cleanupErrors, message) => {
+  if (operationError !== undefined && cleanupErrors.length === 0) {
+    throw operationError;
+  }
+  if (operationError !== undefined || cleanupErrors.length > 0) {
+    throw new AggregateError(
+      operationError === undefined ? cleanupErrors : [operationError, ...cleanupErrors],
+      message,
+      operationError === undefined ? undefined : { cause: operationError },
+    );
+  }
+};
+
+export const ensureDir = (directoryPath) => {
+  mkdirSync(directoryPath, { recursive: true });
+};
+
+export const parseArgs = (argv) => {
+  const args = new Map();
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (!token.startsWith('--')) {
+      continue;
+    }
+    const [key, inlineValue] = token.split('=', 2);
+    if (inlineValue !== undefined) {
+      args.set(key, inlineValue);
+      continue;
+    }
+    const next = argv[index + 1];
+    if (!next || next.startsWith('--')) {
+      args.set(key, 'true');
+      continue;
+    }
+    args.set(key, next);
+    index += 1;
+  }
+  return args;
+};
+
+export const findMonorepoRoot = (startDirectory) => {
+  let current = startDirectory;
+  const { root } = path.parse(current);
+  while (true) {
+    if (MONOREPO_MARKERS.some((marker) => existsSync(path.join(current, marker)))) {
+      return current;
+    }
+    if (current === root) {
+      break;
+    }
+    current = path.dirname(current);
+  }
+  throw new Error(`Unable to locate monorepo root above ${startDirectory}.`);
+};
+
+export const MONOREPO_ROOT = path.resolve(
+  process.env.HEXO_RENDERER_ASCIIDOC_REPOSITORY_ROOT ?? findMonorepoRoot(PACKAGE_ROOT),
+);
+
+export const createEvidenceNormalizer = ({
+  repositoryRoot = MONOREPO_ROOT,
+  sessionRoot = process.env.HEXO_RENDERER_ASCIIDOC_SESSION_ROOT,
+  additionalRoots = [],
+} = {}) => {
+  const replacements = [
+    [repositoryRoot, '<repo>'],
+    [sessionRoot, '<session>'],
+    [tmpdir(), '<tmp>'],
+    [homedir(), '<home>'],
+    [process.env.HOME, '<home>'],
+    ...additionalRoots,
+  ]
+    .filter(([absolutePath]) => absolutePath && path.isAbsolute(absolutePath))
+    .map(([absolutePath, replacement]) => [path.resolve(absolutePath), replacement])
+    .sort(([left], [right]) => right.length - left.length);
+
+  return (value) => {
+    let normalized = String(value);
+    for (const [absolutePath, replacement] of replacements) {
+      normalized = normalized.replaceAll(absolutePath, replacement);
+    }
+    return normalized;
+  };
+};
+
+const defaultEvidenceNormalizer = createEvidenceNormalizer();
+export const normalizeEvidenceText = (value) => defaultEvidenceNormalizer(value);
+
+export const readJsonFile = (filePath) => JSON.parse(readFileSync(filePath, 'utf8'));
+
+export const writeJsonFile = (filePath, data) => {
+  ensureDir(path.dirname(filePath));
+  writeFileSync(filePath, `${JSON.stringify(data, null, 2)}\n`, 'utf8');
+};
+
+export const writeTextFile = (filePath, text) => {
+  ensureDir(path.dirname(filePath));
+  writeFileSync(filePath, text, 'utf8');
+};
+
+export const createTempDirectory = (prefix) => mkdtempSync(path.join(tmpdir(), prefix));
+
+export const sha256Buffer = (value) => createHash('sha256').update(value).digest('hex');
+
+export const sha256File = (filePath) => sha256Buffer(readFileSync(filePath));
+
+const capturePathState = (entryPath) => {
+  if (!lexistsSync(entryPath)) {
+    return { type: 'missing' };
+  }
+  const stat = lstatSync(entryPath);
+  if (stat.isSymbolicLink()) {
+    return {
+      type: 'symlink',
+      target: readlinkSync(entryPath),
+    };
+  }
+  if (stat.isDirectory()) {
+    return {
+      type: 'directory',
+      mode: stat.mode,
+      entries: Object.fromEntries(
+        readdirSync(entryPath)
+          .sort()
+          .map((entry) => [entry, capturePathState(path.join(entryPath, entry))]),
+      ),
+    };
+  }
+  return {
+    type: 'file',
+    mode: stat.mode,
+    contents: readFileSync(entryPath),
+  };
+};
+
+const restorePathState = (entryPath, state) => {
+  rmSync(entryPath, { force: true, recursive: true });
+  if (state.type === 'missing') {
+    return;
+  }
+  if (state.type === 'directory') {
+    mkdirSync(entryPath, { recursive: true });
+    for (const [entry, childState] of Object.entries(state.entries)) {
+      restorePathState(path.join(entryPath, entry), childState);
+    }
+    chmodSync(entryPath, state.mode);
+    return;
+  }
+  if (state.type === 'symlink') {
+    ensureDir(path.dirname(entryPath));
+    symlinkSync(state.target, entryPath);
+    return;
+  }
+  ensureDir(path.dirname(entryPath));
+  writeFileSync(entryPath, state.contents);
+  chmodSync(entryPath, state.mode);
+};
+
+const serializePathState = (state) => {
+  if (state.type === 'file') {
+    return { ...state, contents: state.contents.toString('base64') };
+  }
+  if (state.type === 'directory') {
+    return {
+      ...state,
+      entries: Object.fromEntries(
+        Object.entries(state.entries).map(([entry, childState]) => [entry, serializePathState(childState)]),
+      ),
+    };
+  }
+  return state;
+};
+
+export const capturePathStates = (rootDirectory, relativePaths) =>
+  Object.fromEntries(
+    relativePaths.map((relativePath) => [relativePath, capturePathState(path.join(rootDirectory, relativePath))]),
+  );
+
+export const restorePathStates = (rootDirectory, states) => {
+  const errors = [];
+  for (const [relativePath, state] of Object.entries(states)) {
+    try {
+      restorePathState(path.join(rootDirectory, relativePath), state);
+    } catch (error) {
+      errors.push(new Error(`Failed to restore ${relativePath}.`, { cause: error }));
+    }
+  }
+  if (errors.length > 0) {
+    throw new AggregateError(errors, `Failed to restore ${errors.length} path state(s).`);
+  }
+};
+
+export const pathStatesEqual = (left, right) =>
+  JSON.stringify(serializePathState(left)) === JSON.stringify(serializePathState(right));
+
+export const collectTarballLicenseChecks = (tarballPath, rootDirectory = MONOREPO_ROOT) =>
+  ROOT_LICENSE_ITEMS.map((licenseItem) => {
+    const packedBytes = readTarEntryBuffer(tarballPath, `package/${licenseItem}`);
+    const rootBytes = readFileSync(path.join(rootDirectory, licenseItem));
+    return {
+      path: licenseItem,
+      packedSha256: sha256Buffer(packedBytes),
+      rootSha256: sha256Buffer(rootBytes),
+      byteEqual: Buffer.compare(packedBytes, rootBytes) === 0,
+    };
+  });
+
+export const createEvidenceRecorder = (evidenceDirectory, pathOptions = {}) => {
+  if (!evidenceDirectory) {
+    return {
+      directory: undefined,
+      writes: [],
+      writeText: () => undefined,
+      writeJson: () => undefined,
+      writeBuffer: () => undefined,
+    };
+  }
+
+  ensureDir(evidenceDirectory);
+  const writes = [];
+  const normalize = createEvidenceNormalizer({
+    repositoryRoot: pathOptions.repositoryRoot,
+    sessionRoot: pathOptions.sessionRoot ?? evidenceDirectory,
+    additionalRoots: pathOptions.additionalRoots,
+  });
+  const record = (relativePath, bytes) => {
+    const absolutePath = path.join(evidenceDirectory, relativePath);
+    const normalizedBytes = Buffer.from(normalize(bytes.toString('utf8')), 'utf8');
+    ensureDir(path.dirname(absolutePath));
+    writeFileSync(absolutePath, normalizedBytes);
+    writes.push({
+      path: relativePath,
+      sha256: sha256Buffer(normalizedBytes),
+      size: normalizedBytes.byteLength,
+    });
+    return absolutePath;
+  };
+
+  return {
+    directory: evidenceDirectory,
+    writes,
+    writeText(relativePath, text) {
+      return record(relativePath, Buffer.from(text, 'utf8'));
+    },
+    writeJson(relativePath, data) {
+      return record(relativePath, Buffer.from(`${JSON.stringify(data, null, 2)}\n`, 'utf8'));
+    },
+    writeBuffer(relativePath, bytes) {
+      return record(relativePath, bytes);
+    },
+  };
+};
+
+const formatCommandFailure = ({ command, args, cwd, result, stderr }) =>
+  [
+    `Command: ${[command, ...args].join(' ')}`,
+    `Context: cwd=${cwd}`,
+    `Status: ${String(result.status)}`,
+    `Signal: ${result.signal ?? 'none'}`,
+    `Error: ${result.error ? `${result.error.name}: ${result.error.message}` : 'none'}`,
+    `Stderr: ${String(stderr).trim() || '<empty>'}`,
+  ].join('\n');
+
+const isSpawnFailure = (result) => result.error !== undefined || result.signal !== null || result.status === null;
+
+export const createCommandRunner = (evidenceDirectory, spawn = spawnSync, pathOptions = {}) => {
+  const logsDirectory = evidenceDirectory ? path.join(evidenceDirectory, 'logs') : undefined;
+  const commands = [];
+  const normalize = createEvidenceNormalizer({
+    repositoryRoot: pathOptions.repositoryRoot,
+    sessionRoot: pathOptions.sessionRoot ?? evidenceDirectory,
+    additionalRoots: pathOptions.additionalRoots,
+  });
+  if (logsDirectory) {
+    ensureDir(logsDirectory);
+  }
+
+  const execute = (command, args, options = {}) => {
+    const cwd = options.cwd ?? PACKAGE_ROOT;
+    const env = { ...process.env, ...options.env };
+    const encoding = options.binary ? undefined : 'utf8';
+    const rendered = [command, ...args].join(' ');
+    const result = spawn(command, args, {
+      cwd,
+      env,
+      encoding,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    const stdout = result.stdout ?? (options.binary ? Buffer.alloc(0) : '');
+    const stderr = result.stderr ?? (options.binary ? Buffer.alloc(0) : '');
+    const label = options.label ?? `command-${String(commands.length + 1).padStart(2, '0')}`;
+    const commandRecord = {
+      label,
+      cwd: normalize(cwd),
+      command,
+      args: args.map((argument) => normalize(argument)),
+      rendered: normalize(rendered),
+      exitCode: result.status,
+      signal: result.signal ?? null,
+      error: result.error ? normalize(`${result.error.name}: ${result.error.message}`) : null,
+    };
+    if (options.phase) {
+      commandRecord.phase = options.phase;
+    }
+
+    if (logsDirectory) {
+      const stdoutName = `${label}.stdout.log`;
+      const stderrName = `${label}.stderr.log`;
+      writeFileSync(
+        path.join(logsDirectory, stdoutName),
+        normalize(Buffer.isBuffer(stdout) ? stdout.toString('utf8') : stdout),
+      );
+      writeFileSync(
+        path.join(logsDirectory, stderrName),
+        normalize(Buffer.isBuffer(stderr) ? stderr.toString('utf8') : stderr),
+      );
+      commandRecord.stdout = path.posix.join('logs', stdoutName);
+      commandRecord.stderr = path.posix.join('logs', stderrName);
+    }
+    commands.push(commandRecord);
+    if (isSpawnFailure(result) || (result.status !== 0 && options.allowFailure !== true)) {
+      throw new Error(formatCommandFailure({ command, args, cwd, result, stderr }));
+    }
+    return {
+      exitCode: result.status,
+      stderr,
+      stdout,
+    };
+  };
+
+  return {
+    commands,
+    run(command, args, options = {}) {
+      return execute(command, args, options).stdout;
+    },
+    runResult(command, args, options = {}) {
+      return execute(command, args, { ...options, allowFailure: true });
+    },
+  };
+};
+
+export const findCommandRecord = (commands, label) => {
+  const command = commands.find((entry) => entry.label === label);
+  assert(command, `Unable to find recorded command ${label}.`);
+  return command;
+};
+
+export const getPackEnvironment = () => ({
+  LC_ALL: 'C.UTF-8',
+  SOURCE_DATE_EPOCH: runPlain('git', ['show', '-s', '--format=%ct', 'HEAD'], { cwd: MONOREPO_ROOT }).trim(),
+  TZ: 'UTC',
+});
+
+export const runPlain = (command, args, options = {}) => {
+  const encoding = options.binary ? undefined : 'utf8';
+  const result = (options.spawn ?? spawnSync)(command, args, {
+    cwd: options.cwd ?? PACKAGE_ROOT,
+    env: { ...process.env, ...options.env },
+    encoding,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  const stdout = result.stdout ?? (options.binary ? Buffer.alloc(0) : '');
+  if (isSpawnFailure(result) || result.status !== 0) {
+    const stderr = result.stderr ?? (options.binary ? Buffer.alloc(0) : '');
+    throw new Error(
+      formatCommandFailure({
+        command,
+        args,
+        cwd: options.cwd ?? PACKAGE_ROOT,
+        result,
+        stderr,
+      }),
+    );
+  }
+  return stdout;
+};
+
+export const readTarEntries = (tarballPath) => {
+  const output = runPlain('tar', ['-tzf', tarballPath], { cwd: PACKAGE_ROOT }).trim();
+  return output.length === 0 ? [] : output.split('\n');
+};
+
+export const readTarEntryBuffer = (tarballPath, entryPath) =>
+  runPlain('tar', ['-xOzf', tarballPath, entryPath], { binary: true, cwd: PACKAGE_ROOT });
+
+export const readTarEntryText = (tarballPath, entryPath) => readTarEntryBuffer(tarballPath, entryPath).toString('utf8');
+
+export const verifyExactTarEntries = (entries, requiredEntries) => {
+  for (const requiredEntry of requiredEntries) {
+    const count = entries.filter((entry) => entry === requiredEntry).length;
+    assert(count === 1, `Expected exactly one ${requiredEntry} entry, found ${count}.`);
+  }
+};
+
+export const verifyExactTarInventory = (entries, requiredEntries, optionalEntries = []) => {
+  verifyExactTarEntries(entries, requiredEntries);
+  const allowedEntries = new Set([...requiredEntries, ...optionalEntries]);
+  const unexpectedEntries = entries.filter((entry) => !allowedEntries.has(entry));
+  assert(unexpectedEntries.length === 0, `Unexpected tarball entries: ${unexpectedEntries.join(', ')}`);
+  for (const optionalEntry of optionalEntries) {
+    const count = entries.filter((entry) => entry === optionalEntry).length;
+    assert(count <= 1, `Expected at most one ${optionalEntry} entry, found ${count}.`);
+  }
+};
+
+export const listDirectoryFiles = (directoryPath) =>
+  readdirSync(directoryPath, { withFileTypes: true })
+    .filter((entry) => entry.isFile())
+    .map((entry) => entry.name)
+    .sort();
+
+export const removePath = (targetPath) => {
+  rmSync(targetPath, { force: true, recursive: true });
+};
+
+export const requireExactPnpmVersion = () => {
+  const version = runPlain('pnpm', ['--version']).trim();
+  assert(
+    version === EXPECTED_PNPM_VERSION,
+    `Expected pnpm ${EXPECTED_PNPM_VERSION}, received ${version}. Run this validation through mise.`,
+  );
+  return version;
+};
+
+export const readInstalledTypescriptVersion = () =>
+  readJsonFile(path.join(PACKAGE_ROOT, 'node_modules', 'typescript', 'package.json')).version;
+
+export const listDistEntries = (directoryPath, relativeTo = directoryPath) => {
+  const entries = [];
+  const items = readdirSync(directoryPath, { withFileTypes: true });
+  for (const item of items) {
+    const relPath = path.relative(relativeTo, path.join(directoryPath, item.name)).replace(/\\/g, '/');
+    if (item.isDirectory()) {
+      entries.push(`${relPath}/`);
+      entries.push(...listDistEntries(path.join(directoryPath, item.name), relativeTo));
+    } else {
+      entries.push(relPath);
+    }
+  }
+  return entries;
+};
+
+export const verifyDistInventory = (distDirectoryPath) => {
+  // Recursively enumerate all entries in the dist tree to catch unexpected nested artifacts.
+  const allDistEntries = listDistEntries(distDirectoryPath);
+  const FULL_ALLOWLIST = [...EXPECTED_ROOT_DIST_FILES, ...OPTIONAL_ROOT_DIST_FILES];
+
+  for (const requiredFile of EXPECTED_ROOT_DIST_FILES) {
+    assert(allDistEntries.includes(requiredFile), `Missing required dist artifact: ${requiredFile}`);
+  }
+
+  const unexpectedEntries = allDistEntries.filter((entry) => !FULL_ALLOWLIST.includes(entry));
+  assert(
+    unexpectedEntries.length === 0,
+    `Unexpected dist entries (nested artifacts not permitted): ${unexpectedEntries.join(', ')}`,
+  );
+
+  // Return only the flat file names for callers that need the list.
+  const distFiles = allDistEntries.filter((entry) => !entry.endsWith('/'));
+
+  for (const declarationName of ['index.d.ts', 'index.d.cts']) {
+    const mapName = `${declarationName}.map`;
+    if (distFiles.includes(mapName)) {
+      verifyDeclarationMapContents(
+        readFileSync(path.join(distDirectoryPath, declarationName)),
+        readFileSync(path.join(distDirectoryPath, mapName)),
+        declarationName,
+        mapName,
+      );
+    }
+  }
+  return distFiles;
+};
+
+export const verifyDeclarationMapContents = (declarationBytes, mapBytes, declarationName, mapName) => {
+  const declaration = declarationBytes.toString('utf8');
+  const sourceMap = JSON.parse(mapBytes.toString('utf8'));
+  assert(sourceMap.file === declarationName, `${mapName} must target ${declarationName}, received ${sourceMap.file}.`);
+  assert(declaration.includes(`//# sourceMappingURL=${mapName}`), `${declarationName} must reference ${mapName}.`);
+};
+
+export const verifyPackCleanup = ({
+  expectedLifecycleState,
+  expectedPackageJson,
+  expectedReadme,
+  expectedReadmeNpm,
+  packageRoot = PACKAGE_ROOT,
+} = {}) => {
+  const packageJsonPath = path.join(packageRoot, 'package.json');
+  const readmePath = path.join(packageRoot, 'README.md');
+  const readmeNpmPath = path.join(packageRoot, 'README.npm.md');
+  const packageJsonBytes = readFileSync(packageJsonPath);
+  const packageJson = JSON.parse(packageJsonBytes.toString('utf8'));
+  assert(packageJson.version === PLACEHOLDER_VERSION, 'package.json version was not reset after packing.');
+  assert(lexistsSync(readmePath), 'README.md is missing after packing.');
+  assert(lexistsSync(readmeNpmPath), 'README.npm.md is missing after packing.');
+  if (expectedPackageJson) {
+    assert(
+      Buffer.compare(packageJsonBytes, expectedPackageJson) === 0,
+      'package.json was not restored byte-for-byte after packing.',
+    );
+  }
+  if (expectedReadme) {
+    assert(
+      Buffer.compare(readFileSync(readmePath), expectedReadme) === 0,
+      'README.md was not restored byte-for-byte after packing.',
+    );
+  }
+  if (expectedReadmeNpm) {
+    assert(
+      Buffer.compare(readFileSync(readmeNpmPath), expectedReadmeNpm) === 0,
+      'README.npm.md was not restored byte-for-byte after packing.',
+    );
+  }
+  assert(!lexistsSync(path.join(packageRoot, '.README.md.npm-backup')), 'README backup was not cleaned up.');
+  assert(
+    !lexistsSync(path.join(packageRoot, '.README.npm.md.npm-backup')),
+    'Hidden npm README backup was not cleaned up.',
+  );
+  assert(
+    !lexistsSync(path.join(packageRoot, '.sync-licenses-state.json')),
+    'sync-licenses state file was not cleaned up.',
+  );
+  assert(
+    !lexistsSync(path.join(packageRoot, '.sync-licenses-backups')),
+    'sync-licenses backup directory was not cleaned up.',
+  );
+  const currentLifecycleState = capturePathStates(packageRoot, PACK_LIFECYCLE_PATHS);
+  if (expectedLifecycleState) {
+    assert(
+      pathStatesEqual(expectedLifecycleState, currentLifecycleState),
+      'Pack lifecycle paths were not restored byte-for-byte after packing.',
+    );
+  }
+  const expectedState = expectedLifecycleState ?? {};
+  if (!expectedLifecycleState || expectedState.COPYING?.type === 'missing') {
+    assert(!lexistsSync(path.join(packageRoot, 'COPYING')), 'Temporary COPYING file remained in package root.');
+  }
+  assert(
+    (expectedLifecycleState && expectedState['COPYING.LESSER']?.type !== 'missing') ||
+      !lexistsSync(path.join(packageRoot, 'COPYING.LESSER')),
+    'Temporary COPYING.LESSER file remained in package root.',
+  );
+  assert(
+    (expectedLifecycleState && expectedState.LICENSES?.type !== 'missing') ||
+      !lexistsSync(path.join(packageRoot, 'LICENSES')),
+    'Temporary LICENSES path remained in package root.',
+  );
+  return {
+    lifecycleState: currentLifecycleState,
+    packageJson: packageJsonBytes,
+    readme: readFileSync(readmePath),
+    readmeNpm: readFileSync(readmeNpmPath),
+  };
+};
+
+export const createFixturePackageJson = (tarballRelativePath, typescriptVersion) => ({
+  name: 'hexo-renderer-asciidoc-packed-consumer',
+  private: true,
+  packageManager: `pnpm@${EXPECTED_PNPM_VERSION}`,
+  type: 'module',
+  dependencies: {
+    hexo: EXPECTED_HEXO_VERSION,
+    'hexo-renderer-asciidoc': tarballRelativePath,
+  },
+  devDependencies: {
+    typescript: typescriptVersion,
+  },
+  hexo: {
+    version: EXPECTED_HEXO_VERSION,
+  },
+});
+
+export const statPath = (entryPath) => (lexistsSync(entryPath) ? lstatSync(entryPath) : undefined);

--- a/src/public/lib/hexo-renderer-asciidoc/src/core/asciidoctor.ts
+++ b/src/public/lib/hexo-renderer-asciidoc/src/core/asciidoctor.ts
@@ -3,41 +3,42 @@
  * SPDX-License-Identifier: LGPL-3.0-or-later WITH LGPL-3.0-linking-exception
  */
 
-import type { Asciidoctor, ProcessorOptions } from 'asciidoctor';
-import asciidoctorFactory from 'asciidoctor';
+import { convert, Logger } from '@asciidoctor/core';
 
-const asciidoctor = asciidoctorFactory();
+type ControlledAsciiDocOptions = Readonly<{
+  doctype: 'article';
+  safe: 'server';
+  to_file: false;
+}>;
 
-export type AsciiDocOptions = ProcessorOptions;
-
-const DEFAULT_OPTIONS = Object.freeze({
+const CONTROLLED_OPTIONS: ControlledAsciiDocOptions = Object.freeze({
   doctype: 'article',
   safe: 'server',
-  attributes: ['source-highlighter=html-pipeline'],
-} satisfies AsciiDocOptions);
+  to_file: false,
+});
 
-/**
- * Canonical Asciidoctor options used when callers do not supply overrides.
- * Exposed mainly for testing and advanced customization.
- */
-export const ASCIIDOCTOR_DEFAULT_OPTIONS: AsciiDocOptions = DEFAULT_OPTIONS;
+const toAsciiDocText = (value: string): string => {
+  if (typeof value !== 'string') {
+    throw new TypeError(`Asciidoctor conversion requires string input: ${typeof value}`);
+  }
 
-/**
- * Convert a chunk of AsciiDoc text into HTML using the shared Asciidoctor instance.
- * The provided options override the default configuration on a per-call basis.
- *
- * @param text - Raw AsciiDoc document body.
- * @param options - Optional overrides merged with {@link ASCIIDOCTOR_DEFAULT_OPTIONS}.
- * @returns The rendered HTML string produced by Asciidoctor.
- */
-export const convertAsciiDoc = (text: string, options?: AsciiDocOptions): string => {
-  const mergedOptions = options ? { ...DEFAULT_OPTIONS, ...options } : DEFAULT_OPTIONS;
-  return asciidoctor.convert(text, mergedOptions) as string;
+  return value;
 };
 
 /**
- * Access the lazily created Asciidoctor runtime instance for low-level integrations.
+ * Convert a chunk of AsciiDoc text into HTML using the stateless `@asciidoctor/core` v4 API.
+ * Each call is independent; there is no shared singleton runtime.
  *
- * @returns The singleton Asciidoctor JS runtime used throughout the plugin.
+ * @param text - Raw AsciiDoc document body.
+ * @returns A promise resolving to the rendered HTML string produced by Asciidoctor.
  */
-export const getAsciidoctor = (): Asciidoctor => asciidoctor;
+export const convertAsciiDoc = async (text: string): Promise<string> => {
+  const result = await convert(toAsciiDocText(text), {
+    ...CONTROLLED_OPTIONS,
+    logger: new Logger(),
+  });
+  if (typeof result !== 'string') {
+    throw new TypeError(`Asciidoctor conversion did not return a string: ${typeof result}`);
+  }
+  return result;
+};

--- a/src/public/lib/hexo-renderer-asciidoc/src/core/highlight.ts
+++ b/src/public/lib/hexo-renderer-asciidoc/src/core/highlight.ts
@@ -45,7 +45,16 @@ const toHighlightLanguage = (language?: string): string => {
 
 /**
  * Replace Asciidoctor's placeholder highlight blocks with Hexo's static highlighter output.
- * Keeps existing HTML structure intact while swapping in `<figure>` markup from `hexo-util`.
+ * Only the canonical `div.listingblock > div.content > pre > code` chain is rewritten so
+ * that passthrough or unrelated `pre` elements elsewhere in the document are left untouched.
+ *
+ * Within the selected `pre`, all four shapes emitted by Asciidoctor 4 and the legacy
+ * html-pipeline highlighter are recognized:
+ *   - `pre.highlight > code[data-lang]` (Asciidoctor 4 default, with a language)
+ *   - `pre.highlight > code` (Asciidoctor 4 default, without a language)
+ *   - `pre[lang] > code` (html-pipeline, with a language)
+ *   - `pre > code` (html-pipeline, without a language)
+ * Language precedence is `code[data-lang]` > `pre[lang]` > `plaintext`.
  *
  * @param html - HTML string generated directly from Asciidoctor.
  * @returns HTML with code blocks rendered using Hexo's static highlighter.
@@ -53,22 +62,19 @@ const toHighlightLanguage = (language?: string): string => {
 export const applyStaticHighlighting = (html: string): string => {
   const $ = cheerio.load(html, CHEERIO_LOAD_OPTIONS);
 
-  $('pre.highlight').each((_index, element) => {
-    if (element.type !== 'tag') {
+  $('div.listingblock > div.content > pre > code').each((_index, codeElement) => {
+    const preElement = codeElement.parent;
+    if (preElement?.type !== 'tag') {
       return;
     }
 
-    const codeNode = element.children?.[0];
-    if (!codeNode || codeNode.type !== 'tag') {
-      return;
-    }
-
-    const lang = toHighlightLanguage(codeNode.attribs?.['data-lang']);
-    const sourceCodeText = decodeXML($(codeNode).text());
+    // biome-ignore lint/complexity/useLiteralKeys: noPropertyAccessFromIndexSignature requires bracket notation for index-signature types
+    const lang = toHighlightLanguage(codeElement.attribs?.['data-lang'] ?? preElement.attribs?.['lang'] ?? undefined);
+    const sourceCodeText = decodeXML($(codeElement).text());
     const highlightOptions = { ...BASE_HIGHLIGHT_OPTIONS, lang };
     const rendered = highlightCode(sourceCodeText, highlightOptions);
 
-    $(element).replaceWith(rendered);
+    $(preElement).replaceWith(rendered);
   });
 
   return $.html();

--- a/src/public/lib/hexo-renderer-asciidoc/src/core/highlight.ts
+++ b/src/public/lib/hexo-renderer-asciidoc/src/core/highlight.ts
@@ -6,7 +6,7 @@
 import type { CheerioOptions } from 'cheerio';
 import * as cheerio from 'cheerio';
 import { decodeXML } from 'entities';
-import { highlight as highlightCode } from 'hexo-util';
+import hexoUtil from 'hexo-util';
 
 const CHEERIO_LOAD_OPTIONS: CheerioOptions = Object.freeze({
   // Cheerio 1 defaults to parse5, which eagerly decodes entities using HTML
@@ -43,6 +43,14 @@ const toHighlightLanguage = (language?: string): string => {
   return language;
 };
 
+const getPreferredLanguage = (codeLanguage: string | undefined, preLanguage: string | undefined): string => {
+  if (typeof codeLanguage === 'string' && codeLanguage.trim().length > 0) {
+    return codeLanguage;
+  }
+
+  return toHighlightLanguage(preLanguage);
+};
+
 /**
  * Replace Asciidoctor's placeholder highlight blocks with Hexo's static highlighter output.
  * Only the canonical `div.listingblock > div.content > pre > code` chain is rewritten so
@@ -69,10 +77,10 @@ export const applyStaticHighlighting = (html: string): string => {
     }
 
     // biome-ignore lint/complexity/useLiteralKeys: noPropertyAccessFromIndexSignature requires bracket notation for index-signature types
-    const lang = toHighlightLanguage(codeElement.attribs?.['data-lang'] ?? preElement.attribs?.['lang'] ?? undefined);
+    const lang = getPreferredLanguage(codeElement.attribs?.['data-lang'], preElement.attribs?.['lang']);
     const sourceCodeText = decodeXML($(codeElement).text());
     const highlightOptions = { ...BASE_HIGHLIGHT_OPTIONS, lang };
-    const rendered = highlightCode(sourceCodeText, highlightOptions);
+    const rendered = hexoUtil.highlight(sourceCodeText, highlightOptions);
 
     $(preElement).replaceWith(rendered);
   });

--- a/src/public/lib/hexo-renderer-asciidoc/src/core/renderer.ts
+++ b/src/public/lib/hexo-renderer-asciidoc/src/core/renderer.ts
@@ -15,8 +15,8 @@ import { escapeCurlyBraces } from './sanitize';
  * @param data - Hexo renderer payload containing the AsciiDoc body.
  * @returns Final HTML string ready to be returned to Hexo.
  */
-const asciidoctorRenderer: Renderer = (data) => {
-  const html = convertAsciiDoc(data.text);
+const asciidoctorRenderer: Renderer = async (data) => {
+  const html = await convertAsciiDoc(data.text);
 
   const highlighted = applyStaticHighlighting(html);
 

--- a/src/public/lib/hexo-renderer-asciidoc/src/hexo/register.ts
+++ b/src/public/lib/hexo-renderer-asciidoc/src/hexo/register.ts
@@ -8,7 +8,6 @@ import type { Hexo } from '../types';
 
 const SUPPORTED_EXTENSIONS = ['ad', 'adoc', 'asciidoc'] as const;
 const OUTPUT_FORMAT = 'html';
-const IS_SYNC = true;
 
 /**
  * Wire the shared renderer into a Hexo instance for all supported AsciiDoc extensions.
@@ -18,7 +17,7 @@ const IS_SYNC = true;
  */
 const registerRenderer = (instance: Hexo): void => {
   for (const extension of SUPPORTED_EXTENSIONS) {
-    instance.extend.renderer.register(extension, OUTPUT_FORMAT, renderer, IS_SYNC);
+    instance.extend.renderer.register(extension, OUTPUT_FORMAT, renderer, false);
   }
 };
 

--- a/src/public/lib/hexo-renderer-asciidoc/src/index.ts
+++ b/src/public/lib/hexo-renderer-asciidoc/src/index.ts
@@ -10,6 +10,6 @@ if (typeof hexo !== 'undefined' && hexo?.extend?.renderer) {
   registerRenderer(hexo);
 }
 
-export { registerRenderer, renderer };
 export type { Hexo, Renderer, RendererData, RendererLocals } from './types';
+export { registerRenderer, renderer };
 export default renderer;

--- a/src/public/lib/hexo-renderer-asciidoc/src/types.ts
+++ b/src/public/lib/hexo-renderer-asciidoc/src/types.ts
@@ -12,7 +12,7 @@ export interface RendererData {
 
 export type RendererLocals = Record<string, unknown>;
 
-export type Renderer = (data: RendererData, locals?: RendererLocals) => string;
+export type Renderer = (data: RendererData, locals?: RendererLocals) => Promise<string>;
 
 export interface RendererExtension {
   register(name: string, output: string, fn: Renderer, sync?: boolean): void;

--- a/src/public/lib/hexo-renderer-asciidoc/test/asciidoctor.coldstart.test.ts
+++ b/src/public/lib/hexo-renderer-asciidoc/test/asciidoctor.coldstart.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Copyright 2015 Shuai Zhang
+ * SPDX-License-Identifier: LGPL-3.0-or-later WITH LGPL-3.0-linking-exception
+ */
+
+import path from 'node:path';
+import { performance } from 'node:perf_hooks';
+import { describe, expect, it } from 'vitest';
+import { runVitestSubprocess } from './helpers/vitest-subprocess';
+
+const CHILD_TIMEOUT_MS = 45_000;
+const CONCURRENT_COLD_STARTS = 3;
+const COLD_START_PROBE_TEST_NAME = 'renders the production renderer in a fresh process for cold-start evidence';
+
+type ColdStartMeasurement = {
+  elapsedMilliseconds: number;
+  label: string;
+};
+
+type ColdStartEvidence = {
+  runs: ColdStartMeasurement[];
+  wallClockMilliseconds: number;
+};
+
+const writeTimingEvidence = (label: string, evidence: ColdStartEvidence): void => {
+  process.stdout.write(`${label}: ${JSON.stringify(evidence)}\n`);
+};
+
+const runColdStartProbe = async (packageRoot: string, label: string): Promise<ColdStartMeasurement> => {
+  const startedAt = performance.now();
+  await runVitestSubprocess({
+    args: ['--config', 'vitest.asciidoctor-runtime.config.ts', '-t', COLD_START_PROBE_TEST_NAME],
+    cwd: packageRoot,
+    timeout: CHILD_TIMEOUT_MS,
+  });
+
+  return {
+    elapsedMilliseconds: performance.now() - startedAt,
+    label,
+  };
+};
+
+const assertColdStartEvidence = (evidence: ColdStartEvidence): void => {
+  expect(evidence.runs).toHaveLength(CONCURRENT_COLD_STARTS);
+  for (const run of evidence.runs) {
+    expect(Number.isFinite(run.elapsedMilliseconds)).toBe(true);
+    expect(run.elapsedMilliseconds).toBeGreaterThan(0);
+  }
+  expect(evidence.wallClockMilliseconds).toBeGreaterThan(0);
+};
+
+describe.sequential('Asciidoctor cold-start timing evidence', () => {
+  it('captures sequential cold-start timings for the production renderer', async () => {
+    const packageRoot = path.resolve(import.meta.dirname, '..');
+    const startedAt = performance.now();
+    const runs: ColdStartMeasurement[] = [];
+
+    for (let index = 1; index <= CONCURRENT_COLD_STARTS; index += 1) {
+      runs.push(await runColdStartProbe(packageRoot, `sequential-${index}`));
+    }
+
+    const evidence: ColdStartEvidence = {
+      runs,
+      wallClockMilliseconds: performance.now() - startedAt,
+    };
+
+    writeTimingEvidence('Sequential cold-start timing evidence', evidence);
+    assertColdStartEvidence(evidence);
+  }, 180_000);
+
+  it('captures bounded-parallel cold-start timings for the production renderer', async () => {
+    const packageRoot = path.resolve(import.meta.dirname, '..');
+    const startedAt = performance.now();
+    const runs = await Promise.all(
+      Array.from({ length: CONCURRENT_COLD_STARTS }, async (_value, index) => {
+        return await runColdStartProbe(packageRoot, `parallel-${index + 1}`);
+      }),
+    );
+
+    const evidence: ColdStartEvidence = {
+      runs,
+      wallClockMilliseconds: performance.now() - startedAt,
+    };
+
+    writeTimingEvidence('Bounded-parallel cold-start timing evidence', evidence);
+    assertColdStartEvidence(evidence);
+  }, 180_000);
+});

--- a/src/public/lib/hexo-renderer-asciidoc/test/asciidoctor.convert.test.ts
+++ b/src/public/lib/hexo-renderer-asciidoc/test/asciidoctor.convert.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2015 Shuai Zhang
+ * SPDX-License-Identifier: LGPL-3.0-or-later WITH LGPL-3.0-linking-exception
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const asciidoctorCore = vi.hoisted(() => ({
+  convert: vi.fn(),
+  Logger: vi.fn(
+    class TestLogger {
+      readonly identity = 'per-conversion-test-logger';
+    },
+  ),
+}));
+
+vi.mock('@asciidoctor/core', () => ({
+  convert: asciidoctorCore.convert,
+  Logger: asciidoctorCore.Logger,
+}));
+
+describe('convertAsciiDoc', () => {
+  beforeEach(() => {
+    asciidoctorCore.convert.mockReset();
+    asciidoctorCore.Logger.mockClear();
+    vi.resetModules();
+  });
+
+  it('passes the exact fixed input and controlled options to @asciidoctor/core', async () => {
+    asciidoctorCore.convert.mockResolvedValue('<p>converted</p>');
+    const { convertAsciiDoc } = await import('../src/core/asciidoctor');
+
+    await expect(convertAsciiDoc('== Exact Input ==')).resolves.toBe('<p>converted</p>');
+    expect(asciidoctorCore.convert).toHaveBeenCalledTimes(1);
+    const logger = asciidoctorCore.Logger.mock.instances[0];
+    expect(asciidoctorCore.convert).toHaveBeenCalledWith('== Exact Input ==', {
+      doctype: 'article',
+      logger,
+      safe: 'server',
+      to_file: false,
+    });
+    expect(asciidoctorCore.Logger).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects before calling @asciidoctor/core when input is not a string', async () => {
+    const { convertAsciiDoc } = await import('../src/core/asciidoctor');
+
+    await expect(convertAsciiDoc(42 as unknown as string)).rejects.toThrow(
+      new TypeError('Asciidoctor conversion requires string input: number'),
+    );
+    expect(asciidoctorCore.convert).not.toHaveBeenCalled();
+  });
+
+  it('rejects with TypeError when Asciidoctor does not return a string', async () => {
+    asciidoctorCore.convert.mockResolvedValue(42);
+    const { convertAsciiDoc } = await import('../src/core/asciidoctor');
+
+    await expect(convertAsciiDoc('== Non String ==')).rejects.toThrow(
+      new TypeError('Asciidoctor conversion did not return a string: number'),
+    );
+  });
+});

--- a/src/public/lib/hexo-renderer-asciidoc/test/asciidoctor.runtime.worker.ts
+++ b/src/public/lib/hexo-renderer-asciidoc/test/asciidoctor.runtime.worker.ts
@@ -1,0 +1,985 @@
+/**
+ * Copyright 2015 Shuai Zhang
+ * SPDX-License-Identifier: LGPL-3.0-or-later WITH LGPL-3.0-linking-exception
+ */
+
+import fs, { mkdirSync, mkdtempSync, readdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { createServer } from 'node:http';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import type { AbstractBlock, BlockProcessor, Reader, Registry } from '@asciidoctor/core';
+import { Extensions, Logger } from '@asciidoctor/core';
+import Hexo from 'hexo';
+import { afterEach, describe, expect, it } from 'vitest';
+import { convertAsciiDoc } from '../src/core/asciidoctor';
+import renderer from '../src/core/renderer';
+import registerRenderer from '../src/hexo/register';
+import type { Hexo as HexoContract } from '../src/types';
+
+const originalCwd = process.cwd();
+const temporaryDirectories: string[] = [];
+const SUPPORTED_EXTENSIONS = ['ad', 'adoc', 'asciidoc'] as const;
+
+type HexoRenderAPI = {
+  render(data: Record<string, unknown>, locals?: Record<string, unknown>): Promise<string>;
+};
+
+type HexoTestInstance = HexoContract & {
+  base_dir: string;
+  render: HexoRenderAPI;
+  init(): Promise<void>;
+  exit(err?: unknown): Promise<void>;
+};
+
+type HexoConstructor = new (baseDir: string, options?: Record<string, unknown>) => HexoTestInstance;
+
+const HexoClass = Hexo as unknown as HexoConstructor;
+
+const createTemporaryDirectory = (): string => {
+  const directory = mkdtempSync(path.join(tmpdir(), 'hexo-renderer-asciidoc-runtime-'));
+  temporaryDirectories.push(directory);
+  return directory;
+};
+
+const createHexoWorkspace = (): string => {
+  const directory = createTemporaryDirectory();
+  writeFileSync(path.join(directory, '_config.yml'), 'title: hexo-renderer-asciidoc\n');
+  return directory;
+};
+
+type LoopbackRequestRecord = {
+  method: string;
+  timestamp: string;
+  url: string;
+};
+
+/**
+ * Evidence record for a single include directive: paths extracted from Asciidoctor's
+ * diagnostic stderr messages and the canonical filesystem path (from realpathSync).
+ *
+ * Asciidoctor v4 emits exact resolved paths in its error messages when includes are
+ * denied or missing, providing direct evidence without inferring from output HTML.
+ */
+type IncludePathEvidence = {
+  /**
+   * The path Asciidoctor computed (after jail normalization) before the jail check.
+   * Extracted from the stderr diagnostic message for denied/missing includes.
+   */
+  jailNormalizedPath: string | null;
+  /** Whether the include was explicitly denied by the server-mode jail. */
+  denied: boolean;
+  /** Exact denial message from stderr (e.g. "illegal reference to ancestor of jail"). */
+  denialMessage: string | null;
+  /**
+   * Canonical realpath from `realpathSync` at test-setup time.
+   * For symlinks this is the target file's real path; null when the path does not exist.
+   */
+  canonicalPath: string | null;
+  /** The path string the include directive was given (from test setup). */
+  requestedPath: string;
+};
+
+/**
+ * Parse the jail-normalized path from an Asciidoctor stderr diagnostic message.
+ *
+ * Asciidoctor v4 formats include diagnostics as:
+ *   asciidoctor: ERROR: <stdin>: line N: include file not found: /abs/path
+ *   asciidoctor: ERROR: <stdin>: line N: illegal reference to ancestor of jail: /abs/path
+ *   asciidoctor: ERROR: <stdin>: line N: outside of jail: /abs/path
+ */
+const parseIncludePathFromStderr = (stderr: string): string | null => {
+  const match = /(?:include file not found|illegal reference to ancestor of jail|outside of jail): (.+)/.exec(stderr);
+  return match?.[1]?.trim() ?? null;
+};
+
+/**
+ * Build an IncludePathEvidence record from the rendered result, captured stderr,
+ * and the test-setup knowledge of what path was requested.
+ */
+const buildIncludePathEvidence = ({
+  denied,
+  requestedPath,
+  stderr,
+}: {
+  denied: boolean;
+  requestedPath: string;
+  stderr: string;
+}): IncludePathEvidence => {
+  const denialMessages = ['include file not found', 'illegal reference to ancestor of jail', 'outside of jail'];
+  const denialLine = stderr.split('\n').find((line) => denialMessages.some((msg) => line.includes(msg))) ?? null;
+  const denialMessage = denialLine?.trim() ?? null;
+  const jailNormalizedPath = parseIncludePathFromStderr(stderr);
+
+  let canonicalPath: string | null = null;
+  try {
+    canonicalPath =
+      typeof fs.realpathSync.native === 'function'
+        ? fs.realpathSync.native(requestedPath)
+        : fs.realpathSync(requestedPath);
+  } catch {
+    canonicalPath = null;
+  }
+
+  return {
+    canonicalPath,
+    denied,
+    denialMessage,
+    jailNormalizedPath,
+    requestedPath,
+  };
+};
+
+const drainPendingTasks = async (): Promise<void> => {
+  await Promise.resolve();
+  await new Promise<void>((resolve) => setImmediate(resolve));
+};
+
+const withCapturedStderr = async <T>(callback: () => Promise<T>): Promise<{ result: T; stderr: string }> => {
+  const originalWrite = process.stderr.write.bind(process.stderr);
+  let stderr = '';
+
+  process.stderr.write = ((chunk: string | Uint8Array) => {
+    stderr += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8');
+    return true;
+  }) as typeof process.stderr.write;
+
+  try {
+    return {
+      result: await callback(),
+      stderr,
+    };
+  } finally {
+    process.stderr.write = originalWrite as typeof process.stderr.write;
+  }
+};
+
+const formatLoopbackRequests = (requests: LoopbackRequestRecord[]): string =>
+  [
+    'unexpected loopback requests reached the include server:',
+    ...requests.map((request) => `- ${request.timestamp} ${request.method} ${request.url}`),
+  ].join('\n');
+
+const withHexo = async <T>(baseDirectory: string, callback: (hexo: HexoTestInstance) => Promise<T>): Promise<T> => {
+  const hexo = new HexoClass(baseDirectory, { silent: true, debug: false });
+  registerRenderer(hexo);
+
+  try {
+    await hexo.init();
+    return await callback(hexo);
+  } finally {
+    await drainPendingTasks();
+    await hexo.exit();
+    await drainPendingTasks();
+  }
+};
+
+const createSourceDocument = (marker: string, language: string): string => `
+== ${marker}
+
+[source,${language}]
+----
+const ${marker.replaceAll('-', '_')} = { lang: '${language}', marker: '${marker}' };
+----
+`;
+
+type OverlapRenderCase = {
+  callId: string;
+  contentSentinel: string;
+  errorSentinel?: string;
+  heading: string;
+  language: string;
+  loggerSentinel: string;
+  optionSentinel: string;
+};
+
+type LoggerLike = {
+  warn(message: string): void;
+};
+
+type ReaderWithLogger = Reader & {
+  getLogger(): LoggerLike;
+};
+
+type DocumentWithAttributes = {
+  getAttribute(name: string): unknown;
+};
+
+type ParentWithDocument = AbstractBlock & {
+  getDocument(): DocumentWithAttributes;
+};
+
+type OverlapBarrierRegistration = {
+  dispose: () => void;
+  getActiveCount: () => number;
+  getLoggers: () => ReadonlyMap<string, LoggerLike>;
+  getMaxActiveCount: () => number;
+};
+
+const OVERLAP_BLOCK_NAME = 'unit2overlap';
+let overlapExtensionSequence = 0;
+
+const countMatches = (value: string, pattern: RegExp): number => value.match(pattern)?.length ?? 0;
+
+const withObservedCoreLoggerWarnings = async <T>(
+  callback: () => Promise<T>,
+): Promise<{ result: T; warningsByLogger: ReadonlyMap<Logger, readonly string[]> }> => {
+  const originalAdd = Logger.prototype.add;
+  const warningsByLogger = new Map<Logger, string[]>();
+
+  Logger.prototype.add = function observedLoggerAdd(...args: Parameters<Logger['add']>): boolean {
+    const result = originalAdd.apply(this, args);
+    const message = args[1];
+    if (typeof message === 'string' && message.startsWith('UNIT2_LOG_SENTINEL:')) {
+      const warnings = warningsByLogger.get(this) ?? [];
+      warnings.push(message);
+      warningsByLogger.set(this, warnings);
+    }
+    return result;
+  };
+
+  try {
+    return {
+      result: await callback(),
+      warningsByLogger,
+    };
+  } finally {
+    Logger.prototype.add = originalAdd;
+  }
+};
+
+const createOverlapDocument = ({
+  callId,
+  contentSentinel,
+  errorSentinel,
+  heading,
+  language,
+  loggerSentinel,
+  optionSentinel,
+}: OverlapRenderCase): string =>
+  [
+    `:unit2-call-id: ${callId}`,
+    `:unit2-option-sentinel: ${optionSentinel}`,
+    `:unit2-logger-sentinel: ${loggerSentinel}`,
+    ...(errorSentinel ? [`:unit2-error-sentinel: ${errorSentinel}`] : []),
+    '',
+    `== ${heading}`,
+    '',
+    `[${OVERLAP_BLOCK_NAME}]`,
+    contentSentinel,
+    '',
+    `[source,${language}]`,
+    '----',
+    `const ${callId.replaceAll('-', '_')} = { content: '${contentSentinel}', option: '${optionSentinel}', logger: '${loggerSentinel}' };`,
+    '----',
+  ].join('\n');
+
+const registerOverlapBarrier = (expectedCount: number): OverlapBarrierRegistration => {
+  overlapExtensionSequence += 1;
+  const extensionName = `unit2-overlap-barrier-${overlapExtensionSequence}`;
+  let activeCount = 0;
+  let maxActiveCount = 0;
+  const loggers = new Map<string, LoggerLike>();
+  let settleBarrier: ((error?: Error) => void) | undefined;
+  const barrier = new Promise<void>((resolve, reject) => {
+    settleBarrier = (error?: Error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve();
+    };
+  });
+  const barrierTimeout = setTimeout(() => {
+    settleBarrier?.(new Error(`only ${activeCount} conversions reached the overlap barrier`));
+  }, 5_000);
+  const OverlapBlock = Extensions.createBlockProcessor('Unit2OverlapBarrier', {
+    async process(this: BlockProcessor, parent: AbstractBlock, reader: Reader, attributes: Record<string, unknown>) {
+      const document = (parent as ParentWithDocument).getDocument();
+      const callId = String(document.getAttribute('unit2-call-id') ?? '');
+      const optionSentinel = String(document.getAttribute('unit2-option-sentinel') ?? '');
+      const loggerSentinel = String(document.getAttribute('unit2-logger-sentinel') ?? '');
+      const errorSentinel = document.getAttribute('unit2-error-sentinel');
+      const logger =
+        typeof (reader as Partial<ReaderWithLogger>).getLogger === 'function'
+          ? (reader as ReaderWithLogger).getLogger()
+          : undefined;
+      if (!logger) {
+        throw new TypeError(`conversion ${callId} did not expose its core logger`);
+      }
+      loggers.set(callId, logger);
+      const barrierText = (await reader.readLines()).join('\n');
+
+      logger.warn(`UNIT2_LOG_SENTINEL:${loggerSentinel}`);
+      activeCount += 1;
+      maxActiveCount = Math.max(maxActiveCount, activeCount);
+      if (activeCount === expectedCount) {
+        clearTimeout(barrierTimeout);
+        settleBarrier?.();
+      }
+
+      try {
+        await barrier;
+        if (typeof errorSentinel === 'string' && errorSentinel.length > 0) {
+          throw new Error(`UNIT2_ERROR_SENTINEL:${errorSentinel}`);
+        }
+
+        return this.createParagraph(parent, `${barrierText}|OPTION:${optionSentinel}|CALL:${callId}`, attributes);
+      } finally {
+        activeCount -= 1;
+      }
+    },
+  });
+  OverlapBlock.option('name', OVERLAP_BLOCK_NAME);
+  OverlapBlock.option('contexts', ['paragraph']);
+  OverlapBlock.option('content_model', 'simple');
+  Extensions.register(extensionName, function registerBarrier(this: Registry) {
+    this.block(OverlapBlock);
+  });
+
+  return {
+    dispose: () => {
+      clearTimeout(barrierTimeout);
+      settleBarrier?.(new Error('overlap barrier disposed before completion'));
+      Extensions.unregister(extensionName);
+    },
+    getActiveCount: () => activeCount,
+    getLoggers: () => loggers,
+    getMaxActiveCount: () => maxActiveCount,
+  };
+};
+
+const withRegisteredOverlapBarrier = async <T>(
+  expectedCount: number,
+  callback: (registration: OverlapBarrierRegistration) => Promise<T>,
+): Promise<T> => {
+  const registration = registerOverlapBarrier(expectedCount);
+  try {
+    return await callback(registration);
+  } finally {
+    registration.dispose();
+  }
+};
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe.sequential('Asciidoctor v4 runtime worker', () => {
+  it('returns string output without writing files', async () => {
+    const workingDirectory = createTemporaryDirectory();
+    process.chdir(workingDirectory);
+
+    const { result, stderr } = await withCapturedStderr(() => convertAsciiDoc('== Controlled to_file false =='));
+
+    expect(result).toContain('<h2 id="_controlled_to_file_false">Controlled to_file false</h2>');
+    expect(readdirSync(workingDirectory)).toEqual([]);
+    expect(stderr).toBe('');
+  });
+
+  it('renders the production renderer in a fresh process for cold-start evidence', async () => {
+    const marker = 'cold-start-production-renderer';
+    const result = await renderer({ text: createSourceDocument(marker, 'javascript') });
+
+    expect(result).toContain(`<h2 id="_${marker.replaceAll('-', '_')}">${marker}</h2>`);
+    expect(result).toContain('<code class="highlight javascript">');
+    expect(result).toContain(marker.replaceAll('-', '_'));
+    expect(result).not.toContain('[object Promise]');
+  });
+
+  it('keeps include resolution tied to the active CWD while ignoring data.path and Hexo site root', async () => {
+    const workingDirectory = createTemporaryDirectory();
+    const firstSiteRoot = createHexoWorkspace();
+    const secondSiteRoot = createHexoWorkspace();
+    const text = 'include::included.adoc[]';
+
+    writeFileSync(path.join(workingDirectory, 'included.adoc'), 'FROM_CWD');
+    writeFileSync(path.join(firstSiteRoot, 'included.adoc'), 'FROM_FIRST_SITE_ROOT');
+    writeFileSync(path.join(secondSiteRoot, 'included.adoc'), 'FROM_SECOND_SITE_ROOT');
+    process.chdir(workingDirectory);
+
+    // Evidence: the expected include path is `{workingDirectory}/included.adoc`.
+    // The three other directories hold distinct sentinels so the output proves which
+    // file was read without ambiguity.
+    const expectedIncludePath = path.join(workingDirectory, 'included.adoc');
+    expect(fs.realpathSync(expectedIncludePath)).toBe(expectedIncludePath);
+
+    const directOutputs = await Promise.all([
+      renderer({ text }),
+      renderer({ text, path: null }),
+      renderer({ text, path: 'nested/document.adoc' }),
+      renderer({ text, path: path.join(workingDirectory, 'document.adoc') }),
+    ]);
+
+    expect(new Set(directOutputs).size).toBe(1);
+    for (const output of directOutputs) {
+      expect(output).toContain('FROM_CWD');
+      expect(output).not.toContain('FROM_FIRST_SITE_ROOT');
+      expect(output).not.toContain('FROM_SECOND_SITE_ROOT');
+    }
+
+    const [firstSiteOutput, secondSiteOutput] = await Promise.all([
+      withHexo(firstSiteRoot, async (hexo) => await hexo.render.render({ text, engine: 'adoc' })),
+      withHexo(secondSiteRoot, async (hexo) => await hexo.render.render({ text, engine: 'adoc' })),
+    ]);
+
+    expect(firstSiteOutput).toContain('FROM_CWD');
+    expect(firstSiteOutput).not.toContain('FROM_FIRST_SITE_ROOT');
+    expect(secondSiteOutput).toContain('FROM_CWD');
+    expect(secondSiteOutput).not.toContain('FROM_SECOND_SITE_ROOT');
+    expect(firstSiteOutput).toBe(secondSiteOutput);
+  });
+
+  it('changes relative include resolution when only the active CWD changes', async () => {
+    const firstWorkingDirectory = createTemporaryDirectory();
+    const secondWorkingDirectory = createTemporaryDirectory();
+    writeFileSync(path.join(firstWorkingDirectory, 'included.adoc'), 'FIRST_CWD');
+    writeFileSync(path.join(secondWorkingDirectory, 'included.adoc'), 'SECOND_CWD');
+
+    process.chdir(firstWorkingDirectory);
+    const first = await renderer({ text: 'include::included.adoc[]' });
+    process.chdir(secondWorkingDirectory);
+    const second = await renderer({ text: 'include::included.adoc[]' });
+
+    expect(first).toContain('FIRST_CWD');
+    expect(first).not.toContain('SECOND_CWD');
+    expect(second).toContain('SECOND_CWD');
+    expect(second).not.toContain('FIRST_CWD');
+  });
+
+  it('captures missing, traversal, absolute, and symlink include behavior', async () => {
+    const root = createTemporaryDirectory();
+    const workingDirectory = path.join(root, 'working');
+    const outsideDirectory = path.join(root, 'outside');
+    mkdirSync(workingDirectory);
+    mkdirSync(outsideDirectory);
+
+    const outsideFile = path.join(outsideDirectory, 'outside.adoc');
+    writeFileSync(outsideFile, 'OUTSIDE_INCLUDE_SENTINEL');
+    symlinkSync(outsideFile, path.join(workingDirectory, 'linked.adoc'));
+    process.chdir(workingDirectory);
+
+    // Pre-compute canonical paths from test-setup to document expected evidence.
+    // For denied cases: Asciidoctor logs the exact resolved path in stderr.
+    // For symlink: realpathSync exposes the real target.
+    const symLinkPath = path.join(workingDirectory, 'linked.adoc');
+    const symLinkRealPath = fs.realpathSync(symLinkPath);
+    expect(symLinkRealPath).toBe(outsideFile);
+
+    const includeCases = [
+      {
+        denied: false,
+        requestedPath: path.join(workingDirectory, 'missing.adoc'),
+        key: 'missing',
+        text: 'include::missing.adoc[]',
+      },
+      {
+        denied: true,
+        requestedPath: path.join(workingDirectory, '../outside/outside.adoc'),
+        key: 'traversal',
+        text: 'include::../outside/outside.adoc[]',
+      },
+      {
+        denied: true,
+        requestedPath: outsideFile,
+        key: 'absolute',
+        text: `include::${outsideFile}[]`,
+      },
+      {
+        denied: false,
+        requestedPath: symLinkPath,
+        key: 'symlink',
+        text: 'include::linked.adoc[]',
+      },
+    ] as const;
+
+    const stderrByCase: Record<(typeof includeCases)[number]['key'], string> = {
+      absolute: '',
+      missing: '',
+      symlink: '',
+      traversal: '',
+    };
+    const renderedByCase: Record<(typeof includeCases)[number]['key'], string> = {
+      absolute: '',
+      missing: '',
+      symlink: '',
+      traversal: '',
+    };
+    const evidenceByCase: Record<(typeof includeCases)[number]['key'], IncludePathEvidence> = {
+      absolute: {
+        canonicalPath: null,
+        denied: true,
+        denialMessage: null,
+        jailNormalizedPath: null,
+        requestedPath: outsideFile,
+      },
+      missing: {
+        canonicalPath: null,
+        denied: false,
+        denialMessage: null,
+        jailNormalizedPath: null,
+        requestedPath: path.join(workingDirectory, 'missing.adoc'),
+      },
+      symlink: {
+        canonicalPath: null,
+        denied: false,
+        denialMessage: null,
+        jailNormalizedPath: null,
+        requestedPath: symLinkPath,
+      },
+      traversal: {
+        canonicalPath: null,
+        denied: true,
+        denialMessage: null,
+        jailNormalizedPath: null,
+        requestedPath: path.join(workingDirectory, '../outside/outside.adoc'),
+      },
+    };
+
+    for (const includeCase of includeCases) {
+      const { result: rendered, stderr } = await withCapturedStderr(
+        async () => await renderer({ text: includeCase.text }),
+      );
+
+      stderrByCase[includeCase.key] = stderr;
+      renderedByCase[includeCase.key] = rendered;
+      evidenceByCase[includeCase.key] = buildIncludePathEvidence({
+        denied: includeCase.denied,
+        requestedPath: includeCase.requestedPath,
+        stderr,
+      });
+    }
+
+    // Output sentinel checks (retained separately from path evidence).
+    expect(renderedByCase.missing).toContain('Unresolved directive');
+    expect(renderedByCase.missing).not.toContain('OUTSIDE_INCLUDE_SENTINEL');
+    expect(renderedByCase.traversal).toContain('Unresolved directive');
+    expect(renderedByCase.traversal).not.toContain('OUTSIDE_INCLUDE_SENTINEL');
+    expect(renderedByCase.absolute).toContain('Unresolved directive');
+    expect(renderedByCase.absolute).not.toContain('OUTSIDE_INCLUDE_SENTINEL');
+    expect(renderedByCase.symlink).toContain('OUTSIDE_INCLUDE_SENTINEL');
+
+    // Exact path evidence from Asciidoctor's stderr diagnostics.
+    expect(evidenceByCase.missing.jailNormalizedPath).toBe(path.join(workingDirectory, 'missing.adoc'));
+    expect(evidenceByCase.missing.denied).toBe(false);
+    expect(evidenceByCase.missing.canonicalPath).toBeNull();
+    expect(evidenceByCase.missing.denialMessage).toContain('include file not found');
+
+    expect(evidenceByCase.traversal.jailNormalizedPath).not.toBeNull();
+    expect(evidenceByCase.traversal.denied).toBe(true);
+    // The file exists outside the jail; realpathSync resolves to the real target.
+    expect(evidenceByCase.traversal.canonicalPath).toBe(outsideFile);
+    expect(evidenceByCase.traversal.denialMessage).toContain('illegal reference to ancestor of jail');
+
+    expect(evidenceByCase.absolute.jailNormalizedPath).not.toBeNull();
+    expect(evidenceByCase.absolute.denied).toBe(true);
+    // The file exists outside the jail; realpathSync resolves to the real target.
+    expect(evidenceByCase.absolute.canonicalPath).toBe(outsideFile);
+    expect(evidenceByCase.absolute.denialMessage).toContain('outside of jail');
+
+    // Symlink: no denial, canonical path resolves to the real target.
+    expect(evidenceByCase.symlink.denied).toBe(false);
+    expect(evidenceByCase.symlink.denialMessage).toBeNull();
+    expect(evidenceByCase.symlink.canonicalPath).toBe(outsideFile);
+    expect(evidenceByCase.symlink.requestedPath).toBe(symLinkPath);
+
+    // Stderr diagnostic checks.
+    expect(stderrByCase.missing).toContain('include file not found');
+    expect(stderrByCase.traversal).toContain('illegal reference to ancestor of jail');
+    expect(stderrByCase.absolute).toContain('outside of jail');
+    expect(stderrByCase.symlink).not.toContain('linked.adoc');
+  });
+
+  it('never issues unexpected loopback URI requests even when allow-uri-read is declared', async () => {
+    const requests: LoopbackRequestRecord[] = [];
+    const server = createServer((request, response) => {
+      requests.push({
+        method: request.method ?? 'UNKNOWN',
+        timestamp: new Date().toISOString(),
+        url: request.url ?? '<empty>',
+      });
+      response.writeHead(403, { 'content-type': 'text/plain; charset=utf-8' });
+      response.end('REMOTE_INCLUDE_REQUEST_FORBIDDEN');
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(0, '127.0.0.1', () => resolve());
+    });
+
+    const address = server.address();
+    if (!address || typeof address === 'string') {
+      await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+      throw new TypeError('expected an ephemeral loopback server address');
+    }
+
+    const withoutAllowUriReadUri = `http://127.0.0.1:${address.port}/case-no-allow/remote.adoc`;
+    const withAllowUriReadUri = `http://127.0.0.1:${address.port}/case-with-allow/remote.adoc`;
+
+    let result: { withoutAllowUriRead: string; withAllowUriRead: string };
+    let stderr: string;
+    try {
+      ({ result, stderr } = await withCapturedStderr(async () => ({
+        withoutAllowUriRead: await renderer({ text: `include::${withoutAllowUriReadUri}[]` }),
+        withAllowUriRead: await renderer({ text: `:allow-uri-read:\n\ninclude::${withAllowUriReadUri}[]` }),
+      })));
+    } finally {
+      await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+    }
+
+    expect(result.withoutAllowUriRead).toContain(withoutAllowUriReadUri);
+    expect(result.withAllowUriRead).toContain(withAllowUriReadUri);
+    expect(result.withoutAllowUriRead).not.toContain('REMOTE_INCLUDE_REQUEST_FORBIDDEN');
+    expect(result.withAllowUriRead).not.toContain('REMOTE_INCLUDE_REQUEST_FORBIDDEN');
+    expect(stderr.match(/allow-uri-read attribute not enabled/g)?.length).toBe(2);
+    if (requests.length > 0) {
+      throw new Error(formatLoopbackRequests(requests));
+    }
+  });
+
+  it('keeps multiple outstanding conversion and renderer promises isolated', async () => {
+    const renderCases = [
+      { marker: 'parallel-javascript', language: 'javascript' },
+      { marker: 'parallel-ruby', language: 'ruby' },
+      { marker: 'parallel-python', language: 'python' },
+    ] as const;
+    const extensionName = 'unit2-concurrency-barrier';
+    let conversionsAtBarrier = 0;
+    let maximumConversionsAtBarrier = 0;
+    let releaseBarrier: (() => void) | undefined;
+    let rejectBarrier: ((reason: Error) => void) | undefined;
+    const barrier = new Promise<void>((resolve, reject) => {
+      releaseBarrier = resolve;
+      rejectBarrier = reject;
+    });
+    const barrierTimeout = setTimeout(() => {
+      rejectBarrier?.(new Error(`only ${conversionsAtBarrier} conversions reached the concurrency barrier`));
+    }, 5_000);
+    const BarrierBlock = Extensions.createBlockProcessor('Unit2ConcurrencyBarrier', {
+      async process(this: BlockProcessor, parent: AbstractBlock, reader: Reader, attributes: Record<string, unknown>) {
+        conversionsAtBarrier += 1;
+        maximumConversionsAtBarrier = Math.max(maximumConversionsAtBarrier, conversionsAtBarrier);
+        if (conversionsAtBarrier === renderCases.length) {
+          clearTimeout(barrierTimeout);
+          releaseBarrier?.();
+        }
+        await barrier;
+        conversionsAtBarrier -= 1;
+        return this.createParagraph(parent, (await reader.readLines()).join('\n'), attributes);
+      },
+    });
+    BarrierBlock.option('name', 'unit2barrier');
+    BarrierBlock.option('contexts', ['paragraph']);
+    BarrierBlock.option('content_model', 'simple');
+    Extensions.register(extensionName, function registerBarrier(this: Registry) {
+      this.block(BarrierBlock);
+    });
+
+    let renderOutputs: string[];
+    try {
+      renderOutputs = await Promise.all(
+        renderCases.map(({ marker, language }) =>
+          renderer({
+            text: `[unit2barrier]\nBARRIER_${marker}\n\n${createSourceDocument(marker, language)}`,
+          }),
+        ),
+      );
+    } finally {
+      clearTimeout(barrierTimeout);
+      Extensions.unregister(extensionName);
+    }
+
+    expect(maximumConversionsAtBarrier).toBe(renderCases.length);
+    expect(conversionsAtBarrier).toBe(0);
+
+    for (const [index, output] of renderOutputs.entries()) {
+      const renderCase = renderCases[index];
+      if (!renderCase) {
+        throw new RangeError(`missing render case at index ${index}`);
+      }
+      const { marker, language } = renderCase;
+      expect(output).toContain(`<h2 id="_${marker.replaceAll('-', '_')}">${marker}</h2>`);
+      expect(output).toContain(`<code class="highlight ${language}">`);
+      expect(output).toContain(marker.replaceAll('-', '_'));
+      expect(output).toContain(`BARRIER_${marker}`);
+      expect(output).not.toContain('[object Promise]');
+      for (const otherCase of renderCases) {
+        if (otherCase !== renderCase) {
+          expect(output).not.toContain(otherCase.marker);
+        }
+      }
+    }
+  });
+
+  it('proves strict real-runtime overlap and isolation across a mixed batch with sentinels', async () => {
+    const successCases = [
+      {
+        callId: 'unit2-batch-javascript',
+        contentSentinel: 'CONTENT_SENTINEL_A',
+        heading: 'Unit2 Batch Javascript',
+        language: 'javascript',
+        loggerSentinel: 'LOGGER_SENTINEL_A',
+        optionSentinel: 'OPTION_SENTINEL_A',
+      },
+      {
+        callId: 'unit2-batch-ruby',
+        contentSentinel: 'CONTENT_SENTINEL_B',
+        heading: 'Unit2 Batch Ruby',
+        language: 'ruby',
+        loggerSentinel: 'LOGGER_SENTINEL_B',
+        optionSentinel: 'OPTION_SENTINEL_B',
+      },
+      {
+        callId: 'unit2-batch-python',
+        contentSentinel: 'CONTENT_SENTINEL_C',
+        heading: 'Unit2 Batch Python',
+        language: 'python',
+        loggerSentinel: 'LOGGER_SENTINEL_C',
+        optionSentinel: 'OPTION_SENTINEL_C',
+      },
+    ] satisfies [OverlapRenderCase, OverlapRenderCase, OverlapRenderCase];
+    const failureCase: OverlapRenderCase = {
+      callId: 'unit2-batch-failure',
+      contentSentinel: 'CONTENT_SENTINEL_FAILURE',
+      errorSentinel: 'ERROR_SENTINEL_FAILURE',
+      heading: 'Unit2 Batch Failure',
+      language: 'json',
+      loggerSentinel: 'LOGGER_SENTINEL_FAILURE',
+      optionSentinel: 'OPTION_SENTINEL_FAILURE',
+    };
+    const mixedBatchCases: OverlapRenderCase[] = [successCases[0], failureCase, successCases[1], successCases[2]];
+
+    const expectedSuccessOutputs = new Map<string, string>();
+    for (const overlapCase of successCases) {
+      const { result } = await withCapturedStderr(
+        async () =>
+          await withRegisteredOverlapBarrier(1, async () => {
+            return await renderer({ text: createOverlapDocument(overlapCase) });
+          }),
+      );
+      expectedSuccessOutputs.set(overlapCase.callId, result);
+    }
+    const { result: expectedFailureReason } = await withCapturedStderr(
+      async () =>
+        await withRegisteredOverlapBarrier(1, async () => {
+          try {
+            await renderer({ text: createOverlapDocument(failureCase) });
+          } catch (error) {
+            return error as Error;
+          }
+
+          throw new TypeError('expected the overlap failure case to reject');
+        }),
+    );
+
+    const {
+      result: { result: mixedResults, stderr: mixedStderr },
+      warningsByLogger,
+    } = await withObservedCoreLoggerWarnings(
+      async () =>
+        await withCapturedStderr(
+          async () =>
+            await withRegisteredOverlapBarrier(mixedBatchCases.length, async (registration) => {
+              const settled = await Promise.allSettled(
+                mixedBatchCases.map((overlapCase) => renderer({ text: createOverlapDocument(overlapCase) })),
+              );
+
+              expect(registration.getMaxActiveCount()).toBe(mixedBatchCases.length);
+              expect(registration.getActiveCount()).toBe(0);
+              return { loggerByCall: new Map(registration.getLoggers()), settled };
+            }),
+        ),
+    );
+
+    expect(mixedResults.settled).toHaveLength(mixedBatchCases.length);
+
+    for (const overlapCase of mixedBatchCases) {
+      expect(countMatches(mixedStderr, new RegExp(`UNIT2_LOG_SENTINEL:${overlapCase.loggerSentinel}`, 'g'))).toBe(1);
+    }
+
+    expect(new Set(mixedResults.loggerByCall.values()).size).toBe(mixedBatchCases.length);
+    for (const overlapCase of mixedBatchCases) {
+      const logger = mixedResults.loggerByCall.get(overlapCase.callId);
+      expect(logger).toBeInstanceOf(Logger);
+      if (!(logger instanceof Logger)) {
+        throw new TypeError(`missing core logger identity for ${overlapCase.callId}`);
+      }
+      expect(warningsByLogger.get(logger)).toEqual([`UNIT2_LOG_SENTINEL:${overlapCase.loggerSentinel}`]);
+      for (const otherCase of mixedBatchCases) {
+        if (otherCase !== overlapCase) {
+          expect(warningsByLogger.get(logger)?.every((warning) => !warning.includes(otherCase.loggerSentinel))).toBe(
+            true,
+          );
+        }
+      }
+    }
+
+    for (const [index, mixedResult] of mixedResults.settled.entries()) {
+      const overlapCase = mixedBatchCases[index];
+      if (!overlapCase) {
+        throw new RangeError(`missing overlap case at index ${index}`);
+      }
+
+      if (overlapCase.errorSentinel) {
+        expect(mixedResult).toMatchObject({ status: 'rejected' });
+        if (mixedResult.status !== 'rejected') {
+          throw new TypeError('expected a rejected overlap result');
+        }
+        expect(mixedResult.reason).toBeInstanceOf(Error);
+        expect(mixedResult.reason.name).toBe(expectedFailureReason.name);
+        expect(mixedResult.reason.message).toBe(expectedFailureReason.message);
+        expect(mixedResult.reason.message).toContain(`UNIT2_ERROR_SENTINEL:${overlapCase.errorSentinel}`);
+        for (const otherCase of mixedBatchCases) {
+          if (otherCase !== overlapCase) {
+            expect(mixedResult.reason.message).not.toContain(otherCase.contentSentinel);
+            expect(mixedResult.reason.message).not.toContain(otherCase.optionSentinel);
+            expect(mixedResult.reason.message).not.toContain(otherCase.loggerSentinel);
+            if (otherCase.errorSentinel) {
+              expect(mixedResult.reason.message).not.toContain(otherCase.errorSentinel);
+            }
+          }
+        }
+        continue;
+      }
+
+      expect(mixedResult).toMatchObject({ status: 'fulfilled' });
+      if (mixedResult.status !== 'fulfilled') {
+        throw new TypeError('expected a fulfilled overlap result');
+      }
+
+      const expectedOutput = expectedSuccessOutputs.get(overlapCase.callId);
+      if (!expectedOutput) {
+        throw new RangeError(`missing expected overlap output for ${overlapCase.callId}`);
+      }
+
+      expect(mixedResult.value).toBe(expectedOutput);
+      expect(mixedResult.value).toContain(
+        `<h2 id="_${overlapCase.heading.toLowerCase().replaceAll(' ', '_')}">${overlapCase.heading}</h2>`,
+      );
+      expect(mixedResult.value).toContain(`<code class="highlight ${overlapCase.language}">`);
+      expect(mixedResult.value).toContain(overlapCase.contentSentinel);
+      expect(mixedResult.value).toContain(overlapCase.optionSentinel);
+      expect(mixedResult.value).toContain(overlapCase.callId.replaceAll('-', '_'));
+      expect(mixedResult.value).not.toContain('[object Promise]');
+      for (const otherCase of mixedBatchCases) {
+        if (otherCase === overlapCase) {
+          continue;
+        }
+
+        expect(mixedResult.value).not.toContain(otherCase.contentSentinel);
+        expect(mixedResult.value).not.toContain(otherCase.optionSentinel);
+        expect(mixedResult.value).not.toContain(otherCase.loggerSentinel);
+        if (otherCase.errorSentinel) {
+          expect(mixedResult.value).not.toContain(otherCase.errorSentinel);
+        }
+      }
+    }
+
+    const recoveryCase: OverlapRenderCase = {
+      callId: 'unit2-post-failure-success',
+      contentSentinel: 'CONTENT_SENTINEL_RECOVERY',
+      heading: 'Unit2 Post Failure Success',
+      language: 'yaml',
+      loggerSentinel: 'LOGGER_SENTINEL_RECOVERY',
+      optionSentinel: 'OPTION_SENTINEL_RECOVERY',
+    };
+    const { result: recoveryOutput, stderr: recoveryStderr } = await withCapturedStderr(
+      async () =>
+        await withRegisteredOverlapBarrier(1, async () => {
+          return await renderer({ text: createOverlapDocument(recoveryCase) });
+        }),
+    );
+
+    expect(countMatches(recoveryStderr, /UNIT2_LOG_SENTINEL:LOGGER_SENTINEL_RECOVERY/g)).toBe(1);
+    expect(recoveryOutput).toContain('<h2 id="_unit2_post_failure_success">Unit2 Post Failure Success</h2>');
+    expect(recoveryOutput).toContain('<code class="highlight yaml">');
+    expect(recoveryOutput).toContain(recoveryCase.contentSentinel);
+    expect(recoveryOutput).toContain(recoveryCase.optionSentinel);
+    expect(recoveryOutput).not.toContain('[object Promise]');
+    for (const overlapCase of mixedBatchCases) {
+      expect(recoveryOutput).not.toContain(overlapCase.contentSentinel);
+      expect(recoveryOutput).not.toContain(overlapCase.optionSentinel);
+      expect(recoveryOutput).not.toContain(overlapCase.loggerSentinel);
+      if (overlapCase.errorSentinel) {
+        expect(recoveryOutput).not.toContain(overlapCase.errorSentinel);
+      }
+    }
+  });
+
+  it('produces equivalent isolated output across repeated bounded parallel batches', async () => {
+    const languages = ['javascript', 'ruby', 'python'] as const;
+    for (let round = 1; round <= 3; round += 1) {
+      const cases = SUPPORTED_EXTENSIONS.map((extension, index) => {
+        const language = languages[index];
+        if (!language) {
+          throw new RangeError(`missing language at index ${index}`);
+        }
+        return {
+          extension,
+          marker: `round-${round}-${extension}-${index}`,
+          language,
+        };
+      });
+
+      const expected = [];
+      for (const testCase of cases) {
+        expected.push(await renderer({ text: createSourceDocument(testCase.marker, testCase.language) }));
+      }
+
+      const actual = await Promise.all(
+        cases.map(
+          async (testCase) => await renderer({ text: createSourceDocument(testCase.marker, testCase.language) }),
+        ),
+      );
+
+      expect(actual).toEqual(expected);
+      for (const [index, output] of actual.entries()) {
+        const testCase = cases[index];
+        if (!testCase) {
+          throw new RangeError(`missing parallel case at index ${index}`);
+        }
+        expect(output).toContain(`<h2 id="_${testCase.marker.replaceAll('-', '_')}">${testCase.marker}</h2>`);
+        expect(output).toContain(`<code class="highlight ${testCase.language}">`);
+      }
+    }
+  });
+
+  it('supports mixed concurrent success and failure and still succeeds afterwards', async () => {
+    const mixedResults = await Promise.allSettled([
+      renderer({ text: createSourceDocument('mixed-success-javascript', 'javascript') }),
+      renderer({ text: 42 as unknown as string }),
+      convertAsciiDoc('== convert-success =='),
+      convertAsciiDoc({ invalid: true } as unknown as string),
+      renderer({ text: createSourceDocument('mixed-success-ruby', 'ruby') }),
+    ]);
+
+    expect(mixedResults[0]).toMatchObject({ status: 'fulfilled' });
+    expect(mixedResults[1]).toMatchObject({ status: 'rejected' });
+    expect(mixedResults[2]).toMatchObject({ status: 'fulfilled' });
+    expect(mixedResults[3]).toMatchObject({ status: 'rejected' });
+    expect(mixedResults[4]).toMatchObject({ status: 'fulfilled' });
+
+    const successfulRendererOutputs = [mixedResults[0], mixedResults[4]]
+      .filter((result): result is PromiseFulfilledResult<string> => result.status === 'fulfilled')
+      .map((result) => result.value);
+    expect(successfulRendererOutputs[0]).toContain('mixed-success-javascript');
+    expect(successfulRendererOutputs[0]).toContain('<code class="highlight javascript">');
+    expect(successfulRendererOutputs[1]).toContain('mixed-success-ruby');
+    expect(successfulRendererOutputs[1]).toContain('<code class="highlight ruby">');
+
+    const failedReasons = [mixedResults[1], mixedResults[3]]
+      .filter((result): result is PromiseRejectedResult => result.status === 'rejected')
+      .map((result) => result.reason);
+    expect(failedReasons).toEqual(expect.arrayContaining([expect.any(TypeError)]));
+
+    const recoveryRender = await renderer({ text: createSourceDocument('post-failure-success', 'python') });
+    const recoveryConvert = await convertAsciiDoc('== Post Failure Success ==');
+
+    expect(recoveryRender).toContain('post-failure-success');
+    expect(recoveryRender).toContain('<code class="highlight python">');
+    expect(recoveryConvert).toContain('Post Failure Success');
+  });
+});

--- a/src/public/lib/hexo-renderer-asciidoc/test/asciidoctor.test.ts
+++ b/src/public/lib/hexo-renderer-asciidoc/test/asciidoctor.test.ts
@@ -3,130 +3,40 @@
  * SPDX-License-Identifier: LGPL-3.0-or-later WITH LGPL-3.0-linking-exception
  */
 
-import { mkdirSync, mkdtempSync, readdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
 import path from 'node:path';
-import { afterEach, describe, expect, it } from 'vitest';
-import { ASCIIDOCTOR_DEFAULT_OPTIONS, convertAsciiDoc } from '../src/core/asciidoctor';
-import renderer from '../src/core/renderer';
+import { describe, expect, it } from 'vitest';
+import { runVitestSubprocess } from './helpers/vitest-subprocess';
 
-const originalCwd = process.cwd();
-const temporaryDirectories: string[] = [];
+const CHILD_TIMEOUT_MS = 30_000;
+const CASES = [
+  'returns string output without writing files',
+  'keeps include resolution tied to the active CWD while ignoring data.path and Hexo site root',
+  'changes relative include resolution when only the active CWD changes',
+  'captures missing, traversal, absolute, and symlink include behavior',
+  'never issues unexpected loopback URI requests even when allow-uri-read is declared',
+  'keeps multiple outstanding conversion and renderer promises isolated',
+  'proves strict real-runtime overlap and isolation across a mixed batch with sentinels',
+  'produces equivalent isolated output across repeated bounded parallel batches',
+  'supports mixed concurrent success and failure and still succeeds afterwards',
+] as const;
+const MATRIX_TIMEOUT_MS = CHILD_TIMEOUT_MS * CASES.length + 30_000;
 
-const createTemporaryDirectory = (): string => {
-  const directory = mkdtempSync(path.join(tmpdir(), 'hexo-renderer-asciidoc-characterization-'));
-  temporaryDirectories.push(directory);
-  return directory;
-};
+describe('Asciidoctor v4 runtime characterization', () => {
+  it(
+    'covers each filesystem, URI, and concurrency case in a strict isolated subprocess',
+    async () => {
+      const packageRoot = path.resolve(import.meta.dirname, '..');
 
-afterEach(() => {
-  process.chdir(originalCwd);
-  for (const directory of temporaryDirectories.splice(0)) {
-    rmSync(directory, { recursive: true, force: true });
-  }
-});
-
-describe.sequential('Asciidoctor v3 filesystem characterization', () => {
-  it('uses the server safe mode and does not set a default base_dir', () => {
-    expect(ASCIIDOCTOR_DEFAULT_OPTIONS).toMatchObject({
-      attributes: ['source-highlighter=html-pipeline'],
-      doctype: 'article',
-      safe: 'server',
-    });
-    expect(ASCIIDOCTOR_DEFAULT_OPTIONS).not.toHaveProperty('base_dir');
-    expect(ASCIIDOCTOR_DEFAULT_OPTIONS).not.toHaveProperty('to_file');
-  });
-
-  it('resolves a local include from the conversion-time CWD', () => {
-    const workingDirectory = createTemporaryDirectory();
-    writeFileSync(path.join(workingDirectory, 'included.adoc'), 'INCLUDED_FROM_CWD');
-    process.chdir(workingDirectory);
-
-    const result = renderer({ text: 'include::included.adoc[]' });
-
-    expect(result).toContain('INCLUDED_FROM_CWD');
-  });
-
-  it('allows an explicit base_dir override only through the conversion seam', () => {
-    const workingDirectory = createTemporaryDirectory();
-    const baseDirectory = createTemporaryDirectory();
-    writeFileSync(path.join(workingDirectory, 'included.adoc'), 'FROM_CWD');
-    writeFileSync(path.join(baseDirectory, 'included.adoc'), 'FROM_BASE_DIR');
-    process.chdir(workingDirectory);
-
-    const fromCwd = convertAsciiDoc('include::included.adoc[]');
-    const fromBaseDirectory = convertAsciiDoc('include::included.adoc[]', {
-      base_dir: baseDirectory,
-    });
-
-    expect(fromCwd).toContain('FROM_CWD');
-    expect(fromBaseDirectory).toContain('FROM_BASE_DIR');
-    expect(fromBaseDirectory).not.toContain('FROM_CWD');
-  });
-
-  it('keeps the to_file false experiment separate and does not create output files for string input', () => {
-    const workingDirectory = createTemporaryDirectory();
-    process.chdir(workingDirectory);
-
-    const html = convertAsciiDoc('== Controlled to_file false ==', { to_file: false });
-
-    expect(html).toContain('<h2 id="_controlled_to_file_false">Controlled to_file false</h2>');
-    expect(readdirSync(workingDirectory)).toEqual([]);
-  });
-
-  it('is invariant across absent, null, relative, and absolute data.path values', () => {
-    const workingDirectory = createTemporaryDirectory();
-    writeFileSync(path.join(workingDirectory, 'included.adoc'), 'PATH_INVARIANT_INCLUDE');
-    process.chdir(workingDirectory);
-    const text = 'include::included.adoc[]';
-
-    const outputs = [
-      renderer({ text }),
-      renderer({ text, path: null }),
-      renderer({ text, path: 'nested/document.adoc' }),
-      renderer({ text, path: path.join(workingDirectory, 'document.adoc') }),
-    ];
-
-    expect(new Set(outputs).size).toBe(1);
-    expect(outputs[0]).toContain('PATH_INVARIANT_INCLUDE');
-  });
-
-  it('changes relative include resolution when only the CWD changes', () => {
-    const firstWorkingDirectory = createTemporaryDirectory();
-    const secondWorkingDirectory = createTemporaryDirectory();
-    writeFileSync(path.join(firstWorkingDirectory, 'included.adoc'), 'FIRST_CWD');
-    writeFileSync(path.join(secondWorkingDirectory, 'included.adoc'), 'SECOND_CWD');
-
-    process.chdir(firstWorkingDirectory);
-    const first = renderer({ text: 'include::included.adoc[]' });
-    process.chdir(secondWorkingDirectory);
-    const second = renderer({ text: 'include::included.adoc[]' });
-
-    expect(first).toContain('FIRST_CWD');
-    expect(first).not.toContain('SECOND_CWD');
-    expect(second).toContain('SECOND_CWD');
-    expect(second).not.toContain('FIRST_CWD');
-  });
-
-  it('denies traversal and absolute paths while retaining symlink include behavior', () => {
-    const root = createTemporaryDirectory();
-    const workingDirectory = path.join(root, 'working');
-    const outsideDirectory = path.join(root, 'outside');
-    mkdirSync(workingDirectory);
-    mkdirSync(outsideDirectory);
-    const outsideFile = path.join(outsideDirectory, 'outside.adoc');
-    writeFileSync(outsideFile, 'OUTSIDE_INCLUDE_SENTINEL');
-    symlinkSync(outsideFile, path.join(workingDirectory, 'linked.adoc'));
-    process.chdir(workingDirectory);
-
-    const traversal = renderer({ text: 'include::../outside/outside.adoc[]' });
-    const absolute = renderer({ text: `include::${outsideFile}[]` });
-    const symlink = renderer({ text: 'include::linked.adoc[]' });
-
-    expect(traversal).toContain('Unresolved directive');
-    expect(traversal).not.toContain('OUTSIDE_INCLUDE_SENTINEL');
-    expect(absolute).toContain('Unresolved directive');
-    expect(absolute).not.toContain('OUTSIDE_INCLUDE_SENTINEL');
-    expect(symlink).toContain('OUTSIDE_INCLUDE_SENTINEL');
-  });
+      for (const testName of CASES) {
+        await expect(
+          runVitestSubprocess({
+            args: ['--config', 'vitest.asciidoctor-runtime.config.ts', '-t', testName],
+            cwd: packageRoot,
+            timeout: CHILD_TIMEOUT_MS,
+          }),
+        ).resolves.toBeUndefined();
+      }
+    },
+    MATRIX_TIMEOUT_MS,
+  );
 });

--- a/src/public/lib/hexo-renderer-asciidoc/test/asciidoctor.test.ts
+++ b/src/public/lib/hexo-renderer-asciidoc/test/asciidoctor.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Copyright 2015 Shuai Zhang
+ * SPDX-License-Identifier: LGPL-3.0-or-later WITH LGPL-3.0-linking-exception
+ */
+
+import { mkdirSync, mkdtempSync, readdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { ASCIIDOCTOR_DEFAULT_OPTIONS, convertAsciiDoc } from '../src/core/asciidoctor';
+import renderer from '../src/core/renderer';
+
+const originalCwd = process.cwd();
+const temporaryDirectories: string[] = [];
+
+const createTemporaryDirectory = (): string => {
+  const directory = mkdtempSync(path.join(tmpdir(), 'hexo-renderer-asciidoc-characterization-'));
+  temporaryDirectories.push(directory);
+  return directory;
+};
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe.sequential('Asciidoctor v3 filesystem characterization', () => {
+  it('uses the server safe mode and does not set a default base_dir', () => {
+    expect(ASCIIDOCTOR_DEFAULT_OPTIONS).toMatchObject({
+      attributes: ['source-highlighter=html-pipeline'],
+      doctype: 'article',
+      safe: 'server',
+    });
+    expect(ASCIIDOCTOR_DEFAULT_OPTIONS).not.toHaveProperty('base_dir');
+    expect(ASCIIDOCTOR_DEFAULT_OPTIONS).not.toHaveProperty('to_file');
+  });
+
+  it('resolves a local include from the conversion-time CWD', () => {
+    const workingDirectory = createTemporaryDirectory();
+    writeFileSync(path.join(workingDirectory, 'included.adoc'), 'INCLUDED_FROM_CWD');
+    process.chdir(workingDirectory);
+
+    const result = renderer({ text: 'include::included.adoc[]' });
+
+    expect(result).toContain('INCLUDED_FROM_CWD');
+  });
+
+  it('allows an explicit base_dir override only through the conversion seam', () => {
+    const workingDirectory = createTemporaryDirectory();
+    const baseDirectory = createTemporaryDirectory();
+    writeFileSync(path.join(workingDirectory, 'included.adoc'), 'FROM_CWD');
+    writeFileSync(path.join(baseDirectory, 'included.adoc'), 'FROM_BASE_DIR');
+    process.chdir(workingDirectory);
+
+    const fromCwd = convertAsciiDoc('include::included.adoc[]');
+    const fromBaseDirectory = convertAsciiDoc('include::included.adoc[]', {
+      base_dir: baseDirectory,
+    });
+
+    expect(fromCwd).toContain('FROM_CWD');
+    expect(fromBaseDirectory).toContain('FROM_BASE_DIR');
+    expect(fromBaseDirectory).not.toContain('FROM_CWD');
+  });
+
+  it('keeps the to_file false experiment separate and does not create output files for string input', () => {
+    const workingDirectory = createTemporaryDirectory();
+    process.chdir(workingDirectory);
+
+    const html = convertAsciiDoc('== Controlled to_file false ==', { to_file: false });
+
+    expect(html).toContain('<h2 id="_controlled_to_file_false">Controlled to_file false</h2>');
+    expect(readdirSync(workingDirectory)).toEqual([]);
+  });
+
+  it('is invariant across absent, null, relative, and absolute data.path values', () => {
+    const workingDirectory = createTemporaryDirectory();
+    writeFileSync(path.join(workingDirectory, 'included.adoc'), 'PATH_INVARIANT_INCLUDE');
+    process.chdir(workingDirectory);
+    const text = 'include::included.adoc[]';
+
+    const outputs = [
+      renderer({ text }),
+      renderer({ text, path: null }),
+      renderer({ text, path: 'nested/document.adoc' }),
+      renderer({ text, path: path.join(workingDirectory, 'document.adoc') }),
+    ];
+
+    expect(new Set(outputs).size).toBe(1);
+    expect(outputs[0]).toContain('PATH_INVARIANT_INCLUDE');
+  });
+
+  it('changes relative include resolution when only the CWD changes', () => {
+    const firstWorkingDirectory = createTemporaryDirectory();
+    const secondWorkingDirectory = createTemporaryDirectory();
+    writeFileSync(path.join(firstWorkingDirectory, 'included.adoc'), 'FIRST_CWD');
+    writeFileSync(path.join(secondWorkingDirectory, 'included.adoc'), 'SECOND_CWD');
+
+    process.chdir(firstWorkingDirectory);
+    const first = renderer({ text: 'include::included.adoc[]' });
+    process.chdir(secondWorkingDirectory);
+    const second = renderer({ text: 'include::included.adoc[]' });
+
+    expect(first).toContain('FIRST_CWD');
+    expect(first).not.toContain('SECOND_CWD');
+    expect(second).toContain('SECOND_CWD');
+    expect(second).not.toContain('FIRST_CWD');
+  });
+
+  it('denies traversal and absolute paths while retaining symlink include behavior', () => {
+    const root = createTemporaryDirectory();
+    const workingDirectory = path.join(root, 'working');
+    const outsideDirectory = path.join(root, 'outside');
+    mkdirSync(workingDirectory);
+    mkdirSync(outsideDirectory);
+    const outsideFile = path.join(outsideDirectory, 'outside.adoc');
+    writeFileSync(outsideFile, 'OUTSIDE_INCLUDE_SENTINEL');
+    symlinkSync(outsideFile, path.join(workingDirectory, 'linked.adoc'));
+    process.chdir(workingDirectory);
+
+    const traversal = renderer({ text: 'include::../outside/outside.adoc[]' });
+    const absolute = renderer({ text: `include::${outsideFile}[]` });
+    const symlink = renderer({ text: 'include::linked.adoc[]' });
+
+    expect(traversal).toContain('Unresolved directive');
+    expect(traversal).not.toContain('OUTSIDE_INCLUDE_SENTINEL');
+    expect(absolute).toContain('Unresolved directive');
+    expect(absolute).not.toContain('OUTSIDE_INCLUDE_SENTINEL');
+    expect(symlink).toContain('OUTSIDE_INCLUDE_SENTINEL');
+  });
+});

--- a/src/public/lib/hexo-renderer-asciidoc/test/dist-inventory.test.mjs
+++ b/src/public/lib/hexo-renderer-asciidoc/test/dist-inventory.test.mjs
@@ -1,0 +1,95 @@
+/**
+ * Copyright 2015 Shuai Zhang
+ * SPDX-License-Identifier: LGPL-3.0-or-later WITH LGPL-3.0-linking-exception
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  EXPECTED_ROOT_DIST_FILES,
+  listDistEntries,
+  OPTIONAL_ROOT_DIST_FILES,
+  verifyDistInventory,
+  verifyExactTarEntries,
+  verifyExactTarInventory,
+} from '../scripts/validation-utils.mjs';
+
+let dist;
+
+const populateRequired = () => {
+  for (const file of EXPECTED_ROOT_DIST_FILES) {
+    writeFileSync(path.join(dist, file), `// ${file}\n`);
+  }
+};
+
+beforeEach(() => {
+  dist = mkdtempSync(path.join(tmpdir(), 'dist-inventory-test-'));
+  populateRequired();
+});
+
+afterEach(() => {
+  rmSync(dist, { force: true, recursive: true });
+});
+
+describe('recursive dist inventory', () => {
+  it('accepts exactly the required root files', () => {
+    expect(verifyDistInventory(dist).sort()).toEqual([...EXPECTED_ROOT_DIST_FILES].sort());
+  });
+
+  describe('required tarball inventory', () => {
+    const required = ['package/README.md', 'package/CHANGELOG.md', 'package/LICENSE'];
+
+    it('accepts exactly one of every required entry', () => {
+      expect(() => verifyExactTarEntries(required, required)).not.toThrow();
+    });
+
+    it('rejects a missing or duplicate changelog', () => {
+      expect(() =>
+        verifyExactTarEntries(
+          required.filter((entry) => !entry.endsWith('CHANGELOG.md')),
+          required,
+        ),
+      ).toThrow(/CHANGELOG\.md entry, found 0/);
+      expect(() => verifyExactTarEntries([...required, 'package/CHANGELOG.md'], required)).toThrow(
+        /CHANGELOG\.md entry, found 2/,
+      );
+    });
+
+    it('rejects unexpected and duplicate optional entries in a complete inventory', () => {
+      expect(() => verifyExactTarInventory([...required, 'package/UNEXPECTED'], required)).toThrow(
+        /package\/UNEXPECTED/,
+      );
+      expect(() =>
+        verifyExactTarInventory([...required, 'package/dist/index.d.ts.map', 'package/dist/index.d.ts.map'], required, [
+          'package/dist/index.d.ts.map',
+        ]),
+      ).toThrow(/found 2/);
+    });
+  });
+
+  it('accepts only the permitted declaration maps', () => {
+    for (const mapName of OPTIONAL_ROOT_DIST_FILES) {
+      const declarationName = mapName.slice(0, -'.map'.length);
+      writeFileSync(path.join(dist, declarationName), `//# sourceMappingURL=${mapName}\n`);
+      writeFileSync(path.join(dist, mapName), JSON.stringify({ file: declarationName }));
+    }
+    expect(verifyDistInventory(dist).sort()).toEqual([...EXPECTED_ROOT_DIST_FILES, ...OPTIONAL_ROOT_DIST_FILES].sort());
+  });
+
+  it('recursively reports and rejects an unexpected nested artifact', () => {
+    mkdirSync(path.join(dist, 'nested', 'deeper'), { recursive: true });
+    writeFileSync(path.join(dist, 'nested', 'deeper', 'runtime.js'), 'export {};\n');
+
+    expect(listDistEntries(dist)).toEqual(
+      expect.arrayContaining(['nested/', 'nested/deeper/', 'nested/deeper/runtime.js']),
+    );
+    expect(() => verifyDistInventory(dist)).toThrow(/nested\/deeper\/runtime\.js/);
+  });
+
+  it('rejects an unexpected root artifact', () => {
+    writeFileSync(path.join(dist, 'index.js.map'), '{}\n');
+    expect(() => verifyDistInventory(dist)).toThrow(/index\.js\.map/);
+  });
+});

--- a/src/public/lib/hexo-renderer-asciidoc/test/doctest/__snapshots__/dlist.test.ts.snap
+++ b/src/public/lib/hexo-renderer-asciidoc/test/doctest/__snapshots__/dlist.test.ts.snap
@@ -102,8 +102,8 @@ exports[`DocTest:dlist > horizontal-with-dimensions 1`] = `
 "<div class="hdlist">
 <table>
 <colgroup>
-<col style="width: 20%;">
-<col style="width: 50%;">
+<col width="20%">
+<col width="50%">
 </colgroup>
 <tr>
 <td class="hdlist1">

--- a/src/public/lib/hexo-renderer-asciidoc/test/doctest/__snapshots__/page_break.test.ts.snap
+++ b/src/public/lib/hexo-renderer-asciidoc/test/doctest/__snapshots__/page_break.test.ts.snap
@@ -4,7 +4,7 @@ exports[`DocTest:page_break > basic 1`] = `
 "<div class="paragraph">
 <p>Text on the first page</p>
 </div>
-<div style="page-break-after: always;"></div>
+<div class="page-break"></div>
 <div class="paragraph">
 <p>was broken!</p>
 </div>"

--- a/src/public/lib/hexo-renderer-asciidoc/test/doctest/__snapshots__/table.test.ts.snap
+++ b/src/public/lib/hexo-renderer-asciidoc/test/doctest/__snapshots__/table.test.ts.snap
@@ -3,9 +3,9 @@
 exports[`DocTest:table > aligns-per-cell 1`] = `
 "<table class="tableblock frame-all grid-all stretch">
 <colgroup>
-<col style="width: 33.3333%;">
-<col style="width: 33.3333%;">
-<col style="width: 33.3334%;">
+<col width="33.3333%">
+<col width="33.3333%">
+<col width="33.3334%">
 </colgroup>
 <tbody>
 <tr>
@@ -28,8 +28,8 @@ exports[`DocTest:table > aligns-per-cell 1`] = `
 exports[`DocTest:table > basic 1`] = `
 "<table class="tableblock frame-all grid-all stretch">
 <colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
+<col width="50%">
+<col width="50%">
 </colgroup>
 <tbody>
 <tr>
@@ -47,7 +47,7 @@ exports[`DocTest:table > basic 1`] = `
 exports[`DocTest:table > cell-with-paragraphs 1`] = `
 "<table class="tableblock frame-all grid-all stretch">
 <colgroup>
-<col style="width: 100%;">
+<col width="100%">
 </colgroup>
 <tbody>
 <tr>
@@ -64,9 +64,9 @@ exports[`DocTest:table > cell-with-paragraphs 1`] = `
 exports[`DocTest:table > colspan 1`] = `
 "<table class="tableblock frame-all grid-all stretch">
 <colgroup>
-<col style="width: 33.3333%;">
-<col style="width: 33.3333%;">
-<col style="width: 33.3334%;">
+<col width="33.3333%">
+<col width="33.3333%">
+<col width="33.3334%">
 </colgroup>
 <tbody>
 <tr>
@@ -85,8 +85,8 @@ exports[`DocTest:table > colspan 1`] = `
 exports[`DocTest:table > insane-cells-formatting 1`] = `
 "<table class="tableblock frame-all grid-all stretch">
 <colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
+<col width="50%">
+<col width="50%">
 </colgroup>
 <tbody>
 <tr>
@@ -118,9 +118,9 @@ exports[`DocTest:table > insane-cells-formatting 1`] = `
 exports[`DocTest:table > rowspan 1`] = `
 "<table class="tableblock frame-all grid-all stretch">
 <colgroup>
-<col style="width: 33.3333%;">
-<col style="width: 33.3333%;">
-<col style="width: 33.3334%;">
+<col width="33.3333%">
+<col width="33.3333%">
+<col width="33.3334%">
 </colgroup>
 <tbody>
 <tr>
@@ -157,7 +157,7 @@ exports[`DocTest:table > with-autowidth 1`] = `
 `;
 
 exports[`DocTest:table > with-autowidth-and-width 1`] = `
-"<table class="tableblock frame-all grid-all" style="width: 80%;">
+"<table class="tableblock frame-all grid-all" width="80%">
 <colgroup>
 <col>
 <col>
@@ -174,9 +174,9 @@ exports[`DocTest:table > with-autowidth-and-width 1`] = `
 exports[`DocTest:table > with-cols-halign 1`] = `
 "<table class="tableblock frame-all grid-all stretch">
 <colgroup>
-<col style="width: 33.3333%;">
-<col style="width: 33.3333%;">
-<col style="width: 33.3334%;">
+<col width="33.3333%">
+<col width="33.3333%">
+<col width="33.3334%">
 </colgroup>
 <tbody>
 <tr>
@@ -191,12 +191,12 @@ exports[`DocTest:table > with-cols-halign 1`] = `
 exports[`DocTest:table > with-cols-styles 1`] = `
 "<table class="tableblock frame-all grid-all stretch">
 <colgroup>
-<col style="width: 16.6666%;">
-<col style="width: 16.6666%;">
-<col style="width: 16.6666%;">
-<col style="width: 16.6666%;">
-<col style="width: 16.6666%;">
-<col style="width: 16.667%;">
+<col width="16.6666%">
+<col width="16.6666%">
+<col width="16.6666%">
+<col width="16.6666%">
+<col width="16.6666%">
+<col width="16.667%">
 </colgroup>
 <tbody>
 <tr>
@@ -218,9 +218,9 @@ exports[`DocTest:table > with-cols-styles 1`] = `
 exports[`DocTest:table > with-cols-valign 1`] = `
 "<table class="tableblock frame-all grid-all stretch">
 <colgroup>
-<col style="width: 33.3333%;">
-<col style="width: 33.3333%;">
-<col style="width: 33.3334%;">
+<col width="33.3333%">
+<col width="33.3333%">
+<col width="33.3334%">
 </colgroup>
 <tbody>
 <tr>
@@ -235,9 +235,9 @@ exports[`DocTest:table > with-cols-valign 1`] = `
 exports[`DocTest:table > with-cols-width 1`] = `
 "<table class="tableblock frame-all grid-all stretch">
 <colgroup>
-<col style="width: 50%;">
-<col style="width: 20%;">
-<col style="width: 30%;">
+<col width="50%">
+<col width="20%">
+<col width="30%">
 </colgroup>
 <tbody>
 <tr>
@@ -252,8 +252,8 @@ exports[`DocTest:table > with-cols-width 1`] = `
 exports[`DocTest:table > with-float 1`] = `
 "<table class="tableblock frame-all grid-all stretch left">
 <colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
+<col width="50%">
+<col width="50%">
 </colgroup>
 <tbody>
 <tr>
@@ -267,8 +267,8 @@ exports[`DocTest:table > with-float 1`] = `
 exports[`DocTest:table > with-footer 1`] = `
 "<table class="tableblock frame-all grid-all stretch">
 <colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
+<col width="50%">
+<col width="50%">
 </colgroup>
 <tbody>
 <tr>
@@ -292,8 +292,8 @@ exports[`DocTest:table > with-footer 1`] = `
 exports[`DocTest:table > with-frame-sides 1`] = `
 "<table class="tableblock frame-sides grid-all stretch">
 <colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
+<col width="50%">
+<col width="50%">
 </colgroup>
 <tbody>
 <tr>
@@ -307,8 +307,8 @@ exports[`DocTest:table > with-frame-sides 1`] = `
 exports[`DocTest:table > with-grid-cols 1`] = `
 "<table class="tableblock frame-all grid-cols stretch">
 <colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
+<col width="50%">
+<col width="50%">
 </colgroup>
 <tbody>
 <tr>
@@ -322,8 +322,8 @@ exports[`DocTest:table > with-grid-cols 1`] = `
 exports[`DocTest:table > with-header 1`] = `
 "<table class="tableblock frame-all grid-all stretch">
 <colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
+<col width="50%">
+<col width="50%">
 </colgroup>
 <thead>
 <tr>
@@ -347,8 +347,8 @@ exports[`DocTest:table > with-header 1`] = `
 exports[`DocTest:table > with-id-and-role 1`] = `
 "<table id="tabular" class="tableblock frame-all grid-all stretch center">
 <colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
+<col width="50%">
+<col width="50%">
 </colgroup>
 <tbody>
 <tr>
@@ -363,8 +363,8 @@ exports[`DocTest:table > with-title 1`] = `
 "<table class="tableblock frame-all grid-all stretch">
 <caption class="title">Table 1. Table FTW!</caption>
 <colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
+<col width="50%">
+<col width="50%">
 </colgroup>
 <tbody>
 <tr>
@@ -376,10 +376,10 @@ exports[`DocTest:table > with-title 1`] = `
 `;
 
 exports[`DocTest:table > with-width 1`] = `
-"<table class="tableblock frame-all grid-all" style="width: 80%;">
+"<table class="tableblock frame-all grid-all" width="80%">
 <colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
+<col width="50%">
+<col width="50%">
 </colgroup>
 <tbody>
 <tr>

--- a/src/public/lib/hexo-renderer-asciidoc/test/doctest/runner.ts
+++ b/src/public/lib/hexo-renderer-asciidoc/test/doctest/runner.ts
@@ -89,8 +89,8 @@ export const registerDocTestGroup = (group: string): void => {
 
   describe(`DocTest:${group}`, () => {
     for (const example of examples) {
-      it(example.name, () => {
-        const actual = renderAsciiDoc(example.content);
+      it(example.name, async () => {
+        const actual = await renderAsciiDoc(example.content);
         expect(normalizeHtml(actual)).toMatchSnapshot();
       });
     }

--- a/src/public/lib/hexo-renderer-asciidoc/test/helpers/canonical-html.ts
+++ b/src/public/lib/hexo-renderer-asciidoc/test/helpers/canonical-html.ts
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2015 Shuai Zhang
+ * SPDX-License-Identifier: LGPL-3.0-or-later WITH LGPL-3.0-linking-exception
+ */
+
+import * as cheerio from 'cheerio';
+
+export const CANONICAL_HTML_ALGORITHM = 'ac07-dom-v1';
+
+interface HtmlNode {
+  attribs?: Record<string, string>;
+  children?: HtmlNode[];
+  data?: string;
+  name?: string;
+  type: string;
+}
+
+interface CanonicalHtmlNode {
+  attributes?: [string, string][];
+  children?: CanonicalHtmlNode[];
+  data?: string;
+  name?: string;
+  type: string;
+}
+
+/**
+ * AC-07 canonical DOM algorithm (`ac07-dom-v1`):
+ *
+ * 1. Parse as an HTML5 document with Cheerio 1.2.0's default parse5 parser.
+ * 2. Preserve document order, node types, element names, text, comments, raw
+ *    script contents, and attribute values after HTML parsing/entity decoding.
+ * 3. Sort attributes lexicographically by name; ignore source attribute order
+ *    and serializer spelling (quotes, void-tag syntax, and entity references).
+ * 4. Compare the resulting JSON-compatible trees for deep equality.
+ */
+export const canonicalizeHtml = (html: string): CanonicalHtmlNode[] => {
+  const $ = cheerio.load(html);
+
+  const canonicalizeNode = (node: HtmlNode): CanonicalHtmlNode => {
+    const canonical: CanonicalHtmlNode = { type: node.type };
+
+    if (node.name !== undefined) {
+      canonical.name = node.name;
+    }
+    if (node.attribs !== undefined) {
+      canonical.attributes = Object.entries(node.attribs).sort(([left], [right]) => left.localeCompare(right));
+    }
+    if (node.data !== undefined) {
+      canonical.data = node.data;
+    }
+    if (node.children !== undefined) {
+      canonical.children = node.children.map(canonicalizeNode);
+    }
+
+    return canonical;
+  };
+
+  return ($.root().get(0)?.children as HtmlNode[] | undefined)?.map(canonicalizeNode) ?? [];
+};

--- a/src/public/lib/hexo-renderer-asciidoc/test/helpers/render.ts
+++ b/src/public/lib/hexo-renderer-asciidoc/test/helpers/render.ts
@@ -15,7 +15,7 @@ const render = renderer as Renderer;
  * @param locals - Additional Hexo locals passed to the renderer.
  * @returns Rendered HTML string.
  */
-export const renderAsciiDoc = (text: string, locals: RendererLocals = {}): string => {
+export const renderAsciiDoc = async (text: string, locals: RendererLocals = {}): Promise<string> => {
   const data: RendererData = { text };
-  return render(data, locals);
+  return await render(data, locals);
 };

--- a/src/public/lib/hexo-renderer-asciidoc/test/helpers/vitest-subprocess.ts
+++ b/src/public/lib/hexo-renderer-asciidoc/test/helpers/vitest-subprocess.ts
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2015 Shuai Zhang
+ * SPDX-License-Identifier: LGPL-3.0-or-later WITH LGPL-3.0-linking-exception
+ */
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+type ExecFileFailure = Error & {
+  code?: number | string | null;
+  signal?: NodeJS.Signals | null;
+  stderr?: Buffer | string;
+  stdout?: Buffer | string;
+};
+
+const STRICT_UNHANDLED_REJECTIONS = '--unhandled-rejections=strict';
+const execFileAsync = promisify(execFile);
+
+const formatOutput = (output: Buffer | string | undefined): string => {
+  if (output === undefined) {
+    return '<empty>';
+  }
+
+  const text = typeof output === 'string' ? output : output.toString('utf8');
+  return text.length > 0 ? text : '<empty>';
+};
+
+const withStrictUnhandledRejections = (): string => {
+  const { NODE_OPTIONS } = process.env;
+  return [NODE_OPTIONS, STRICT_UNHANDLED_REJECTIONS].filter(Boolean).join(' ');
+};
+
+export const runVitestSubprocess = async ({
+  args,
+  cwd,
+  timeout,
+}: {
+  args: string[];
+  cwd: string;
+  timeout: number;
+}): Promise<void> => {
+  try {
+    await execFileAsync('pnpm', ['exec', 'vitest', 'run', ...args], {
+      cwd,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        NODE_OPTIONS: withStrictUnhandledRejections(),
+      },
+      maxBuffer: 10 * 1024 * 1024,
+      timeout,
+    });
+  } catch (error) {
+    const failure = error as ExecFileFailure;
+
+    throw new Error(
+      [
+        `Vitest subprocess failed: pnpm exec vitest run ${args.join(' ')}`,
+        `status: ${failure.code ?? 'unknown'}`,
+        `signal: ${failure.signal ?? 'none'}`,
+        '',
+        `stdout:\n${formatOutput(failure.stdout)}`,
+        '',
+        `stderr:\n${formatOutput(failure.stderr)}`,
+      ].join('\n'),
+      { cause: error },
+    );
+  }
+};

--- a/src/public/lib/hexo-renderer-asciidoc/test/hexo.integration.test.ts
+++ b/src/public/lib/hexo-renderer-asciidoc/test/hexo.integration.test.ts
@@ -11,10 +11,13 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import registerRenderer from '../src/hexo/register';
 import type { Hexo as HexoContract } from '../src/types';
 
-const HEXO_ENGINE = 'adoc';
+const SUPPORTED_EXTENSIONS = ['ad', 'adoc', 'asciidoc'] as const;
 
 type HexoRenderAPI = {
+  isRenderable(path: string): boolean;
+  isRenderableSync(path: string): boolean;
   render(data: Record<string, unknown>, locals?: Record<string, unknown>): Promise<string>;
+  renderSync(data: Record<string, unknown>, locals?: Record<string, unknown>): string;
 };
 
 type HexoTestInstance = HexoContract & {
@@ -55,9 +58,30 @@ describe('Hexo integration', () => {
     disposeWorkspace?.();
   });
 
-  it('renders AsciiDoc via Hexo render pipeline', async () => {
-    const html = await hexoInstance.render.render({ text: '== Hexo Integration ==', engine: HEXO_ENGINE });
+  it('registers ad, adoc, and asciidoc as async-only renderable extensions', () => {
+    for (const extension of SUPPORTED_EXTENSIONS) {
+      expect(hexoInstance.render.isRenderable(extension)).toBe(true);
+      expect(hexoInstance.render.isRenderableSync(extension)).toBe(false);
+    }
+  });
 
-    expect(html).toContain('<h2 id="_hexo_integration">Hexo Integration</h2>');
+  it('awaits asynchronous rendering for every supported extension without leaking [object Promise]', async () => {
+    for (const extension of SUPPORTED_EXTENSIONS) {
+      const heading = `Hexo Integration ${extension}`;
+      const html = await hexoInstance.render.render({ text: `== ${heading} ==`, engine: extension });
+
+      expect(html).toContain(`<h2 id="_hexo_integration_${extension}">${heading}</h2>`);
+      expect(html).not.toContain('[object Promise]');
+    }
+  });
+
+  it('returns the original input from renderSync for every supported extension', () => {
+    for (const extension of SUPPORTED_EXTENSIONS) {
+      const text = `== Sync Fallback ${extension} ==`;
+      const output = hexoInstance.render.renderSync({ text, engine: extension });
+
+      expect(output).toBe(text);
+      expect(output).not.toContain('[object Promise]');
+    }
   });
 });

--- a/src/public/lib/hexo-renderer-asciidoc/test/highlight.test.ts
+++ b/src/public/lib/hexo-renderer-asciidoc/test/highlight.test.ts
@@ -37,4 +37,62 @@ describe('applyStaticHighlighting', () => {
     expect(options?.lang).toBe('xml');
     expect(result).toContain(highlightResult);
   });
+
+  it('uses plaintext for a language-less code block and fixed highlighting options', () => {
+    const highlightMock = vi.spyOn(hexoUtil, 'highlight').mockReturnValue('<figure class="highlight">plain</figure>');
+    const html = `<div class="listingblock"><div class="content">
+<pre class="highlight"><code>plain &amp; text</code></pre>
+</div></div>`;
+
+    const result = applyStaticHighlighting(html);
+
+    expect(highlightMock).toHaveBeenCalledWith('plain & text', {
+      autoDetect: false,
+      gutter: false,
+      lang: 'plaintext',
+      wrap: false,
+    });
+    expect(result).toContain('<figure class="highlight">plain</figure>');
+  });
+
+  it('rewrites a passthrough pre.highlight block outside the canonical listing-block boundary', () => {
+    const highlightResult = '<pre><code class="highlight javascript">rewritten</code></pre>';
+    const highlightMock = vi.spyOn(hexoUtil, 'highlight').mockReturnValue(highlightResult);
+    const html = `<article class="raw-boundary">
+<pre class="highlight"><code data-lang="javascript">const raw = 1;</code></pre>
+</article>`;
+
+    const result = applyStaticHighlighting(html);
+
+    expect(highlightMock).toHaveBeenCalledWith('const raw = 1;', {
+      autoDetect: false,
+      gutter: false,
+      lang: 'javascript',
+      wrap: false,
+    });
+    expect(result).toContain(highlightResult);
+    expect(result).not.toContain('<pre class="highlight"><code data-lang="javascript">const raw = 1;</code></pre>');
+  });
+
+  it('highlights multiple blocks in order with independent languages and entity decoding', () => {
+    const highlightMock = vi
+      .spyOn(hexoUtil, 'highlight')
+      .mockImplementation(
+        (source, options) => `<figure data-language="${options?.lang}" data-source-length="${source.length}"></figure>`,
+      );
+    const html = `<div class="listingblock"><div class="content">
+<pre class="highlight"><code data-lang="xml">&lt;one&gt;&amp;amp;</code></pre>
+</div></div>
+<div class="listingblock"><div class="content">
+<pre class="highlight"><code>two &amp; three</code></pre>
+</div></div>`;
+
+    const result = applyStaticHighlighting(html);
+
+    expect(highlightMock.mock.calls).toEqual([
+      ['<one>&amp;', { autoDetect: false, gutter: false, lang: 'xml', wrap: false }],
+      ['two & three', { autoDetect: false, gutter: false, lang: 'plaintext', wrap: false }],
+    ]);
+    expect(result.indexOf('data-language="xml"')).toBeLessThan(result.indexOf('data-language="plaintext"'));
+  });
 });

--- a/src/public/lib/hexo-renderer-asciidoc/test/highlight.test.ts
+++ b/src/public/lib/hexo-renderer-asciidoc/test/highlight.test.ts
@@ -77,6 +77,34 @@ describe('applyStaticHighlighting', () => {
     });
   });
 
+  it('falls back to pre[lang] when code[data-lang] is empty', () => {
+    const highlightMock = vi
+      .spyOn(hexoUtil, 'highlight')
+      .mockReturnValue('<figure class="highlight">precedence-empty</figure>');
+
+    applyStaticHighlighting(wrapCanonicalListingBlock('<pre lang="python"><code data-lang="">value = 1</code></pre>'));
+
+    expect(highlightMock).toHaveBeenCalledWith('value = 1', {
+      ...FIXED_HIGHLIGHT_OPTIONS,
+      lang: 'python',
+    });
+  });
+
+  it('falls back to pre[lang] when code[data-lang] is whitespace only', () => {
+    const highlightMock = vi
+      .spyOn(hexoUtil, 'highlight')
+      .mockReturnValue('<figure class="highlight">precedence-whitespace</figure>');
+
+    applyStaticHighlighting(
+      wrapCanonicalListingBlock('<pre lang="python"><code data-lang="   ">value = 1</code></pre>'),
+    );
+
+    expect(highlightMock).toHaveBeenCalledWith('value = 1', {
+      ...FIXED_HIGHLIGHT_OPTIONS,
+      lang: 'python',
+    });
+  });
+
   it('decodes XML entities exactly once before highlighting', () => {
     const highlightMock = vi.spyOn(hexoUtil, 'highlight').mockReturnValue('<figure class="highlight">decoded</figure>');
 

--- a/src/public/lib/hexo-renderer-asciidoc/test/highlight.test.ts
+++ b/src/public/lib/hexo-renderer-asciidoc/test/highlight.test.ts
@@ -7,92 +7,142 @@ import * as hexoUtil from 'hexo-util';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { applyStaticHighlighting } from '../src/core/highlight';
 
+const FIXED_HIGHLIGHT_OPTIONS = {
+  autoDetect: false,
+  gutter: false,
+  wrap: false,
+};
+
+const wrapCanonicalListingBlock = (preHtml: string): string => `<div class="listingblock">
+<div class="content">
+${preHtml}
+</div>
+</div>`;
+
 afterEach(() => {
   vi.restoreAllMocks();
 });
 
 describe('applyStaticHighlighting', () => {
-  it('decodes escaped code text before invoking hexo highlighter', () => {
-    const highlightResult = '<figure class="highlight"></figure>';
-    const highlightMock = vi.spyOn(hexoUtil, 'highlight').mockReturnValue(highlightResult);
+  it.each([
+    {
+      name: 'pre.highlight > code[data-lang]',
+      preHtml: '<pre class="highlight"><code data-lang="xml">&lt;node /&gt;</code></pre>',
+      expectedSource: '<node />',
+      expectedLanguage: 'xml',
+    },
+    {
+      name: 'pre.highlight > code',
+      preHtml: '<pre class="highlight"><code>plain &amp; text</code></pre>',
+      expectedSource: 'plain & text',
+      expectedLanguage: 'plaintext',
+    },
+    {
+      name: 'pre[lang] > code',
+      preHtml: '<pre lang="python"><code>value = 1</code></pre>',
+      expectedSource: 'value = 1',
+      expectedLanguage: 'python',
+    },
+    {
+      name: 'pre > code',
+      preHtml: '<pre><code>bare &amp; code</code></pre>',
+      expectedSource: 'bare & code',
+      expectedLanguage: 'plaintext',
+    },
+  ])('highlights the canonical $name shape', ({ preHtml, expectedSource, expectedLanguage }) => {
+    const highlightMock = vi
+      .spyOn(hexoUtil, 'highlight')
+      .mockImplementation((_source, options) => `<figure data-language="${options?.lang}"></figure>`);
 
-    const html = `<div class="listingblock">
-<div class="content">
-<pre class="highlight"><code data-lang="xml">&lt;div class=&quot;test&quot;&gt;AT&amp;T&lt;/div&gt;</code></pre>
-</div>
-</div>`;
-
-    const result = applyStaticHighlighting(html);
+    const result = applyStaticHighlighting(wrapCanonicalListingBlock(preHtml));
 
     expect(highlightMock).toHaveBeenCalledTimes(1);
-    const callArgs = highlightMock.mock.calls[0];
-    expect(callArgs).toBeDefined();
-    if (!callArgs) {
-      throw new Error('Expected hexoUtil.highlight to be called at least once');
-    }
-
-    const [source, options] = callArgs;
-    expect(source).toBe('<div class="test">AT&T</div>');
-    expect(options).toBeDefined();
-    expect(options?.lang).toBe('xml');
-    expect(result).toContain(highlightResult);
-  });
-
-  it('uses plaintext for a language-less code block and fixed highlighting options', () => {
-    const highlightMock = vi.spyOn(hexoUtil, 'highlight').mockReturnValue('<figure class="highlight">plain</figure>');
-    const html = `<div class="listingblock"><div class="content">
-<pre class="highlight"><code>plain &amp; text</code></pre>
-</div></div>`;
-
-    const result = applyStaticHighlighting(html);
-
-    expect(highlightMock).toHaveBeenCalledWith('plain & text', {
-      autoDetect: false,
-      gutter: false,
-      lang: 'plaintext',
-      wrap: false,
+    expect(highlightMock).toHaveBeenCalledWith(expectedSource, {
+      ...FIXED_HIGHLIGHT_OPTIONS,
+      lang: expectedLanguage,
     });
-    expect(result).toContain('<figure class="highlight">plain</figure>');
+    expect(result).toContain(`<figure data-language="${expectedLanguage}"></figure>`);
   });
 
-  it('rewrites a passthrough pre.highlight block outside the canonical listing-block boundary', () => {
-    const highlightResult = '<pre><code class="highlight javascript">rewritten</code></pre>';
-    const highlightMock = vi.spyOn(hexoUtil, 'highlight').mockReturnValue(highlightResult);
-    const html = `<article class="raw-boundary">
-<pre class="highlight"><code data-lang="javascript">const raw = 1;</code></pre>
-</article>`;
+  it('prefers code[data-lang] over pre[lang]', () => {
+    const highlightMock = vi
+      .spyOn(hexoUtil, 'highlight')
+      .mockReturnValue('<figure class="highlight">precedence</figure>');
 
-    const result = applyStaticHighlighting(html);
+    applyStaticHighlighting(wrapCanonicalListingBlock('<pre lang="python"><code data-lang="ruby">puts 1</code></pre>'));
 
-    expect(highlightMock).toHaveBeenCalledWith('const raw = 1;', {
-      autoDetect: false,
-      gutter: false,
-      lang: 'javascript',
-      wrap: false,
+    expect(highlightMock).toHaveBeenCalledWith('puts 1', {
+      ...FIXED_HIGHLIGHT_OPTIONS,
+      lang: 'ruby',
     });
-    expect(result).toContain(highlightResult);
-    expect(result).not.toContain('<pre class="highlight"><code data-lang="javascript">const raw = 1;</code></pre>');
   });
 
-  it('highlights multiple blocks in order with independent languages and entity decoding', () => {
+  it('decodes XML entities exactly once before highlighting', () => {
+    const highlightMock = vi.spyOn(hexoUtil, 'highlight').mockReturnValue('<figure class="highlight">decoded</figure>');
+
+    applyStaticHighlighting(
+      wrapCanonicalListingBlock(
+        '<pre class="highlight"><code data-lang="xml">&lt;one&gt;&amp;amp;notit;&lt;/one&gt;</code></pre>',
+      ),
+    );
+
+    expect(highlightMock).toHaveBeenCalledWith('<one>&amp;notit;</one>', {
+      ...FIXED_HIGHLIGHT_OPTIONS,
+      lang: 'xml',
+    });
+  });
+
+  it('highlights multiple canonical blocks in document order with isolated language detection', () => {
     const highlightMock = vi
       .spyOn(hexoUtil, 'highlight')
       .mockImplementation(
-        (source, options) => `<figure data-language="${options?.lang}" data-source-length="${source.length}"></figure>`,
+        (source, options) => `<figure data-language="${options?.lang}" data-source="${source}"></figure>`,
       );
-    const html = `<div class="listingblock"><div class="content">
-<pre class="highlight"><code data-lang="xml">&lt;one&gt;&amp;amp;</code></pre>
-</div></div>
-<div class="listingblock"><div class="content">
-<pre class="highlight"><code>two &amp; three</code></pre>
-</div></div>`;
+
+    const html = `${wrapCanonicalListingBlock('<pre class="highlight"><code data-lang="xml">&lt;one&gt;&amp;amp;</code></pre>')}
+${wrapCanonicalListingBlock('<pre lang="python"><code>value = 1</code></pre>')}
+${wrapCanonicalListingBlock('<pre><code>three &amp; four</code></pre>')}`;
 
     const result = applyStaticHighlighting(html);
 
     expect(highlightMock.mock.calls).toEqual([
-      ['<one>&amp;', { autoDetect: false, gutter: false, lang: 'xml', wrap: false }],
-      ['two & three', { autoDetect: false, gutter: false, lang: 'plaintext', wrap: false }],
+      ['<one>&amp;', { ...FIXED_HIGHLIGHT_OPTIONS, lang: 'xml' }],
+      ['value = 1', { ...FIXED_HIGHLIGHT_OPTIONS, lang: 'python' }],
+      ['three & four', { ...FIXED_HIGHLIGHT_OPTIONS, lang: 'plaintext' }],
     ]);
-    expect(result.indexOf('data-language="xml"')).toBeLessThan(result.indexOf('data-language="plaintext"'));
+    expect(result.indexOf('data-language="xml"')).toBeLessThan(result.indexOf('data-language="python"'));
+    expect(result.indexOf('data-language="python"')).toBeLessThan(result.indexOf('data-language="plaintext"'));
+  });
+
+  it.each([
+    {
+      name: 'arbitrary outer boundary',
+      html: '<article><pre class="highlight"><code data-lang="javascript">const raw = 1;</code></pre></article>',
+    },
+    {
+      name: 'nested wrapper under content',
+      html: '<div class="listingblock"><div class="content"><div><pre class="highlight"><code data-lang="javascript">const nested = 1;</code></pre></div></div></div>',
+    },
+    {
+      name: 'nested non-direct code child',
+      html: '<div class="listingblock"><div class="content"><pre class="highlight"><span><code data-lang="javascript">const wrapped = 1;</code></span></pre></div></div>',
+    },
+    {
+      name: 'passthrough-like boundary',
+      html: '<div class="pass"><div class="content"><pre class="highlight"><code data-lang="javascript">const passthrough = 1;</code></pre></div></div>',
+    },
+    {
+      name: 'canonical listing block without direct code child',
+      html: '<div class="listingblock"><div class="content"><pre>plain &amp; text</pre></div></div>',
+    },
+  ])('leaves $name untouched', ({ html }) => {
+    const highlightMock = vi
+      .spyOn(hexoUtil, 'highlight')
+      .mockReturnValue('<figure class="highlight">rewritten</figure>');
+
+    const result = applyStaticHighlighting(html);
+
+    expect(highlightMock).not.toHaveBeenCalled();
+    expect(result).toContain(html);
   });
 });

--- a/src/public/lib/hexo-renderer-asciidoc/test/index.test.ts
+++ b/src/public/lib/hexo-renderer-asciidoc/test/index.test.ts
@@ -4,15 +4,22 @@
  */
 
 import * as entities from 'entities';
-import { describe, expect, it } from 'vitest';
+import * as hexoUtil from 'hexo-util';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import renderer from '../src/core/renderer';
+import { CANONICAL_HTML_ALGORITHM, canonicalizeHtml } from './helpers/canonical-html';
 import { renderAsciiDoc } from './helpers/render';
 
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
 describe('Asciidoc renderer', () => {
-  it('header', () => {
+  it('header', async () => {
     const body = `
 == Test H2 ==
 `;
-    const result = renderAsciiDoc(body);
+    const result = await renderAsciiDoc(body);
 
     expect(result).toEqual(`<div class="sect1">
 <h2 id="_test_h2">Test H2</h2>
@@ -22,7 +29,7 @@ describe('Asciidoc renderer', () => {
 </div>`);
   });
 
-  it('code highlight', () => {
+  it('code highlight', async () => {
     const body = `
 [source,ruby]
 ----
@@ -32,7 +39,7 @@ get '/hi' do
   "Hello World!"
 end
 ----`;
-    const result = renderAsciiDoc(body);
+    const result = await renderAsciiDoc(body);
 
     expect(entities.decodeHTML(result)).toEqual(
       entities.decodeHTML(`<div class="listingblock">
@@ -47,17 +54,46 @@ get <span class="string">'/hi'</span> <span class="keyword">do</span>
     );
   });
 
-  it('escapes braces after conversion and syntax highlighting', () => {
+  it('escapes braces after conversion and syntax highlighting', async () => {
     const body = `
 [source,javascript]
 ----
 const value = { nested: true };
 ----`;
 
-    const result = renderAsciiDoc(body);
+    const result = await renderAsciiDoc(body);
 
     expect(result).toContain('&#123;');
     expect(result).toContain('&#125;');
     expect(result).not.toContain('{ nested:');
+  });
+
+  it('preserves noncanonical passthrough DOM through the full production renderer', async () => {
+    const passthroughHtml = `<section id="ac07-raw" data-entity="fish &amp; chips" onclick="window.rawHandler({ event: 'click' })">
+<script>window.rawExecutable = { nested: "{script-braces}", entity: "&amp;" };</script>
+<pre class="noncanonical"><code data-lang="javascript">const raw = { entity: "&amp;", braces: "{code-braces}" };</code></pre>
+<p data-braces="{attribute-braces}">entities: &amp; &lt; &gt;; literal {text-braces}</p>
+</section>`;
+    const body = `++++
+${passthroughHtml}
+++++
+`;
+    const highlightMock = vi
+      .spyOn(hexoUtil, 'highlight')
+      .mockReturnValue('<figure class="highlight">unexpected rewrite</figure>');
+
+    const renderPromise = renderer({ text: body });
+
+    expect(renderPromise).toBeInstanceOf(Promise);
+    const result = await renderPromise;
+    const expectedTransformedHtml = passthroughHtml.replaceAll('{', '&#123;').replaceAll('}', '&#125;');
+    const expectedTransformedDom = canonicalizeHtml(expectedTransformedHtml);
+
+    expect(CANONICAL_HTML_ALGORITHM).toBe('ac07-dom-v1');
+    expect(highlightMock).not.toHaveBeenCalled();
+    expect(canonicalizeHtml(result)).toEqual(expectedTransformedDom);
+    expect(result.match(/&#123;/g)).toHaveLength(7);
+    expect(result.match(/&#125;/g)).toHaveLength(7);
+    expect(result).not.toMatch(/[{}]/);
   });
 });

--- a/src/public/lib/hexo-renderer-asciidoc/test/index.test.ts
+++ b/src/public/lib/hexo-renderer-asciidoc/test/index.test.ts
@@ -46,4 +46,18 @@ get <span class="string">'/hi'</span> <span class="keyword">do</span>
 </div>`),
     );
   });
+
+  it('escapes braces after conversion and syntax highlighting', () => {
+    const body = `
+[source,javascript]
+----
+const value = { nested: true };
+----`;
+
+    const result = renderAsciiDoc(body);
+
+    expect(result).toContain('&#123;');
+    expect(result).toContain('&#125;');
+    expect(result).not.toContain('{ nested:');
+  });
 });

--- a/src/public/lib/hexo-renderer-asciidoc/test/packed-artifact.test.ts
+++ b/src/public/lib/hexo-renderer-asciidoc/test/packed-artifact.test.ts
@@ -38,7 +38,7 @@ let artifactDirectory: string;
 let consumerDirectory: string;
 let distWasAbsentBeforeBuild = false;
 let builtDistFiles: string[] = [];
-let packedManifest: { dependencies?: { asciidoctor?: string }; name?: string; version?: string };
+let packedManifest: { dependencies?: { '@asciidoctor/core'?: string }; name?: string; version?: string };
 let packedArtifact: { inventory: string[]; sha256: string; version: string };
 let consumerManifest: {
   dependencies: { hexo: string; 'hexo-renderer-asciidoc': string };
@@ -58,7 +58,7 @@ const runNodeProbe = (scriptName: string, source: string): Record<string, unknow
 };
 
 beforeAll(() => {
-  temporaryDirectory = mkdtempSync(path.join(tmpdir(), 'hexo-renderer-asciidoc-packed-v3-'));
+  temporaryDirectory = mkdtempSync(path.join(tmpdir(), 'hexo-renderer-asciidoc-packed-v4-'));
   artifactDirectory = path.join(temporaryDirectory, 'artifact');
   consumerDirectory = path.join(temporaryDirectory, 'consumer');
   mkdirSync(artifactDirectory);
@@ -81,7 +81,7 @@ beforeAll(() => {
   const packResult = JSON.parse(packOutput) as Array<{ filename: string }>;
   const archivePath = path.join(artifactDirectory, packResult[0]?.filename ?? '');
   if (!existsSync(archivePath)) {
-    throw new Error('npm pack did not produce the expected v3 artifact');
+    throw new Error('npm pack did not produce the expected v4 artifact');
   }
 
   packedManifest = JSON.parse(
@@ -98,7 +98,7 @@ beforeAll(() => {
   };
 
   consumerManifest = {
-    name: 'hexo-renderer-asciidoc-packed-v3-consumer',
+    name: 'hexo-renderer-asciidoc-packed-v4-consumer',
     private: true,
     packageManager: `pnpm@${execFileSync('pnpm', ['--version'], { encoding: 'utf8' }).trim()}`,
     dependencies: {
@@ -122,8 +122,8 @@ afterAll(() => {
   rmSync(distDirectory, { recursive: true, force: true });
 });
 
-describe('packed Asciidoctor v3 package import shapes', () => {
-  it('builds a fresh dist, records packed metadata, and preserves the current runtime dependency', () => {
+describe('packed Asciidoctor v4 package import shapes', () => {
+  it('builds a fresh dist, records packed metadata, and pins the v4 runtime dependency', () => {
     expect(distWasAbsentBeforeBuild).toBe(true);
     expect(builtDistFiles).toEqual(expectedDistFiles);
 
@@ -133,7 +133,7 @@ describe('packed Asciidoctor v3 package import shapes', () => {
     expect(expectedHtml).toContain('<code class="highlight javascript">');
 
     expect(packedManifest.name).toBe('hexo-renderer-asciidoc');
-    expect(packedManifest.dependencies?.asciidoctor).toBe('3.0.4');
+    expect(packedManifest.dependencies?.['@asciidoctor/core']).toBe('4.0.4');
     expect(packedArtifact.version).toBe(packedManifest.version);
     expect(packedArtifact.inventory).toEqual(
       expect.arrayContaining(['package/package.json', ...expectedDistFiles.map((file) => `package/dist/${file}`)]),
@@ -159,26 +159,28 @@ const registerResult = packageRoot.registerRenderer({
   },
 });
 const render = (fn) => fn({ text: sample });
-process.stdout.write(JSON.stringify({
-  rootType: typeof packageRoot,
-  keys: Object.keys(packageRoot).sort(),
-  defaultType: typeof packageRoot.default,
-  rendererType: typeof packageRoot.renderer,
-  registerRendererType: typeof packageRoot.registerRenderer,
-  defaultEqualsRenderer: packageRoot.default === packageRoot.renderer,
-  registerResultIsUndefined: registerResult === undefined,
-  outputs: {
-    default: render(packageRoot.default),
-    named: render(packageRoot.renderer),
-    registered: registrations.map(([extension, outputFormat, registeredRenderer, sync]) => ({
-      extension,
-      outputFormat,
-      rendererIsPublic: registeredRenderer === packageRoot.renderer,
-      sync,
-      html: render(registeredRenderer),
-    })),
-  },
-}));`,
+(async () => {
+  process.stdout.write(JSON.stringify({
+    rootType: typeof packageRoot,
+    keys: Object.keys(packageRoot).sort(),
+    defaultType: typeof packageRoot.default,
+    rendererType: typeof packageRoot.renderer,
+    registerRendererType: typeof packageRoot.registerRenderer,
+    defaultEqualsRenderer: packageRoot.default === packageRoot.renderer,
+    registerResultIsUndefined: registerResult === undefined,
+    outputs: {
+      default: await render(packageRoot.default),
+      named: await render(packageRoot.renderer),
+      registered: await Promise.all(registrations.map(async ([extension, outputFormat, registeredRenderer, sync]) => ({
+        extension,
+        outputFormat,
+        rendererIsPublic: registeredRenderer === packageRoot.renderer,
+        sync,
+        html: await render(registeredRenderer),
+      }))),
+    },
+  }));
+})();`,
     );
 
     expect(probe).toEqual({
@@ -193,9 +195,9 @@ process.stdout.write(JSON.stringify({
         default: expectedHtml,
         named: expectedHtml,
         registered: [
-          { extension: 'ad', outputFormat: 'html', rendererIsPublic: true, sync: true, html: expectedHtml },
-          { extension: 'adoc', outputFormat: 'html', rendererIsPublic: true, sync: true, html: expectedHtml },
-          { extension: 'asciidoc', outputFormat: 'html', rendererIsPublic: true, sync: true, html: expectedHtml },
+          { extension: 'ad', outputFormat: 'html', rendererIsPublic: true, sync: false, html: expectedHtml },
+          { extension: 'adoc', outputFormat: 'html', rendererIsPublic: true, sync: false, html: expectedHtml },
+          { extension: 'asciidoc', outputFormat: 'html', rendererIsPublic: true, sync: false, html: expectedHtml },
         ],
       },
     });
@@ -231,16 +233,16 @@ process.stdout.write(JSON.stringify({
   namespaceRendererEqualsNamed: namespaceRenderer === renderer,
   registerResultIsUndefined: registerResult === undefined,
   outputs: {
-    nestedDefault: render(nestedDefault),
-    named: render(renderer),
-    namespaceNamed: render(namespaceRenderer),
-    registered: registrations.map(([extension, outputFormat, registeredRenderer, sync]) => ({
+    nestedDefault: await render(nestedDefault),
+    named: await render(renderer),
+    namespaceNamed: await render(namespaceRenderer),
+    registered: await Promise.all(registrations.map(async ([extension, outputFormat, registeredRenderer, sync]) => ({
       extension,
       outputFormat,
       rendererIsPublic: registeredRenderer === renderer,
       sync,
-      html: render(registeredRenderer),
-    })),
+      html: await render(registeredRenderer),
+    }))),
   },
 }));`,
     );
@@ -261,9 +263,9 @@ process.stdout.write(JSON.stringify({
         named: expectedHtml,
         namespaceNamed: expectedHtml,
         registered: [
-          { extension: 'ad', outputFormat: 'html', rendererIsPublic: true, sync: true, html: expectedHtml },
-          { extension: 'adoc', outputFormat: 'html', rendererIsPublic: true, sync: true, html: expectedHtml },
-          { extension: 'asciidoc', outputFormat: 'html', rendererIsPublic: true, sync: true, html: expectedHtml },
+          { extension: 'ad', outputFormat: 'html', rendererIsPublic: true, sync: false, html: expectedHtml },
+          { extension: 'adoc', outputFormat: 'html', rendererIsPublic: true, sync: false, html: expectedHtml },
+          { extension: 'asciidoc', outputFormat: 'html', rendererIsPublic: true, sync: false, html: expectedHtml },
         ],
       },
     });

--- a/src/public/lib/hexo-renderer-asciidoc/test/packed-artifact.test.ts
+++ b/src/public/lib/hexo-renderer-asciidoc/test/packed-artifact.test.ts
@@ -1,0 +1,271 @@
+/**
+ * Copyright 2015 Shuai Zhang
+ * SPDX-License-Identifier: LGPL-3.0-or-later WITH LGPL-3.0-linking-exception
+ */
+
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+const packageRoot = path.resolve(import.meta.dirname, '..');
+const distDirectory = path.join(packageRoot, 'dist');
+const expectedDistFiles = ['index.cjs', 'index.d.cts', 'index.d.cts.map'];
+const expectedHexoVersion = '8.1.2';
+const probeText = `
+== Packed Artifact ==
+
+[source,javascript]
+----
+const value = { nested: true };
+----
+`;
+const expectedHtml = `<div class="sect1">
+<h2 id="_packed_artifact">Packed Artifact</h2>
+<div class="sectionbody">
+<div class="listingblock">
+<div class="content">
+<pre><code class="highlight javascript"><span class="keyword">const</span> value = &#123; <span class="attr">nested</span>: <span class="literal">true</span> &#125;;</code></pre>
+</div>
+</div>
+</div>
+</div>`;
+
+let temporaryDirectory: string;
+let artifactDirectory: string;
+let consumerDirectory: string;
+let distWasAbsentBeforeBuild = false;
+let builtDistFiles: string[] = [];
+let packedManifest: { dependencies?: { asciidoctor?: string }; name?: string; version?: string };
+let packedArtifact: { inventory: string[]; sha256: string; version: string };
+let consumerManifest: {
+  dependencies: { hexo: string; 'hexo-renderer-asciidoc': string };
+  name: string;
+  packageManager: string;
+  private: boolean;
+};
+
+const runNodeProbe = (scriptName: string, source: string): Record<string, unknown> => {
+  const scriptPath = path.join(consumerDirectory, scriptName);
+  writeFileSync(scriptPath, source);
+  const stdout = execFileSync(process.execPath, [scriptPath], {
+    cwd: consumerDirectory,
+    encoding: 'utf8',
+  });
+  return JSON.parse(stdout) as Record<string, unknown>;
+};
+
+beforeAll(() => {
+  temporaryDirectory = mkdtempSync(path.join(tmpdir(), 'hexo-renderer-asciidoc-packed-v3-'));
+  artifactDirectory = path.join(temporaryDirectory, 'artifact');
+  consumerDirectory = path.join(temporaryDirectory, 'consumer');
+  mkdirSync(artifactDirectory);
+  mkdirSync(consumerDirectory);
+
+  rmSync(distDirectory, { recursive: true, force: true });
+  distWasAbsentBeforeBuild = !existsSync(distDirectory);
+  if (!distWasAbsentBeforeBuild) {
+    throw new Error('dist/ must be absent before the packed-artifact build');
+  }
+
+  execFileSync('pnpm', ['run', 'build'], { cwd: packageRoot, stdio: 'pipe' });
+  builtDistFiles = readdirSync(distDirectory).sort();
+
+  const packOutput = execFileSync(
+    'npm',
+    ['pack', '--ignore-scripts', '--json', '--pack-destination', artifactDirectory],
+    { cwd: packageRoot, encoding: 'utf8' },
+  );
+  const packResult = JSON.parse(packOutput) as Array<{ filename: string }>;
+  const archivePath = path.join(artifactDirectory, packResult[0]?.filename ?? '');
+  if (!existsSync(archivePath)) {
+    throw new Error('npm pack did not produce the expected v3 artifact');
+  }
+
+  packedManifest = JSON.parse(
+    execFileSync('tar', ['-xOzf', archivePath, 'package/package.json'], { encoding: 'utf8' }),
+  ) as typeof packedManifest;
+  const version = packedManifest.version;
+  if (typeof version !== 'string') {
+    throw new Error('packed artifact does not contain a package version');
+  }
+  packedArtifact = {
+    inventory: execFileSync('tar', ['-tzf', archivePath], { encoding: 'utf8' }).trim().split('\n'),
+    sha256: createHash('sha256').update(readFileSync(archivePath)).digest('hex'),
+    version,
+  };
+
+  consumerManifest = {
+    name: 'hexo-renderer-asciidoc-packed-v3-consumer',
+    private: true,
+    packageManager: `pnpm@${execFileSync('pnpm', ['--version'], { encoding: 'utf8' }).trim()}`,
+    dependencies: {
+      hexo: expectedHexoVersion,
+      'hexo-renderer-asciidoc': `file:${archivePath}`,
+    },
+  };
+  writeFileSync(path.join(consumerDirectory, 'package.json'), `${JSON.stringify(consumerManifest, undefined, 2)}\n`);
+  execFileSync('pnpm', ['install', '--lockfile-only', '--ignore-scripts'], {
+    cwd: consumerDirectory,
+    stdio: 'pipe',
+  });
+  execFileSync('pnpm', ['install', '--frozen-lockfile', '--ignore-scripts'], {
+    cwd: consumerDirectory,
+    stdio: 'pipe',
+  });
+}, 60_000);
+
+afterAll(() => {
+  rmSync(temporaryDirectory, { recursive: true, force: true });
+  rmSync(distDirectory, { recursive: true, force: true });
+});
+
+describe('packed Asciidoctor v3 package import shapes', () => {
+  it('builds a fresh dist, records packed metadata, and preserves the current runtime dependency', () => {
+    expect(distWasAbsentBeforeBuild).toBe(true);
+    expect(builtDistFiles).toEqual(expectedDistFiles);
+
+    expect(expectedHtml).toContain('<h2 id="_packed_artifact">Packed Artifact</h2>');
+    expect(expectedHtml).toContain('&#123;');
+    expect(expectedHtml).toContain('&#125;');
+    expect(expectedHtml).toContain('<code class="highlight javascript">');
+
+    expect(packedManifest.name).toBe('hexo-renderer-asciidoc');
+    expect(packedManifest.dependencies?.asciidoctor).toBe('3.0.4');
+    expect(packedArtifact.version).toBe(packedManifest.version);
+    expect(packedArtifact.inventory).toEqual(
+      expect.arrayContaining(['package/package.json', ...expectedDistFiles.map((file) => `package/dist/${file}`)]),
+    );
+    expect(packedArtifact.sha256).toMatch(/^[\da-f]{64}$/);
+    expect(consumerManifest.dependencies.hexo).toBe(expectedHexoVersion);
+    expect(existsSync(path.join(consumerDirectory, 'pnpm-lock.yaml'))).toBe(true);
+  });
+
+  it('invokes CommonJS default, named, and registered renderers with identical HTML', () => {
+    const probe = runNodeProbe(
+      'commonjs.cjs',
+      `const sample = ${JSON.stringify(probeText)};
+const packageRoot = require('hexo-renderer-asciidoc');
+const registrations = [];
+const registerResult = packageRoot.registerRenderer({
+  extend: {
+    renderer: {
+      register(...args) {
+        registrations.push(args);
+      },
+    },
+  },
+});
+const render = (fn) => fn({ text: sample });
+process.stdout.write(JSON.stringify({
+  rootType: typeof packageRoot,
+  keys: Object.keys(packageRoot).sort(),
+  defaultType: typeof packageRoot.default,
+  rendererType: typeof packageRoot.renderer,
+  registerRendererType: typeof packageRoot.registerRenderer,
+  defaultEqualsRenderer: packageRoot.default === packageRoot.renderer,
+  registerResultIsUndefined: registerResult === undefined,
+  outputs: {
+    default: render(packageRoot.default),
+    named: render(packageRoot.renderer),
+    registered: registrations.map(([extension, outputFormat, registeredRenderer, sync]) => ({
+      extension,
+      outputFormat,
+      rendererIsPublic: registeredRenderer === packageRoot.renderer,
+      sync,
+      html: render(registeredRenderer),
+    })),
+  },
+}));`,
+    );
+
+    expect(probe).toEqual({
+      rootType: 'object',
+      keys: ['default', 'registerRenderer', 'renderer'],
+      defaultType: 'function',
+      rendererType: 'function',
+      registerRendererType: 'function',
+      defaultEqualsRenderer: true,
+      registerResultIsUndefined: true,
+      outputs: {
+        default: expectedHtml,
+        named: expectedHtml,
+        registered: [
+          { extension: 'ad', outputFormat: 'html', rendererIsPublic: true, sync: true, html: expectedHtml },
+          { extension: 'adoc', outputFormat: 'html', rendererIsPublic: true, sync: true, html: expectedHtml },
+          { extension: 'asciidoc', outputFormat: 'html', rendererIsPublic: true, sync: true, html: expectedHtml },
+        ],
+      },
+    });
+  });
+
+  it('invokes the ESM nested default, named, namespace, and registered renderers with identical HTML', () => {
+    const probe = runNodeProbe(
+      'module.mjs',
+      `const sample = ${JSON.stringify(probeText)};
+import packageDefault, { registerRenderer, renderer } from 'hexo-renderer-asciidoc';
+const registrations = [];
+const registerResult = registerRenderer({
+  extend: {
+    renderer: {
+      register(...args) {
+        registrations.push(args);
+      },
+    },
+  },
+});
+const nestedDefault = packageDefault.default;
+const namespaceRenderer = packageDefault.renderer;
+const render = (fn) => fn({ text: sample });
+process.stdout.write(JSON.stringify({
+  defaultType: typeof packageDefault,
+  defaultKeys: Object.keys(packageDefault).sort(),
+  nestedDefaultType: typeof nestedDefault,
+  namespaceRendererType: typeof namespaceRenderer,
+  rendererType: typeof renderer,
+  registerRendererType: typeof registerRenderer,
+  defaultEqualsRenderer: packageDefault === renderer,
+  nestedDefaultEqualsRenderer: nestedDefault === renderer,
+  namespaceRendererEqualsNamed: namespaceRenderer === renderer,
+  registerResultIsUndefined: registerResult === undefined,
+  outputs: {
+    nestedDefault: render(nestedDefault),
+    named: render(renderer),
+    namespaceNamed: render(namespaceRenderer),
+    registered: registrations.map(([extension, outputFormat, registeredRenderer, sync]) => ({
+      extension,
+      outputFormat,
+      rendererIsPublic: registeredRenderer === renderer,
+      sync,
+      html: render(registeredRenderer),
+    })),
+  },
+}));`,
+    );
+
+    expect(probe).toEqual({
+      defaultType: 'object',
+      defaultKeys: ['default', 'registerRenderer', 'renderer'],
+      nestedDefaultType: 'function',
+      namespaceRendererType: 'function',
+      rendererType: 'function',
+      registerRendererType: 'function',
+      defaultEqualsRenderer: false,
+      nestedDefaultEqualsRenderer: true,
+      namespaceRendererEqualsNamed: true,
+      registerResultIsUndefined: true,
+      outputs: {
+        nestedDefault: expectedHtml,
+        named: expectedHtml,
+        namespaceNamed: expectedHtml,
+        registered: [
+          { extension: 'ad', outputFormat: 'html', rendererIsPublic: true, sync: true, html: expectedHtml },
+          { extension: 'adoc', outputFormat: 'html', rendererIsPublic: true, sync: true, html: expectedHtml },
+          { extension: 'asciidoc', outputFormat: 'html', rendererIsPublic: true, sync: true, html: expectedHtml },
+        ],
+      },
+    });
+  });
+});

--- a/src/public/lib/hexo-renderer-asciidoc/test/packed-artifact.test.ts
+++ b/src/public/lib/hexo-renderer-asciidoc/test/packed-artifact.test.ts
@@ -12,8 +12,9 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 const packageRoot = path.resolve(import.meta.dirname, '..');
 const distDirectory = path.join(packageRoot, 'dist');
-const expectedDistFiles = ['index.cjs', 'index.d.cts', 'index.d.cts.map'];
+const expectedDistFiles = ['index.cjs', 'index.d.cts', 'index.d.cts.map', 'index.d.ts', 'index.d.ts.map', 'index.js'];
 const expectedHexoVersion = '8.1.2';
+const expectedPnpmVersion = '10.34.5';
 const probeText = `
 == Packed Artifact ==
 
@@ -38,7 +39,19 @@ let artifactDirectory: string;
 let consumerDirectory: string;
 let distWasAbsentBeforeBuild = false;
 let builtDistFiles: string[] = [];
-let packedManifest: { dependencies?: { '@asciidoctor/core'?: string }; name?: string; version?: string };
+let packedManifest: {
+  dependencies?: { '@asciidoctor/core'?: string };
+  exports?: {
+    '.': {
+      import?: { default?: string; types?: string };
+      require?: { default?: string; types?: string };
+    };
+  };
+  main?: string;
+  name?: string;
+  types?: string;
+  version?: string;
+};
 let packedArtifact: { inventory: string[]; sha256: string; version: string };
 let consumerManifest: {
   dependencies: { hexo: string; 'hexo-renderer-asciidoc': string };
@@ -64,7 +77,9 @@ beforeAll(() => {
   mkdirSync(artifactDirectory);
   mkdirSync(consumerDirectory);
 
-  rmSync(distDirectory, { recursive: true, force: true });
+  if (existsSync(distDirectory)) {
+    rmSync(distDirectory, { recursive: true, force: true });
+  }
   distWasAbsentBeforeBuild = !existsSync(distDirectory);
   if (!distWasAbsentBeforeBuild) {
     throw new Error('dist/ must be absent before the packed-artifact build');
@@ -73,13 +88,11 @@ beforeAll(() => {
   execFileSync('pnpm', ['run', 'build'], { cwd: packageRoot, stdio: 'pipe' });
   builtDistFiles = readdirSync(distDirectory).sort();
 
-  const packOutput = execFileSync(
-    'npm',
-    ['pack', '--ignore-scripts', '--json', '--pack-destination', artifactDirectory],
-    { cwd: packageRoot, encoding: 'utf8' },
-  );
-  const packResult = JSON.parse(packOutput) as Array<{ filename: string }>;
-  const archivePath = path.join(artifactDirectory, packResult[0]?.filename ?? '');
+  execFileSync('pnpm', ['pack', '--pack-destination', artifactDirectory], { cwd: packageRoot, stdio: 'pipe' });
+  const archiveEntries = readdirSync(artifactDirectory)
+    .filter((entry) => entry.endsWith('.tgz'))
+    .sort();
+  const archivePath = path.join(artifactDirectory, archiveEntries[0] ?? '');
   if (!existsSync(archivePath)) {
     throw new Error('npm pack did not produce the expected v4 artifact');
   }
@@ -100,7 +113,7 @@ beforeAll(() => {
   consumerManifest = {
     name: 'hexo-renderer-asciidoc-packed-v4-consumer',
     private: true,
-    packageManager: `pnpm@${execFileSync('pnpm', ['--version'], { encoding: 'utf8' }).trim()}`,
+    packageManager: `pnpm@${expectedPnpmVersion}`,
     dependencies: {
       hexo: expectedHexoVersion,
       'hexo-renderer-asciidoc': `file:${archivePath}`,
@@ -123,9 +136,19 @@ afterAll(() => {
 });
 
 describe('packed Asciidoctor v4 package import shapes', () => {
-  it('builds a fresh dist, records packed metadata, and pins the v4 runtime dependency', () => {
+  it('records the initial dist state, builds a fresh dist, and pins the v4 runtime dependency', () => {
     expect(distWasAbsentBeforeBuild).toBe(true);
     expect(builtDistFiles).toEqual(expectedDistFiles);
+    for (const declarationName of ['index.d.ts', 'index.d.cts']) {
+      const mapName = `${declarationName}.map`;
+      const declarationMap = JSON.parse(readFileSync(path.join(distDirectory, mapName), 'utf8')) as {
+        file?: string;
+      };
+      expect(declarationMap.file).toBe(declarationName);
+      expect(readFileSync(path.join(distDirectory, declarationName), 'utf8')).toContain(
+        `//# sourceMappingURL=${mapName}`,
+      );
+    }
 
     expect(expectedHtml).toContain('<h2 id="_packed_artifact">Packed Artifact</h2>');
     expect(expectedHtml).toContain('&#123;');
@@ -134,6 +157,12 @@ describe('packed Asciidoctor v4 package import shapes', () => {
 
     expect(packedManifest.name).toBe('hexo-renderer-asciidoc');
     expect(packedManifest.dependencies?.['@asciidoctor/core']).toBe('4.0.4');
+    expect(packedManifest.main).toBe('./dist/index.cjs');
+    expect(packedManifest.types).toBe('./dist/index.d.ts');
+    expect(packedManifest.exports?.['.']?.import?.default).toBe('./dist/index.js');
+    expect(packedManifest.exports?.['.']?.import?.types).toBe('./dist/index.d.ts');
+    expect(packedManifest.exports?.['.']?.require?.default).toBe('./dist/index.cjs');
+    expect(packedManifest.exports?.['.']?.require?.types).toBe('./dist/index.d.cts');
     expect(packedArtifact.version).toBe(packedManifest.version);
     expect(packedArtifact.inventory).toEqual(
       expect.arrayContaining(['package/package.json', ...expectedDistFiles.map((file) => `package/dist/${file}`)]),
@@ -218,24 +247,16 @@ const registerResult = registerRenderer({
     },
   },
 });
-const nestedDefault = packageDefault.default;
-const namespaceRenderer = packageDefault.renderer;
 const render = (fn) => fn({ text: sample });
 process.stdout.write(JSON.stringify({
   defaultType: typeof packageDefault,
-  defaultKeys: Object.keys(packageDefault).sort(),
-  nestedDefaultType: typeof nestedDefault,
-  namespaceRendererType: typeof namespaceRenderer,
   rendererType: typeof renderer,
   registerRendererType: typeof registerRenderer,
   defaultEqualsRenderer: packageDefault === renderer,
-  nestedDefaultEqualsRenderer: nestedDefault === renderer,
-  namespaceRendererEqualsNamed: namespaceRenderer === renderer,
   registerResultIsUndefined: registerResult === undefined,
   outputs: {
-    nestedDefault: await render(nestedDefault),
+    default: await render(packageDefault),
     named: await render(renderer),
-    namespaceNamed: await render(namespaceRenderer),
     registered: await Promise.all(registrations.map(async ([extension, outputFormat, registeredRenderer, sync]) => ({
       extension,
       outputFormat,
@@ -248,20 +269,14 @@ process.stdout.write(JSON.stringify({
     );
 
     expect(probe).toEqual({
-      defaultType: 'object',
-      defaultKeys: ['default', 'registerRenderer', 'renderer'],
-      nestedDefaultType: 'function',
-      namespaceRendererType: 'function',
+      defaultType: 'function',
       rendererType: 'function',
       registerRendererType: 'function',
-      defaultEqualsRenderer: false,
-      nestedDefaultEqualsRenderer: true,
-      namespaceRendererEqualsNamed: true,
+      defaultEqualsRenderer: true,
       registerResultIsUndefined: true,
       outputs: {
-        nestedDefault: expectedHtml,
+        default: expectedHtml,
         named: expectedHtml,
-        namespaceNamed: expectedHtml,
         registered: [
           { extension: 'ad', outputFormat: 'html', rendererIsPublic: true, sync: false, html: expectedHtml },
           { extension: 'adoc', outputFormat: 'html', rendererIsPublic: true, sync: false, html: expectedHtml },

--- a/src/public/lib/hexo-renderer-asciidoc/test/pipeline-failure.worker.ts
+++ b/src/public/lib/hexo-renderer-asciidoc/test/pipeline-failure.worker.ts
@@ -1,0 +1,232 @@
+/**
+ * Copyright 2015 Shuai Zhang
+ * SPDX-License-Identifier: LGPL-3.0-or-later WITH LGPL-3.0-linking-exception
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import Hexo from 'hexo';
+import { describe, expect, it } from 'vitest';
+import { convertAsciiDoc } from '../src/core/asciidoctor';
+import { applyStaticHighlighting } from '../src/core/highlight';
+import { escapeCurlyBraces } from '../src/core/sanitize';
+import type { Hexo as HexoContract, Renderer, RendererData } from '../src/types';
+
+const HEXO_ENGINE = 'adoc';
+const SAMPLE_TEXT = `
+== Pipeline Failure Probe ==
+
+[source,javascript]
+----
+const value = { nested: true };
+----
+`;
+// Independently reviewed v3 baseline; intentionally not derived from production stages.
+const PINNED_V3_EXPECTED_HTML = `<div class="sect1">
+<h2 id="_pipeline_failure_probe">Pipeline Failure Probe</h2>
+<div class="sectionbody">
+<div class="listingblock">
+<div class="content">
+<pre><code class="highlight javascript"><span class="keyword">const</span> value = &#123; <span class="attr">nested</span>: <span class="literal">true</span> &#125;;</code></pre>
+</div>
+</div>
+</div>
+</div>`;
+
+type HexoRenderAPI = {
+  render(data: Record<string, unknown>, locals?: Record<string, unknown>): Promise<string>;
+};
+
+type HexoTestInstance = HexoContract & {
+  base_dir: string;
+  render: HexoRenderAPI;
+  init(): Promise<void>;
+  exit(err?: unknown): Promise<void>;
+};
+
+type HexoConstructor = new (baseDir: string, options?: Record<string, unknown>) => HexoTestInstance;
+
+type StageName = 'convert' | 'highlight' | 'escape';
+type ConvertStage = (text: string) => string;
+type HtmlStage = (html: string) => string;
+
+const HexoClass = Hexo as unknown as HexoConstructor;
+
+const createHexoWorkspace = (): string => {
+  const tempDir = mkdtempSync(path.join(tmpdir(), 'hexo-renderer-asciidoc-pipeline-failure-'));
+  writeFileSync(path.join(tempDir, '_config.yml'), 'title: hexo-renderer-asciidoc\n');
+  return tempDir;
+};
+
+const drainPendingTasks = async (): Promise<void> => {
+  await Promise.resolve();
+  await new Promise<void>((resolve) => setImmediate(resolve));
+};
+
+/**
+ * Test-only seam: compose the real production v3 stages while allowing one stage
+ * to be replaced with a throwing sentinel. This keeps product source unchanged.
+ */
+const createRendererProbe = ({
+  convert = convertAsciiDoc,
+  highlight = applyStaticHighlighting,
+  escapeStage = escapeCurlyBraces,
+}: {
+  convert?: ConvertStage;
+  highlight?: HtmlStage;
+  escapeStage?: HtmlStage;
+} = {}) => {
+  const calls: StageName[] = [];
+
+  const probeRenderer: Renderer = (data: RendererData) => {
+    calls.push('convert');
+    const html = convert(data.text);
+
+    calls.push('highlight');
+    const highlighted = highlight(html);
+
+    calls.push('escape');
+    return escapeStage(highlighted);
+  };
+
+  return {
+    calls,
+    renderer: probeRenderer,
+    reset() {
+      calls.length = 0;
+    },
+  };
+};
+
+const renderViaHexo = async (probeRenderer: Renderer, text: string = SAMPLE_TEXT): Promise<string> => {
+  const workspace = createHexoWorkspace();
+  const hexo = new HexoClass(workspace, { silent: true, debug: false });
+  hexo.extend.renderer.register(HEXO_ENGINE, 'html', probeRenderer, true);
+
+  try {
+    await hexo.init();
+    return await hexo.render.render({ text, engine: HEXO_ENGINE });
+  } finally {
+    try {
+      await drainPendingTasks();
+      await hexo.exit();
+      await drainPendingTasks();
+    } finally {
+      rmSync(workspace, { recursive: true, force: true });
+    }
+  }
+};
+
+describe.sequential('pipeline failure probe worker', () => {
+  it('preserves a conversion sentinel and stops before highlighting or escaping', async () => {
+    const sentinel = new Error('conversion sentinel');
+    const probe = createRendererProbe({
+      convert: () => {
+        throw sentinel;
+      },
+    });
+
+    let directError: unknown;
+    try {
+      probe.renderer({ text: SAMPLE_TEXT });
+    } catch (error) {
+      directError = error;
+    }
+
+    expect(directError).toBe(sentinel);
+    expect(probe.calls).toEqual(['convert']);
+
+    probe.reset();
+    await expect(renderViaHexo(probe.renderer)).rejects.toBe(sentinel);
+    expect(probe.calls).toEqual(['convert']);
+  });
+
+  it('preserves a highlighting sentinel and stops before escaping', async () => {
+    const sentinel = new Error('highlighting sentinel');
+    const probe = createRendererProbe({
+      highlight: () => {
+        throw sentinel;
+      },
+    });
+
+    let directError: unknown;
+    try {
+      probe.renderer({ text: SAMPLE_TEXT });
+    } catch (error) {
+      directError = error;
+    }
+
+    expect(directError).toBe(sentinel);
+    expect(probe.calls).toEqual(['convert', 'highlight']);
+
+    probe.reset();
+    await expect(renderViaHexo(probe.renderer)).rejects.toBe(sentinel);
+    expect(probe.calls).toEqual(['convert', 'highlight']);
+  });
+
+  it('preserves an escaping sentinel after conversion and highlighting', async () => {
+    const sentinel = new Error('escape sentinel');
+    const probe = createRendererProbe({
+      escapeStage: () => {
+        throw sentinel;
+      },
+    });
+
+    let directError: unknown;
+    try {
+      probe.renderer({ text: SAMPLE_TEXT });
+    } catch (error) {
+      directError = error;
+    }
+
+    expect(directError).toBe(sentinel);
+    expect(probe.calls).toEqual(['convert', 'highlight', 'escape']);
+
+    probe.reset();
+    await expect(renderViaHexo(probe.renderer)).rejects.toBe(sentinel);
+    expect(probe.calls).toEqual(['convert', 'highlight', 'escape']);
+  });
+
+  it('still renders successfully after an injected escape failure', async () => {
+    const sentinel = new Error('escape once sentinel');
+
+    let directFailed = false;
+    const directProbe = createRendererProbe({
+      escapeStage: (html) => {
+        if (!directFailed) {
+          directFailed = true;
+          throw sentinel;
+        }
+
+        return escapeCurlyBraces(html);
+      },
+    });
+
+    expect(() => directProbe.renderer({ text: SAMPLE_TEXT })).toThrow(sentinel);
+    expect(directProbe.calls).toEqual(['convert', 'highlight', 'escape']);
+
+    directProbe.reset();
+    expect(directProbe.renderer({ text: SAMPLE_TEXT })).toBe(PINNED_V3_EXPECTED_HTML);
+    expect(directProbe.calls).toEqual(['convert', 'highlight', 'escape']);
+
+    let hexoFailed = false;
+    const hexoProbe = createRendererProbe({
+      escapeStage: (html) => {
+        if (!hexoFailed) {
+          hexoFailed = true;
+          throw sentinel;
+        }
+
+        return escapeCurlyBraces(html);
+      },
+    });
+
+    await expect(renderViaHexo(hexoProbe.renderer)).rejects.toBe(sentinel);
+    expect(hexoProbe.calls).toEqual(['convert', 'highlight', 'escape']);
+
+    hexoProbe.reset();
+    await expect(renderViaHexo(hexoProbe.renderer)).resolves.toBe(PINNED_V3_EXPECTED_HTML);
+    expect(hexoProbe.calls).toEqual(['convert', 'highlight', 'escape']);
+  });
+});

--- a/src/public/lib/hexo-renderer-asciidoc/test/pipeline-failure.worker.ts
+++ b/src/public/lib/hexo-renderer-asciidoc/test/pipeline-failure.worker.ts
@@ -7,13 +7,106 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import Hexo from 'hexo';
-import { describe, expect, it } from 'vitest';
-import { convertAsciiDoc } from '../src/core/asciidoctor';
-import { applyStaticHighlighting } from '../src/core/highlight';
-import { escapeCurlyBraces } from '../src/core/sanitize';
-import type { Hexo as HexoContract, Renderer, RendererData } from '../src/types';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Hexo as HexoContract, Renderer } from '../src/types';
 
-const HEXO_ENGINE = 'adoc';
+type StageName = 'convertAsciiDoc' | 'applyStaticHighlighting' | 'escapeCurlyBraces';
+
+type FailureInjection = {
+  sentinel: unknown;
+  stage: StageName;
+};
+
+const pipeline = vi.hoisted(() => ({
+  applyStaticHighlighting: vi.fn(),
+  calls: [] as StageName[],
+  convertAsciiDoc: vi.fn(),
+  escapeCurlyBraces: vi.fn(),
+  failure: null as FailureInjection | null,
+  pendingConversions: 0,
+}));
+
+vi.mock('../src/core/asciidoctor', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/core/asciidoctor')>();
+
+  pipeline.convertAsciiDoc.mockImplementation(async (text: string) => {
+    pipeline.calls.push('convertAsciiDoc');
+    pipeline.pendingConversions += 1;
+
+    try {
+      const failure = pipeline.failure;
+      if (failure?.stage === 'convertAsciiDoc') {
+        pipeline.failure = null;
+        throw failure.sentinel;
+      }
+
+      return await actual.convertAsciiDoc(text);
+    } finally {
+      pipeline.pendingConversions -= 1;
+    }
+  });
+
+  return {
+    ...actual,
+    convertAsciiDoc: pipeline.convertAsciiDoc,
+  };
+});
+
+vi.mock('../src/core/highlight', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/core/highlight')>();
+
+  pipeline.applyStaticHighlighting.mockImplementation((html: string) => {
+    pipeline.calls.push('applyStaticHighlighting');
+
+    const failure = pipeline.failure;
+    if (failure?.stage === 'applyStaticHighlighting') {
+      pipeline.failure = null;
+      throw failure.sentinel;
+    }
+
+    return actual.applyStaticHighlighting(html);
+  });
+
+  return {
+    ...actual,
+    applyStaticHighlighting: pipeline.applyStaticHighlighting,
+  };
+});
+
+vi.mock('../src/core/sanitize', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/core/sanitize')>();
+
+  pipeline.escapeCurlyBraces.mockImplementation((html: string) => {
+    pipeline.calls.push('escapeCurlyBraces');
+
+    const failure = pipeline.failure;
+    if (failure?.stage === 'escapeCurlyBraces') {
+      pipeline.failure = null;
+
+      const throwingHtml = {
+        replace: () => {
+          throw failure.sentinel;
+        },
+      } as unknown as string;
+
+      // Run the production sanitizer so a catch-and-fallback mutation is observable.
+      return actual.escapeCurlyBraces(throwingHtml);
+    }
+
+    return actual.escapeCurlyBraces(html);
+  });
+
+  return {
+    ...actual,
+    escapeCurlyBraces: pipeline.escapeCurlyBraces,
+  };
+});
+
+import renderer from '../src/core/renderer';
+import registerRenderer from '../src/hexo/register';
+
+const SUPPORTED_EXTENSIONS = ['ad', 'adoc', 'asciidoc'] as const;
+const COMPLETE_TRACE: readonly StageName[] = ['convertAsciiDoc', 'applyStaticHighlighting', 'escapeCurlyBraces'];
 const SAMPLE_TEXT = `
 == Pipeline Failure Probe ==
 
@@ -36,20 +129,24 @@ const PINNED_V4_EXPECTED_HTML = `<div class="sect1">
 
 type HexoRenderAPI = {
   render(data: Record<string, unknown>, locals?: Record<string, unknown>): Promise<string>;
+  renderSync(data: Record<string, unknown>, locals?: Record<string, unknown>): string;
+};
+
+type HexoRendererRegistry = HexoContract['extend']['renderer'] & {
+  get(name: string, sync?: boolean): Renderer | undefined;
 };
 
 type HexoTestInstance = HexoContract & {
   base_dir: string;
+  extend: {
+    renderer: HexoRendererRegistry;
+  };
   render: HexoRenderAPI;
   init(): Promise<void>;
   exit(err?: unknown): Promise<void>;
 };
 
 type HexoConstructor = new (baseDir: string, options?: Record<string, unknown>) => HexoTestInstance;
-
-type StageName = 'convert' | 'highlight' | 'escape';
-type ConvertStage = (text: string) => string | Promise<string>;
-type HtmlStage = (html: string) => string;
 
 const HexoClass = Hexo as unknown as HexoConstructor;
 
@@ -64,148 +161,167 @@ const drainPendingTasks = async (): Promise<void> => {
   await new Promise<void>((resolve) => setImmediate(resolve));
 };
 
-/**
- * Test-only seam: compose the real production v4 stages while allowing one stage
- * to be replaced with a throwing sentinel. This keeps product source unchanged.
- */
-const createRendererProbe = ({
-  convert = convertAsciiDoc,
-  highlight = applyStaticHighlighting,
-  escapeStage = escapeCurlyBraces,
-}: {
-  convert?: ConvertStage;
-  highlight?: HtmlStage;
-  escapeStage?: HtmlStage;
-} = {}) => {
-  const calls: StageName[] = [];
-
-  const probeRenderer: Renderer = async (data: RendererData) => {
-    calls.push('convert');
-    const html = await convert(data.text);
-
-    calls.push('highlight');
-    const highlighted = highlight(html);
-
-    calls.push('escape');
-    return escapeStage(highlighted);
-  };
-
-  return {
-    calls,
-    renderer: probeRenderer,
-    reset() {
-      calls.length = 0;
-    },
-  };
+const resetObservations = (): void => {
+  pipeline.calls.length = 0;
+  pipeline.convertAsciiDoc.mockClear();
+  pipeline.applyStaticHighlighting.mockClear();
+  pipeline.escapeCurlyBraces.mockClear();
 };
 
-const renderViaHexo = async (probeRenderer: Renderer, text: string = SAMPLE_TEXT): Promise<string> => {
-  const workspace = createHexoWorkspace();
-  const hexo = new HexoClass(workspace, { silent: true, debug: false });
-  hexo.extend.renderer.register(HEXO_ENGINE, 'html', probeRenderer, false);
+const armFailure = (stage: StageName, sentinel: unknown): void => {
+  if (pipeline.failure !== null) {
+    throw new Error(`A ${pipeline.failure.stage} failure is already armed`);
+  }
 
+  pipeline.failure = { sentinel, stage };
+};
+
+const captureOutcome = async <T>(
+  operation: () => Promise<T>,
+): Promise<{ reason: unknown; status: 'rejected' } | { status: 'fulfilled'; value: T }> => {
   try {
-    await hexo.init();
-    return await hexo.render.render({ text, engine: HEXO_ENGINE });
-  } finally {
+    return { status: 'fulfilled', value: await operation() };
+  } catch (reason) {
+    return { reason, status: 'rejected' };
+  }
+};
+
+const expectExactSentinelRejection = async (operation: () => Promise<unknown>, sentinel: unknown): Promise<void> => {
+  const outcome = await captureOutcome(operation);
+
+  expect(outcome.status).toBe('rejected');
+  if (outcome.status === 'fulfilled') {
+    throw new Error(`Expected rejection, but the renderer returned a ${typeof outcome.value} fallback`);
+  }
+
+  // Identity excludes wrapping, cause-only propagation, and stringification.
+  expect(outcome.reason).toBe(sentinel);
+};
+
+const expectStageTrace = (expected: readonly StageName[]): void => {
+  expect(pipeline.calls).toEqual(expected);
+  expect(pipeline.convertAsciiDoc).toHaveBeenCalledTimes(expected.includes('convertAsciiDoc') ? 1 : 0);
+  expect(pipeline.applyStaticHighlighting).toHaveBeenCalledTimes(expected.includes('applyStaticHighlighting') ? 1 : 0);
+  expect(pipeline.escapeCurlyBraces).toHaveBeenCalledTimes(expected.includes('escapeCurlyBraces') ? 1 : 0);
+};
+
+const expectPendingTasksDrained = async (): Promise<void> => {
+  await drainPendingTasks();
+  expect(pipeline.pendingConversions).toBe(0);
+};
+
+const createSentinel = (stage: StageName): Readonly<{ identity: symbol; stage: StageName }> =>
+  Object.freeze({
+    identity: Symbol(`${stage} sentinel`),
+    stage,
+  });
+
+const FAILURE_CASES = [
+  {
+    expectedTrace: ['convertAsciiDoc'],
+    extension: 'ad',
+    stage: 'convertAsciiDoc',
+  },
+  {
+    expectedTrace: ['convertAsciiDoc', 'applyStaticHighlighting'],
+    extension: 'adoc',
+    stage: 'applyStaticHighlighting',
+  },
+  {
+    expectedTrace: COMPLETE_TRACE,
+    extension: 'asciidoc',
+    stage: 'escapeCurlyBraces',
+  },
+] as const satisfies readonly {
+  expectedTrace: readonly StageName[];
+  extension: (typeof SUPPORTED_EXTENSIONS)[number];
+  stage: StageName;
+}[];
+
+describe.sequential('production pipeline failure worker', () => {
+  let hexoInstance: HexoTestInstance;
+  let workspace: string;
+
+  beforeAll(async () => {
+    workspace = createHexoWorkspace();
+    hexoInstance = new HexoClass(workspace, { silent: true, debug: false });
+    registerRenderer(hexoInstance);
+    await hexoInstance.init();
+  });
+
+  afterAll(async () => {
     try {
       await drainPendingTasks();
-      await hexo.exit();
+      await hexoInstance.exit();
       await drainPendingTasks();
     } finally {
       rmSync(workspace, { recursive: true, force: true });
     }
-  }
-};
-
-describe.sequential('pipeline failure probe worker', () => {
-  it('preserves a conversion sentinel and stops before highlighting or escaping', async () => {
-    const sentinel = new Error('conversion sentinel');
-    const probe = createRendererProbe({
-      convert: () => {
-        throw sentinel;
-      },
-    });
-
-    await expect(probe.renderer({ text: SAMPLE_TEXT })).rejects.toBe(sentinel);
-    expect(probe.calls).toEqual(['convert']);
-
-    probe.reset();
-    await expect(renderViaHexo(probe.renderer)).rejects.toBe(sentinel);
-    expect(probe.calls).toEqual(['convert']);
   });
 
-  it('preserves a highlighting sentinel and stops before escaping', async () => {
-    const sentinel = new Error('highlighting sentinel');
-    const probe = createRendererProbe({
-      highlight: () => {
-        throw sentinel;
-      },
-    });
-
-    await expect(probe.renderer({ text: SAMPLE_TEXT })).rejects.toBe(sentinel);
-    expect(probe.calls).toEqual(['convert', 'highlight']);
-
-    probe.reset();
-    await expect(renderViaHexo(probe.renderer)).rejects.toBe(sentinel);
-    expect(probe.calls).toEqual(['convert', 'highlight']);
+  beforeEach(() => {
+    pipeline.failure = null;
+    resetObservations();
   });
 
-  it('preserves an escaping sentinel after conversion and highlighting', async () => {
-    const sentinel = new Error('escape sentinel');
-    const probe = createRendererProbe({
-      escapeStage: () => {
-        throw sentinel;
-      },
-    });
-
-    await expect(probe.renderer({ text: SAMPLE_TEXT })).rejects.toBe(sentinel);
-    expect(probe.calls).toEqual(['convert', 'highlight', 'escape']);
-
-    probe.reset();
-    await expect(renderViaHexo(probe.renderer)).rejects.toBe(sentinel);
-    expect(probe.calls).toEqual(['convert', 'highlight', 'escape']);
+  afterEach(async () => {
+    pipeline.failure = null;
+    await expectPendingTasksDrained();
   });
 
-  it('still renders successfully after an injected escape failure', async () => {
-    const sentinel = new Error('escape once sentinel');
+  it.each(FAILURE_CASES)(
+    'preserves the exact $stage sentinel through the production renderer and Hexo .$extension rendering',
+    async ({ expectedTrace, extension, stage }) => {
+      const sentinel = createSentinel(stage);
 
-    let directFailed = false;
-    const directProbe = createRendererProbe({
-      escapeStage: (html) => {
-        if (!directFailed) {
-          directFailed = true;
-          throw sentinel;
-        }
+      armFailure(stage, sentinel);
+      await expectExactSentinelRejection(() => renderer({ text: SAMPLE_TEXT }), sentinel);
+      expectStageTrace(expectedTrace);
+      expect(pipeline.failure).toBeNull();
+      await expectPendingTasksDrained();
 
-        return escapeCurlyBraces(html);
-      },
-    });
+      resetObservations();
+      await expect(renderer({ text: SAMPLE_TEXT })).resolves.toBe(PINNED_V4_EXPECTED_HTML);
+      expectStageTrace(COMPLETE_TRACE);
+      await expectPendingTasksDrained();
 
-    await expect(directProbe.renderer({ text: SAMPLE_TEXT })).rejects.toBe(sentinel);
-    expect(directProbe.calls).toEqual(['convert', 'highlight', 'escape']);
+      resetObservations();
+      expect(hexoInstance.extend.renderer.get(extension)).toBe(renderer);
+      armFailure(stage, sentinel);
+      await expectExactSentinelRejection(
+        () => hexoInstance.render.render({ text: SAMPLE_TEXT, engine: extension }),
+        sentinel,
+      );
+      expectStageTrace(expectedTrace);
+      expect(pipeline.failure).toBeNull();
+      await expectPendingTasksDrained();
 
-    directProbe.reset();
-    await expect(directProbe.renderer({ text: SAMPLE_TEXT })).resolves.toBe(PINNED_V4_EXPECTED_HTML);
-    expect(directProbe.calls).toEqual(['convert', 'highlight', 'escape']);
+      resetObservations();
+      await expect(hexoInstance.render.render({ text: SAMPLE_TEXT, engine: extension })).resolves.toBe(
+        PINNED_V4_EXPECTED_HTML,
+      );
+      expectStageTrace(COMPLETE_TRACE);
+      await expectPendingTasksDrained();
+    },
+  );
 
-    let hexoFailed = false;
-    const hexoProbe = createRendererProbe({
-      escapeStage: (html) => {
-        if (!hexoFailed) {
-          hexoFailed = true;
-          throw sentinel;
-        }
+  it.each(SUPPORTED_EXTENSIONS)(
+    'does not invoke the production renderer pipeline from Hexo renderSync for .$extension',
+    (extension) => {
+      const text = `== Sync Zero Invocation ${extension} ==`;
+      const sentinel = createSentinel('convertAsciiDoc');
 
-        return escapeCurlyBraces(html);
-      },
-    });
+      expect(hexoInstance.extend.renderer.get(extension)).toBe(renderer);
+      armFailure('convertAsciiDoc', sentinel);
+      const armedFailure = pipeline.failure;
 
-    await expect(renderViaHexo(hexoProbe.renderer)).rejects.toBe(sentinel);
-    expect(hexoProbe.calls).toEqual(['convert', 'highlight', 'escape']);
+      const output = hexoInstance.render.renderSync({ text, engine: extension });
 
-    hexoProbe.reset();
-    await expect(renderViaHexo(hexoProbe.renderer)).resolves.toBe(PINNED_V4_EXPECTED_HTML);
-    expect(hexoProbe.calls).toEqual(['convert', 'highlight', 'escape']);
-  });
+      expect(output).toBe(text);
+      expect(output).not.toContain('[object Promise]');
+      expectStageTrace([]);
+      expect(pipeline.failure).toBe(armedFailure);
+      pipeline.failure = null;
+    },
+  );
 });

--- a/src/public/lib/hexo-renderer-asciidoc/test/pipeline-failure.worker.ts
+++ b/src/public/lib/hexo-renderer-asciidoc/test/pipeline-failure.worker.ts
@@ -11,6 +11,7 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } 
 import type { Hexo as HexoContract, Renderer } from '../src/types';
 
 type StageName = 'convertAsciiDoc' | 'applyStaticHighlighting' | 'escapeCurlyBraces';
+type BoundaryName = '@asciidoctor/core.convert' | 'hexo-util.highlight' | 'sanitize.replace';
 
 type FailureInjection = {
   sentinel: unknown;
@@ -18,19 +19,19 @@ type FailureInjection = {
 };
 
 const pipeline = vi.hoisted(() => ({
-  applyStaticHighlighting: vi.fn(),
-  calls: [] as StageName[],
-  convertAsciiDoc: vi.fn(),
+  calls: [] as BoundaryName[],
+  coreConvert: vi.fn(),
   escapeCurlyBraces: vi.fn(),
   failure: null as FailureInjection | null,
+  hexoHighlight: vi.fn(),
   pendingConversions: 0,
 }));
 
-vi.mock('../src/core/asciidoctor', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('../src/core/asciidoctor')>();
+vi.mock('@asciidoctor/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@asciidoctor/core')>();
 
-  pipeline.convertAsciiDoc.mockImplementation(async (text: string) => {
-    pipeline.calls.push('convertAsciiDoc');
+  pipeline.coreConvert.mockImplementation(async (...args: Parameters<typeof actual.convert>) => {
+    pipeline.calls.push('@asciidoctor/core.convert');
     pipeline.pendingConversions += 1;
 
     try {
@@ -40,7 +41,7 @@ vi.mock('../src/core/asciidoctor', async (importOriginal) => {
         throw failure.sentinel;
       }
 
-      return await actual.convertAsciiDoc(text);
+      return await actual.convert(...args);
     } finally {
       pipeline.pendingConversions -= 1;
     }
@@ -48,15 +49,16 @@ vi.mock('../src/core/asciidoctor', async (importOriginal) => {
 
   return {
     ...actual,
-    convertAsciiDoc: pipeline.convertAsciiDoc,
+    convert: pipeline.coreConvert,
   };
 });
 
-vi.mock('../src/core/highlight', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('../src/core/highlight')>();
+vi.mock('hexo-util', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('hexo-util')>();
+  const actualDefault = (actual as typeof actual & { default: typeof actual }).default;
 
-  pipeline.applyStaticHighlighting.mockImplementation((html: string) => {
-    pipeline.calls.push('applyStaticHighlighting');
+  pipeline.hexoHighlight.mockImplementation((...args: Parameters<typeof actual.highlight>) => {
+    pipeline.calls.push('hexo-util.highlight');
 
     const failure = pipeline.failure;
     if (failure?.stage === 'applyStaticHighlighting') {
@@ -64,12 +66,17 @@ vi.mock('../src/core/highlight', async (importOriginal) => {
       throw failure.sentinel;
     }
 
-    return actual.applyStaticHighlighting(html);
+    return actual.highlight(...args);
   });
 
   return {
     ...actual,
-    applyStaticHighlighting: pipeline.applyStaticHighlighting,
+    default: new Proxy(actualDefault, {
+      get(target, property, receiver) {
+        return property === 'highlight' ? pipeline.hexoHighlight : Reflect.get(target, property, receiver);
+      },
+    }),
+    highlight: pipeline.hexoHighlight,
   };
 });
 
@@ -77,7 +84,7 @@ vi.mock('../src/core/sanitize', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../src/core/sanitize')>();
 
   pipeline.escapeCurlyBraces.mockImplementation((html: string) => {
-    pipeline.calls.push('escapeCurlyBraces');
+    pipeline.calls.push('sanitize.replace');
 
     const failure = pipeline.failure;
     if (failure?.stage === 'escapeCurlyBraces') {
@@ -106,8 +113,13 @@ import renderer from '../src/core/renderer';
 import registerRenderer from '../src/hexo/register';
 
 const SUPPORTED_EXTENSIONS = ['ad', 'adoc', 'asciidoc'] as const;
-const COMPLETE_TRACE: readonly StageName[] = ['convertAsciiDoc', 'applyStaticHighlighting', 'escapeCurlyBraces'];
-const SAMPLE_TEXT = `
+const COMPLETE_TRACE: readonly BoundaryName[] = [
+  '@asciidoctor/core.convert',
+  'hexo-util.highlight',
+  'sanitize.replace',
+];
+// This source block produces Asciidoctor's canonical listing-block chain, so static highlighting is mandatory.
+const CANONICAL_SOURCE_TEXT = `
 == Pipeline Failure Probe ==
 
 [source,javascript]
@@ -163,9 +175,9 @@ const drainPendingTasks = async (): Promise<void> => {
 
 const resetObservations = (): void => {
   pipeline.calls.length = 0;
-  pipeline.convertAsciiDoc.mockClear();
-  pipeline.applyStaticHighlighting.mockClear();
+  pipeline.coreConvert.mockClear();
   pipeline.escapeCurlyBraces.mockClear();
+  pipeline.hexoHighlight.mockClear();
 };
 
 const armFailure = (stage: StageName, sentinel: unknown): void => {
@@ -198,11 +210,11 @@ const expectExactSentinelRejection = async (operation: () => Promise<unknown>, s
   expect(outcome.reason).toBe(sentinel);
 };
 
-const expectStageTrace = (expected: readonly StageName[]): void => {
+const expectBoundaryTrace = (expected: readonly BoundaryName[]): void => {
   expect(pipeline.calls).toEqual(expected);
-  expect(pipeline.convertAsciiDoc).toHaveBeenCalledTimes(expected.includes('convertAsciiDoc') ? 1 : 0);
-  expect(pipeline.applyStaticHighlighting).toHaveBeenCalledTimes(expected.includes('applyStaticHighlighting') ? 1 : 0);
-  expect(pipeline.escapeCurlyBraces).toHaveBeenCalledTimes(expected.includes('escapeCurlyBraces') ? 1 : 0);
+  expect(pipeline.coreConvert).toHaveBeenCalledTimes(expected.includes('@asciidoctor/core.convert') ? 1 : 0);
+  expect(pipeline.hexoHighlight).toHaveBeenCalledTimes(expected.includes('hexo-util.highlight') ? 1 : 0);
+  expect(pipeline.escapeCurlyBraces).toHaveBeenCalledTimes(expected.includes('sanitize.replace') ? 1 : 0);
 };
 
 const expectPendingTasksDrained = async (): Promise<void> => {
@@ -210,20 +222,27 @@ const expectPendingTasksDrained = async (): Promise<void> => {
   expect(pipeline.pendingConversions).toBe(0);
 };
 
-const createSentinel = (stage: StageName): Readonly<{ identity: symbol; stage: StageName }> =>
-  Object.freeze({
-    identity: Symbol(`${stage} sentinel`),
-    stage,
-  });
+class PipelineFailureSentinel extends Error {
+  readonly identity: symbol;
+
+  constructor(readonly stage: StageName) {
+    super(`${stage} sentinel`);
+    this.name = 'PipelineFailureSentinel';
+    this.identity = Symbol(`${stage} sentinel`);
+  }
+}
+
+const createSentinel = (stage: StageName): Readonly<PipelineFailureSentinel> =>
+  Object.freeze(new PipelineFailureSentinel(stage));
 
 const FAILURE_CASES = [
   {
-    expectedTrace: ['convertAsciiDoc'],
+    expectedTrace: ['@asciidoctor/core.convert'],
     extension: 'ad',
     stage: 'convertAsciiDoc',
   },
   {
-    expectedTrace: ['convertAsciiDoc', 'applyStaticHighlighting'],
+    expectedTrace: ['@asciidoctor/core.convert', 'hexo-util.highlight'],
     extension: 'adoc',
     stage: 'applyStaticHighlighting',
   },
@@ -233,7 +252,7 @@ const FAILURE_CASES = [
     stage: 'escapeCurlyBraces',
   },
 ] as const satisfies readonly {
-  expectedTrace: readonly StageName[];
+  expectedTrace: readonly BoundaryName[];
   extension: (typeof SUPPORTED_EXTENSIONS)[number];
   stage: StageName;
 }[];
@@ -275,32 +294,32 @@ describe.sequential('production pipeline failure worker', () => {
       const sentinel = createSentinel(stage);
 
       armFailure(stage, sentinel);
-      await expectExactSentinelRejection(() => renderer({ text: SAMPLE_TEXT }), sentinel);
-      expectStageTrace(expectedTrace);
+      await expectExactSentinelRejection(() => renderer({ text: CANONICAL_SOURCE_TEXT }), sentinel);
+      expectBoundaryTrace(expectedTrace);
       expect(pipeline.failure).toBeNull();
       await expectPendingTasksDrained();
 
       resetObservations();
-      await expect(renderer({ text: SAMPLE_TEXT })).resolves.toBe(PINNED_V4_EXPECTED_HTML);
-      expectStageTrace(COMPLETE_TRACE);
+      await expect(renderer({ text: CANONICAL_SOURCE_TEXT })).resolves.toBe(PINNED_V4_EXPECTED_HTML);
+      expectBoundaryTrace(COMPLETE_TRACE);
       await expectPendingTasksDrained();
 
       resetObservations();
       expect(hexoInstance.extend.renderer.get(extension)).toBe(renderer);
       armFailure(stage, sentinel);
       await expectExactSentinelRejection(
-        () => hexoInstance.render.render({ text: SAMPLE_TEXT, engine: extension }),
+        () => hexoInstance.render.render({ text: CANONICAL_SOURCE_TEXT, engine: extension }),
         sentinel,
       );
-      expectStageTrace(expectedTrace);
+      expectBoundaryTrace(expectedTrace);
       expect(pipeline.failure).toBeNull();
       await expectPendingTasksDrained();
 
       resetObservations();
-      await expect(hexoInstance.render.render({ text: SAMPLE_TEXT, engine: extension })).resolves.toBe(
+      await expect(hexoInstance.render.render({ text: CANONICAL_SOURCE_TEXT, engine: extension })).resolves.toBe(
         PINNED_V4_EXPECTED_HTML,
       );
-      expectStageTrace(COMPLETE_TRACE);
+      expectBoundaryTrace(COMPLETE_TRACE);
       await expectPendingTasksDrained();
     },
   );
@@ -319,7 +338,7 @@ describe.sequential('production pipeline failure worker', () => {
 
       expect(output).toBe(text);
       expect(output).not.toContain('[object Promise]');
-      expectStageTrace([]);
+      expectBoundaryTrace([]);
       expect(pipeline.failure).toBe(armedFailure);
       pipeline.failure = null;
     },

--- a/src/public/lib/hexo-renderer-asciidoc/test/pipeline-failure.worker.ts
+++ b/src/public/lib/hexo-renderer-asciidoc/test/pipeline-failure.worker.ts
@@ -22,8 +22,8 @@ const SAMPLE_TEXT = `
 const value = { nested: true };
 ----
 `;
-// Independently reviewed v3 baseline; intentionally not derived from production stages.
-const PINNED_V3_EXPECTED_HTML = `<div class="sect1">
+// Independently reviewed v4 baseline; intentionally not derived from production stages.
+const PINNED_V4_EXPECTED_HTML = `<div class="sect1">
 <h2 id="_pipeline_failure_probe">Pipeline Failure Probe</h2>
 <div class="sectionbody">
 <div class="listingblock">
@@ -48,7 +48,7 @@ type HexoTestInstance = HexoContract & {
 type HexoConstructor = new (baseDir: string, options?: Record<string, unknown>) => HexoTestInstance;
 
 type StageName = 'convert' | 'highlight' | 'escape';
-type ConvertStage = (text: string) => string;
+type ConvertStage = (text: string) => string | Promise<string>;
 type HtmlStage = (html: string) => string;
 
 const HexoClass = Hexo as unknown as HexoConstructor;
@@ -65,7 +65,7 @@ const drainPendingTasks = async (): Promise<void> => {
 };
 
 /**
- * Test-only seam: compose the real production v3 stages while allowing one stage
+ * Test-only seam: compose the real production v4 stages while allowing one stage
  * to be replaced with a throwing sentinel. This keeps product source unchanged.
  */
 const createRendererProbe = ({
@@ -79,9 +79,9 @@ const createRendererProbe = ({
 } = {}) => {
   const calls: StageName[] = [];
 
-  const probeRenderer: Renderer = (data: RendererData) => {
+  const probeRenderer: Renderer = async (data: RendererData) => {
     calls.push('convert');
-    const html = convert(data.text);
+    const html = await convert(data.text);
 
     calls.push('highlight');
     const highlighted = highlight(html);
@@ -102,7 +102,7 @@ const createRendererProbe = ({
 const renderViaHexo = async (probeRenderer: Renderer, text: string = SAMPLE_TEXT): Promise<string> => {
   const workspace = createHexoWorkspace();
   const hexo = new HexoClass(workspace, { silent: true, debug: false });
-  hexo.extend.renderer.register(HEXO_ENGINE, 'html', probeRenderer, true);
+  hexo.extend.renderer.register(HEXO_ENGINE, 'html', probeRenderer, false);
 
   try {
     await hexo.init();
@@ -127,14 +127,7 @@ describe.sequential('pipeline failure probe worker', () => {
       },
     });
 
-    let directError: unknown;
-    try {
-      probe.renderer({ text: SAMPLE_TEXT });
-    } catch (error) {
-      directError = error;
-    }
-
-    expect(directError).toBe(sentinel);
+    await expect(probe.renderer({ text: SAMPLE_TEXT })).rejects.toBe(sentinel);
     expect(probe.calls).toEqual(['convert']);
 
     probe.reset();
@@ -150,14 +143,7 @@ describe.sequential('pipeline failure probe worker', () => {
       },
     });
 
-    let directError: unknown;
-    try {
-      probe.renderer({ text: SAMPLE_TEXT });
-    } catch (error) {
-      directError = error;
-    }
-
-    expect(directError).toBe(sentinel);
+    await expect(probe.renderer({ text: SAMPLE_TEXT })).rejects.toBe(sentinel);
     expect(probe.calls).toEqual(['convert', 'highlight']);
 
     probe.reset();
@@ -173,14 +159,7 @@ describe.sequential('pipeline failure probe worker', () => {
       },
     });
 
-    let directError: unknown;
-    try {
-      probe.renderer({ text: SAMPLE_TEXT });
-    } catch (error) {
-      directError = error;
-    }
-
-    expect(directError).toBe(sentinel);
+    await expect(probe.renderer({ text: SAMPLE_TEXT })).rejects.toBe(sentinel);
     expect(probe.calls).toEqual(['convert', 'highlight', 'escape']);
 
     probe.reset();
@@ -203,11 +182,11 @@ describe.sequential('pipeline failure probe worker', () => {
       },
     });
 
-    expect(() => directProbe.renderer({ text: SAMPLE_TEXT })).toThrow(sentinel);
+    await expect(directProbe.renderer({ text: SAMPLE_TEXT })).rejects.toBe(sentinel);
     expect(directProbe.calls).toEqual(['convert', 'highlight', 'escape']);
 
     directProbe.reset();
-    expect(directProbe.renderer({ text: SAMPLE_TEXT })).toBe(PINNED_V3_EXPECTED_HTML);
+    await expect(directProbe.renderer({ text: SAMPLE_TEXT })).resolves.toBe(PINNED_V4_EXPECTED_HTML);
     expect(directProbe.calls).toEqual(['convert', 'highlight', 'escape']);
 
     let hexoFailed = false;
@@ -226,7 +205,7 @@ describe.sequential('pipeline failure probe worker', () => {
     expect(hexoProbe.calls).toEqual(['convert', 'highlight', 'escape']);
 
     hexoProbe.reset();
-    await expect(renderViaHexo(hexoProbe.renderer)).resolves.toBe(PINNED_V3_EXPECTED_HTML);
+    await expect(renderViaHexo(hexoProbe.renderer)).resolves.toBe(PINNED_V4_EXPECTED_HTML);
     expect(hexoProbe.calls).toEqual(['convert', 'highlight', 'escape']);
   });
 });

--- a/src/public/lib/hexo-renderer-asciidoc/test/pipeline.test.ts
+++ b/src/public/lib/hexo-renderer-asciidoc/test/pipeline.test.ts
@@ -124,7 +124,7 @@ describe('renderer pipeline', () => {
     expect(pipeline.escape).not.toHaveBeenCalled();
   });
 
-  it('characterizes conversion, highlighting, and escaping failures in an isolated subprocess', async () => {
+  it('runs strict isolated production pipeline failures, drains work, and exits cleanly', async () => {
     const packageRoot = path.resolve(import.meta.dirname, '..');
 
     await expect(

--- a/src/public/lib/hexo-renderer-asciidoc/test/pipeline.test.ts
+++ b/src/public/lib/hexo-renderer-asciidoc/test/pipeline.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Copyright 2015 Shuai Zhang
+ * SPDX-License-Identifier: LGPL-3.0-or-later WITH LGPL-3.0-linking-exception
+ */
+
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const pipeline = vi.hoisted(() => ({
+  calls: [] as string[],
+  convert: vi.fn(),
+  highlight: vi.fn(),
+  escape: vi.fn(),
+}));
+
+vi.mock('../src/core/asciidoctor', () => ({
+  convertAsciiDoc: pipeline.convert,
+}));
+
+vi.mock('../src/core/highlight', () => ({
+  applyStaticHighlighting: pipeline.highlight,
+}));
+
+vi.mock('../src/core/sanitize', () => ({
+  escapeCurlyBraces: pipeline.escape,
+}));
+
+import renderer from '../src/core/renderer';
+
+beforeEach(() => {
+  pipeline.calls.length = 0;
+  pipeline.convert.mockReset().mockImplementation((text: string) => {
+    pipeline.calls.push('convert');
+    return `<converted>${text}</converted>`;
+  });
+  pipeline.highlight.mockReset().mockImplementation((html: string) => {
+    pipeline.calls.push('highlight');
+    return `<highlighted>${html}</highlighted>`;
+  });
+  pipeline.escape.mockReset().mockImplementation((html: string) => {
+    pipeline.calls.push('escape');
+    return `<escaped>${html}</escaped>`;
+  });
+});
+
+describe('renderer pipeline', () => {
+  it('runs conversion, highlighting, and brace escaping in order', () => {
+    const result = renderer({ text: 'input' });
+
+    expect(pipeline.calls).toEqual(['convert', 'highlight', 'escape']);
+    expect(pipeline.convert).toHaveBeenCalledWith('input');
+    expect(pipeline.highlight).toHaveBeenCalledWith('<converted>input</converted>');
+    expect(pipeline.escape).toHaveBeenCalledWith('<highlighted><converted>input</converted></highlighted>');
+    expect(result).toBe('<escaped><highlighted><converted>input</converted></highlighted></escaped>');
+  });
+
+  it('preserves conversion error identity and suppresses downstream stages', () => {
+    const sentinel = new Error('conversion sentinel');
+    pipeline.convert.mockImplementation(() => {
+      pipeline.calls.push('convert');
+      throw sentinel;
+    });
+
+    let caught: unknown;
+    try {
+      renderer({ text: 'input' });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBe(sentinel);
+    expect(pipeline.calls).toEqual(['convert']);
+    expect(pipeline.highlight).not.toHaveBeenCalled();
+    expect(pipeline.escape).not.toHaveBeenCalled();
+  });
+
+  it('preserves highlighting error identity and suppresses brace escaping', () => {
+    const sentinel = new Error('highlighting sentinel');
+    pipeline.highlight.mockImplementation(() => {
+      pipeline.calls.push('highlight');
+      throw sentinel;
+    });
+
+    let caught: unknown;
+    try {
+      renderer({ text: 'input' });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBe(sentinel);
+    expect(pipeline.calls).toEqual(['convert', 'highlight']);
+    expect(pipeline.escape).not.toHaveBeenCalled();
+  });
+
+  it('characterizes conversion, highlighting, and escaping failures in an isolated subprocess', () => {
+    const packageRoot = path.resolve(import.meta.dirname, '..');
+
+    expect(() =>
+      execFileSync('pnpm', ['exec', 'vitest', 'run', '--config', 'vitest.pipeline-failure.config.ts'], {
+        cwd: packageRoot,
+        env: { ...process.env, NODE_OPTIONS: '--unhandled-rejections=strict' },
+        stdio: 'pipe',
+        timeout: 30_000,
+      }),
+    ).not.toThrow();
+  }, 60_000);
+});

--- a/src/public/lib/hexo-renderer-asciidoc/test/pipeline.test.ts
+++ b/src/public/lib/hexo-renderer-asciidoc/test/pipeline.test.ts
@@ -3,9 +3,15 @@
  * SPDX-License-Identifier: LGPL-3.0-or-later WITH LGPL-3.0-linking-exception
  */
 
-import { execFileSync } from 'node:child_process';
 import path from 'node:path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { runVitestSubprocess } from './helpers/vitest-subprocess';
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  reject: (reason?: unknown) => void;
+  resolve: (value: T) => void;
+};
 
 const pipeline = vi.hoisted(() => ({
   calls: [] as string[],
@@ -28,6 +34,17 @@ vi.mock('../src/core/sanitize', () => ({
 
 import renderer from '../src/core/renderer';
 
+const createDeferred = <T>(): Deferred<T> => {
+  let reject: Deferred<T>['reject'] = () => undefined;
+  let resolve: Deferred<T>['resolve'] = () => undefined;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+
+  return { promise, reject, resolve };
+};
+
 beforeEach(() => {
   pipeline.calls.length = 0;
   pipeline.convert.mockReset().mockImplementation((text: string) => {
@@ -45,65 +62,77 @@ beforeEach(() => {
 });
 
 describe('renderer pipeline', () => {
-  it('runs conversion, highlighting, and brace escaping in order', () => {
-    const result = renderer({ text: 'input' });
+  it('awaits conversion before highlighting and brace escaping', async () => {
+    const deferredConversion = createDeferred<string>();
+    pipeline.convert.mockReset().mockImplementation(() => {
+      pipeline.calls.push('convert:called');
+      return deferredConversion.promise.then((html) => {
+        pipeline.calls.push('convert:resolved');
+        return html;
+      });
+    });
+    pipeline.highlight.mockReset().mockImplementation((html: string) => {
+      pipeline.calls.push('highlight');
+      return `<highlighted>${html}</highlighted>`;
+    });
+    pipeline.escape.mockReset().mockImplementation((html: string) => {
+      pipeline.calls.push('escape');
+      return `<escaped>${html}</escaped>`;
+    });
 
-    expect(pipeline.calls).toEqual(['convert', 'highlight', 'escape']);
+    const renderPromise = renderer({ text: 'input' });
+
+    await Promise.resolve();
+
     expect(pipeline.convert).toHaveBeenCalledWith('input');
+    expect(pipeline.calls).toEqual(['convert:called']);
+    expect(pipeline.highlight).not.toHaveBeenCalled();
+    expect(pipeline.escape).not.toHaveBeenCalled();
+
+    deferredConversion.resolve('<converted>input</converted>');
+
+    await expect(renderPromise).resolves.toBe(
+      '<escaped><highlighted><converted>input</converted></highlighted></escaped>',
+    );
+    expect(pipeline.calls).toEqual(['convert:called', 'convert:resolved', 'highlight', 'escape']);
     expect(pipeline.highlight).toHaveBeenCalledWith('<converted>input</converted>');
     expect(pipeline.escape).toHaveBeenCalledWith('<highlighted><converted>input</converted></highlighted>');
-    expect(result).toBe('<escaped><highlighted><converted>input</converted></highlighted></escaped>');
   });
 
-  it('preserves conversion error identity and suppresses downstream stages', () => {
+  it('preserves conversion error identity and suppresses downstream stages', async () => {
     const sentinel = new Error('conversion sentinel');
     pipeline.convert.mockImplementation(() => {
       pipeline.calls.push('convert');
       throw sentinel;
     });
 
-    let caught: unknown;
-    try {
-      renderer({ text: 'input' });
-    } catch (error) {
-      caught = error;
-    }
-
-    expect(caught).toBe(sentinel);
+    await expect(renderer({ text: 'input' })).rejects.toBe(sentinel);
     expect(pipeline.calls).toEqual(['convert']);
     expect(pipeline.highlight).not.toHaveBeenCalled();
     expect(pipeline.escape).not.toHaveBeenCalled();
   });
 
-  it('preserves highlighting error identity and suppresses brace escaping', () => {
+  it('preserves highlighting error identity and suppresses brace escaping', async () => {
     const sentinel = new Error('highlighting sentinel');
     pipeline.highlight.mockImplementation(() => {
       pipeline.calls.push('highlight');
       throw sentinel;
     });
 
-    let caught: unknown;
-    try {
-      renderer({ text: 'input' });
-    } catch (error) {
-      caught = error;
-    }
-
-    expect(caught).toBe(sentinel);
+    await expect(renderer({ text: 'input' })).rejects.toBe(sentinel);
     expect(pipeline.calls).toEqual(['convert', 'highlight']);
     expect(pipeline.escape).not.toHaveBeenCalled();
   });
 
-  it('characterizes conversion, highlighting, and escaping failures in an isolated subprocess', () => {
+  it('characterizes conversion, highlighting, and escaping failures in an isolated subprocess', async () => {
     const packageRoot = path.resolve(import.meta.dirname, '..');
 
-    expect(() =>
-      execFileSync('pnpm', ['exec', 'vitest', 'run', '--config', 'vitest.pipeline-failure.config.ts'], {
+    await expect(
+      runVitestSubprocess({
+        args: ['--config', 'vitest.pipeline-failure.config.ts'],
         cwd: packageRoot,
-        env: { ...process.env, NODE_OPTIONS: '--unhandled-rejections=strict' },
-        stdio: 'pipe',
         timeout: 30_000,
       }),
-    ).not.toThrow();
+    ).resolves.toBeUndefined();
   }, 60_000);
 });

--- a/src/public/lib/hexo-renderer-asciidoc/test/register.test.ts
+++ b/src/public/lib/hexo-renderer-asciidoc/test/register.test.ts
@@ -9,7 +9,7 @@ import registerRenderer from '../src/hexo/register';
 import type { Hexo } from '../src/types';
 
 describe('registerRenderer', () => {
-  it('registers exactly ad, adoc, and asciidoc as synchronous HTML renderers', () => {
+  it('registers exactly ad, adoc, and asciidoc as asynchronous HTML renderers', () => {
     const register = vi.fn();
     const instance = {
       config: {},
@@ -20,9 +20,9 @@ describe('registerRenderer', () => {
 
     expect(result).toBeUndefined();
     expect(register.mock.calls).toEqual([
-      ['ad', 'html', renderer, true],
-      ['adoc', 'html', renderer, true],
-      ['asciidoc', 'html', renderer, true],
+      ['ad', 'html', renderer, false],
+      ['adoc', 'html', renderer, false],
+      ['asciidoc', 'html', renderer, false],
     ]);
   });
 });

--- a/src/public/lib/hexo-renderer-asciidoc/test/register.test.ts
+++ b/src/public/lib/hexo-renderer-asciidoc/test/register.test.ts
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2015 Shuai Zhang
+ * SPDX-License-Identifier: LGPL-3.0-or-later WITH LGPL-3.0-linking-exception
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import renderer from '../src/core/renderer';
+import registerRenderer from '../src/hexo/register';
+import type { Hexo } from '../src/types';
+
+describe('registerRenderer', () => {
+  it('registers exactly ad, adoc, and asciidoc as synchronous HTML renderers', () => {
+    const register = vi.fn();
+    const instance = {
+      config: {},
+      extend: { renderer: { register } },
+    } as Hexo;
+
+    const result = registerRenderer(instance);
+
+    expect(result).toBeUndefined();
+    expect(register.mock.calls).toEqual([
+      ['ad', 'html', renderer, true],
+      ['adoc', 'html', renderer, true],
+      ['asciidoc', 'html', renderer, true],
+    ]);
+  });
+});

--- a/src/public/lib/hexo-renderer-asciidoc/test/sync-licenses.test.mjs
+++ b/src/public/lib/hexo-renderer-asciidoc/test/sync-licenses.test.mjs
@@ -1,0 +1,450 @@
+/**
+ * Copyright 2015 Shuai Zhang
+ * SPDX-License-Identifier: LGPL-3.0-or-later WITH LGPL-3.0-linking-exception
+ */
+
+import { execFileSync } from 'node:child_process';
+import {
+  cpSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readlinkSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const sourceScript = path.resolve(import.meta.dirname, '../scripts/sync-licenses.mjs');
+const backupSuffix = '.sync-licenses-backup';
+const lexistsSync = (entryPath) => {
+  try {
+    lstatSync(entryPath);
+    return true;
+  } catch (error) {
+    if (error?.code === 'ENOENT') {
+      return false;
+    }
+    throw error;
+  }
+};
+
+let fixtureRoot;
+let packageRoot;
+
+const run = (mode) => {
+  try {
+    execFileSync(process.execPath, ['scripts/sync-licenses.mjs', mode], {
+      cwd: packageRoot,
+      encoding: 'utf8',
+      stdio: 'pipe',
+    });
+    return { succeeded: true, stderr: '' };
+  } catch (error) {
+    return { succeeded: false, stderr: String(error.stderr) };
+  }
+};
+
+beforeEach(() => {
+  fixtureRoot = mkdtempSync(path.join(tmpdir(), 'sync-licenses-test-'));
+  packageRoot = path.join(fixtureRoot, 'package');
+  mkdirSync(path.join(packageRoot, 'scripts'), { recursive: true });
+  mkdirSync(path.join(fixtureRoot, 'LICENSES'), { recursive: true });
+  writeFileSync(path.join(fixtureRoot, 'pnpm-workspace.yaml'), 'packages: []\n');
+  writeFileSync(path.join(fixtureRoot, 'LICENSE'), 'root license\n');
+  writeFileSync(path.join(fixtureRoot, 'COPYING'), 'root copying\n');
+  writeFileSync(path.join(fixtureRoot, 'COPYING.LESSER'), 'root lesser\n');
+  writeFileSync(path.join(fixtureRoot, 'LICENSES', 'LGPL-3.0-linking-exception.txt'), 'root exception\n');
+  writeFileSync(path.join(packageRoot, 'LICENSE'), 'user package license\n');
+  cpSync(sourceScript, path.join(packageRoot, 'scripts', 'sync-licenses.mjs'));
+});
+
+afterEach(() => {
+  rmSync(fixtureRoot, { force: true, recursive: true });
+});
+
+describe('sync-licenses ownership and recovery', () => {
+  it('copies a dangling source symlink exactly and restores the package target', () => {
+    const source = path.join(fixtureRoot, 'LICENSE');
+    const target = path.join(packageRoot, 'LICENSE');
+    rmSync(source);
+    symlinkSync('missing-root-license', source);
+
+    expect(run('prepack').succeeded).toBe(true);
+    expect(lstatSync(target).isSymbolicLink()).toBe(true);
+    expect(readlinkSync(target)).toBe('missing-root-license');
+
+    expect(run('postpack').succeeded).toBe(true);
+    expect(lstatSync(target).isFile()).toBe(true);
+    expect(readFileSync(target, 'utf8')).toBe('user package license\n');
+  });
+
+  it('restores a dangling destination symlink exactly', () => {
+    const target = path.join(packageRoot, 'LICENSE');
+    rmSync(target);
+    symlinkSync('../missing-user-license', target);
+
+    expect(run('prepack').succeeded).toBe(true);
+    expect(lstatSync(target).isFile()).toBe(true);
+
+    expect(run('postpack').succeeded).toBe(true);
+    expect(lstatSync(target).isSymbolicLink()).toBe(true);
+    expect(readlinkSync(target)).toBe('../missing-user-license');
+  });
+
+  it.each([
+    ['state file', '.sync-licenses-state.json'],
+    ['backup directory', '.sync-licenses-backups'],
+    ['legacy backup', `COPYING${backupSuffix}`],
+  ])('preflights and preserves a dangling %s', (_label, relativePath) => {
+    const orphan = path.join(packageRoot, relativePath);
+    symlinkSync('missing-user-data', orphan);
+
+    expect(run('prepack').succeeded).toBe(false);
+    expect(lexistsSync(orphan)).toBe(true);
+    expect(lstatSync(orphan).isSymbolicLink()).toBe(true);
+    expect(readlinkSync(orphan)).toBe('missing-user-data');
+    expect(readFileSync(path.join(packageRoot, 'LICENSE'), 'utf8')).toBe('user package license\n');
+  });
+
+  it('preflights an orphaned managed backup even when its target is absent', () => {
+    const orphan = path.join(packageRoot, '.sync-licenses-backups', `COPYING${backupSuffix}`);
+    mkdirSync(path.dirname(orphan), { recursive: true });
+    writeFileSync(orphan, 'orphaned user data\n');
+
+    const result = run('prepack');
+
+    expect(result.succeeded).toBe(false);
+    expect(existsSync(path.join(packageRoot, '.sync-licenses-state.json'))).toBe(false);
+    expect(readFileSync(orphan, 'utf8')).toBe('orphaned user data\n');
+    expect(readFileSync(path.join(packageRoot, 'LICENSE'), 'utf8')).toBe('user package license\n');
+    expect(existsSync(path.join(packageRoot, 'COPYING'))).toBe(false);
+  });
+
+  it('preflights and preserves a legacy orphaned backup', () => {
+    const legacyBackup = path.join(packageRoot, `COPYING${backupSuffix}`);
+    writeFileSync(legacyBackup, 'legacy orphan\n');
+
+    expect(run('prepack').succeeded).toBe(false);
+    expect(readFileSync(legacyBackup, 'utf8')).toBe('legacy orphan\n');
+    expect(existsSync(path.join(packageRoot, '.sync-licenses-state.json'))).toBe(false);
+  });
+
+  it('preflights and preserves an existing state file and backup', () => {
+    const state = path.join(packageRoot, '.sync-licenses-state.json');
+    const orphan = path.join(packageRoot, '.sync-licenses-backups', 'orphan');
+    mkdirSync(path.dirname(orphan), { recursive: true });
+    writeFileSync(state, '{"user":"state"}\n');
+    writeFileSync(orphan, 'backup bytes\n');
+
+    expect(run('prepack').succeeded).toBe(false);
+    expect(readFileSync(state, 'utf8')).toBe('{"user":"state"}\n');
+    expect(readFileSync(orphan, 'utf8')).toBe('backup bytes\n');
+    expect(readFileSync(path.join(packageRoot, 'LICENSE'), 'utf8')).toBe('user package license\n');
+  });
+
+  it('preflights every source before moving a user target', () => {
+    rmSync(path.join(fixtureRoot, 'COPYING'));
+
+    expect(run('prepack').succeeded).toBe(false);
+    expect(readFileSync(path.join(packageRoot, 'LICENSE'), 'utf8')).toBe('user package license\n');
+    expect(existsSync(path.join(packageRoot, '.sync-licenses-state.json'))).toBe(false);
+    expect(existsSync(path.join(packageRoot, '.sync-licenses-backups'))).toBe(false);
+  });
+
+  it('rejects a symlinked license parent without mutating its external target', () => {
+    const external = path.join(fixtureRoot, 'external-licenses');
+    const sentinel = path.join(external, 'LGPL-3.0-linking-exception.txt');
+    mkdirSync(external);
+    writeFileSync(sentinel, 'external sentinel\n');
+    symlinkSync(external, path.join(packageRoot, 'LICENSES'));
+
+    const result = run('prepack');
+
+    expect(result.succeeded).toBe(false);
+    expect(result.stderr).toContain('Refusing to follow symlinked package parent path LICENSES');
+    expect(readFileSync(sentinel, 'utf8')).toBe('external sentinel\n');
+    expect(lstatSync(path.join(packageRoot, 'LICENSES')).isSymbolicLink()).toBe(true);
+    expect(readFileSync(path.join(packageRoot, 'LICENSE'), 'utf8')).toBe('user package license\n');
+    expect(existsSync(path.join(packageRoot, '.sync-licenses-state.json'))).toBe(false);
+  });
+
+  it('refuses postpack cleanup through a replaced parent symlink without mutating external data', () => {
+    expect(run('prepack').succeeded).toBe(true);
+    const external = path.join(fixtureRoot, 'external-cleanup');
+    const sentinel = path.join(external, 'LGPL-3.0-linking-exception.txt');
+    mkdirSync(external);
+    writeFileSync(sentinel, 'external cleanup sentinel\n');
+    rmSync(path.join(packageRoot, 'LICENSES'), { recursive: true });
+    symlinkSync(external, path.join(packageRoot, 'LICENSES'));
+
+    const result = run('postpack');
+
+    expect(result.succeeded).toBe(false);
+    expect(result.stderr).toContain('Refusing to follow symlinked package parent path LICENSES');
+    expect(readFileSync(sentinel, 'utf8')).toBe('external cleanup sentinel\n');
+    expect(lstatSync(path.join(packageRoot, 'LICENSES')).isSymbolicLink()).toBe(true);
+    expect(existsSync(path.join(packageRoot, '.sync-licenses-state.json'))).toBe(true);
+  });
+
+  it('postpack without valid state refuses to delete targets or orphaned backups', () => {
+    const copying = path.join(packageRoot, 'COPYING');
+    const orphan = path.join(packageRoot, '.sync-licenses-backups', 'unrecorded');
+    mkdirSync(path.dirname(orphan), { recursive: true });
+    writeFileSync(copying, 'user copying\n');
+    writeFileSync(orphan, 'user backup\n');
+
+    expect(run('postpack').succeeded).toBe(false);
+    expect(readFileSync(copying, 'utf8')).toBe('user copying\n');
+    expect(readFileSync(orphan, 'utf8')).toBe('user backup\n');
+  });
+
+  it.each([
+    [
+      'an unknown state version',
+      {
+        version: 999,
+        createdBackupDirectory: false,
+        createdDirectories: [],
+        items: [{ target: 'LICENSE', backup: null }],
+      },
+    ],
+    [
+      'a missing root field',
+      {
+        version: 1,
+        createdBackupDirectory: false,
+        items: [{ target: 'LICENSE', backup: null }],
+      },
+    ],
+    [
+      'an extra root field',
+      {
+        version: 1,
+        createdBackupDirectory: false,
+        createdDirectories: [],
+        items: [{ target: 'LICENSE', backup: null }],
+        extra: true,
+      },
+    ],
+    [
+      'an extra item field',
+      {
+        version: 1,
+        createdBackupDirectory: false,
+        createdDirectories: [],
+        items: [{ target: 'LICENSE', backup: null, extra: true }],
+      },
+    ],
+    [
+      'a traversal target',
+      {
+        version: 1,
+        createdBackupDirectory: false,
+        createdDirectories: [],
+        items: [{ target: '../LICENSE', backup: null }],
+      },
+    ],
+    [
+      'a traversal backup',
+      {
+        version: 1,
+        createdBackupDirectory: true,
+        createdDirectories: [],
+        items: [{ target: 'LICENSE', backup: '../LICENSE.sync-licenses-backup' }],
+      },
+    ],
+    [
+      'an absolute created directory',
+      {
+        version: 1,
+        createdBackupDirectory: false,
+        createdDirectories: ['/tmp'],
+        items: [{ target: 'LICENSE', backup: null }],
+      },
+    ],
+    [
+      'duplicate target records',
+      {
+        version: 1,
+        createdBackupDirectory: false,
+        createdDirectories: [],
+        items: [
+          { target: 'LICENSE', backup: null },
+          { target: 'LICENSE', backup: null },
+        ],
+      },
+    ],
+    [
+      'duplicate created directories',
+      {
+        version: 1,
+        createdBackupDirectory: false,
+        createdDirectories: ['LICENSES', 'LICENSES'],
+        items: [{ target: 'LICENSE', backup: null }],
+      },
+    ],
+    [
+      'inconsistent backup metadata',
+      {
+        version: 1,
+        createdBackupDirectory: false,
+        createdDirectories: [],
+        items: [{ target: 'LICENSE', backup: `.sync-licenses-backups/LICENSE${backupSuffix}` }],
+      },
+    ],
+  ])('rejects %s without changing targets, backups, or state', (_label, stateValue) => {
+    const state = path.join(packageRoot, '.sync-licenses-state.json');
+    const backup = path.join(packageRoot, '.sync-licenses-backups', `LICENSE${backupSuffix}`);
+    mkdirSync(path.dirname(backup), { recursive: true });
+    writeFileSync(backup, 'user backup bytes\n');
+    const stateBytes = `${JSON.stringify(stateValue, null, 2)}\n`;
+    writeFileSync(state, stateBytes);
+
+    const result = run('postpack');
+
+    expect(result.succeeded).toBe(false);
+    expect(result.stderr).toContain('Refusing cleanup');
+    expect(readFileSync(path.join(packageRoot, 'LICENSE'), 'utf8')).toBe('user package license\n');
+    expect(readFileSync(backup, 'utf8')).toBe('user backup bytes\n');
+    expect(readFileSync(state, 'utf8')).toBe(stateBytes);
+  });
+
+  it('rejects malformed JSON without changing targets, backups, or state', () => {
+    const state = path.join(packageRoot, '.sync-licenses-state.json');
+    const backup = path.join(packageRoot, '.sync-licenses-backups', `LICENSE${backupSuffix}`);
+    mkdirSync(path.dirname(backup), { recursive: true });
+    writeFileSync(backup, 'user backup bytes\n');
+    writeFileSync(state, '{"version": 1');
+
+    const result = run('postpack');
+
+    expect(result.succeeded).toBe(false);
+    expect(result.stderr).toContain('not valid JSON');
+    expect(result.stderr).toContain('Refusing cleanup');
+    expect(readFileSync(path.join(packageRoot, 'LICENSE'), 'utf8')).toBe('user package license\n');
+    expect(readFileSync(backup, 'utf8')).toBe('user backup bytes\n');
+    expect(readFileSync(state, 'utf8')).toBe('{"version": 1');
+  });
+
+  it('restores recorded data while preserving an unrecorded backup', () => {
+    expect(run('prepack').succeeded).toBe(true);
+    const orphan = path.join(packageRoot, '.sync-licenses-backups', 'unrecorded');
+    writeFileSync(orphan, 'do not remove\n');
+
+    expect(run('postpack').succeeded).toBe(true);
+    expect(readFileSync(path.join(packageRoot, 'LICENSE'), 'utf8')).toBe('user package license\n');
+    expect(existsSync(path.join(packageRoot, 'COPYING'))).toBe(false);
+    expect(existsSync(path.join(packageRoot, 'COPYING.LESSER'))).toBe(false);
+    expect(existsSync(path.join(packageRoot, '.sync-licenses-state.json'))).toBe(false);
+    expect(readFileSync(orphan, 'utf8')).toBe('do not remove\n');
+  });
+
+  it('attempts later recorded restorations after an earlier backup is missing', () => {
+    const backupDirectory = path.join(packageRoot, '.sync-licenses-backups');
+    const copyingBackup = path.join(backupDirectory, `COPYING${backupSuffix}`);
+    mkdirSync(backupDirectory, { recursive: true });
+    writeFileSync(path.join(packageRoot, 'COPYING'), 'temporary copied license\n');
+    writeFileSync(copyingBackup, 'user copying restored\n');
+    writeFileSync(
+      path.join(packageRoot, '.sync-licenses-state.json'),
+      JSON.stringify({
+        version: 1,
+        createdBackupDirectory: true,
+        createdDirectories: [],
+        items: [
+          { target: 'LICENSE', backup: `.sync-licenses-backups/LICENSE${backupSuffix}` },
+          { target: 'COPYING', backup: `.sync-licenses-backups/COPYING${backupSuffix}` },
+        ],
+      }),
+    );
+
+    expect(run('postpack').succeeded).toBe(false);
+    expect(readFileSync(path.join(packageRoot, 'COPYING'), 'utf8')).toBe('user copying restored\n');
+    const remainingState = JSON.parse(readFileSync(path.join(packageRoot, '.sync-licenses-state.json'), 'utf8'));
+    expect(remainingState.items).toEqual([
+      {
+        target: 'LICENSE',
+        backup: `.sync-licenses-backups/LICENSE${backupSuffix}`,
+        completed: false,
+      },
+      {
+        target: 'COPYING',
+        backup: `.sync-licenses-backups/COPYING${backupSuffix}`,
+        completed: true,
+      },
+    ]);
+  });
+
+  it('aggregates multiple cleanup failures, retains retry state, and succeeds after repair', () => {
+    const backupDirectory = path.join(packageRoot, '.sync-licenses-backups');
+    const statePath = path.join(packageRoot, '.sync-licenses-state.json');
+    mkdirSync(backupDirectory);
+    writeFileSync(path.join(packageRoot, 'COPYING'), 'temporary copying\n');
+    writeFileSync(
+      statePath,
+      JSON.stringify({
+        version: 2,
+        createdBackupDirectory: true,
+        createdDirectories: [],
+        items: [
+          {
+            target: 'LICENSE',
+            backup: `.sync-licenses-backups/LICENSE${backupSuffix}`,
+            completed: false,
+          },
+          {
+            target: 'COPYING',
+            backup: `.sync-licenses-backups/COPYING${backupSuffix}`,
+            completed: false,
+          },
+        ],
+      }),
+    );
+
+    const failed = run('postpack');
+
+    expect(failed.succeeded).toBe(false);
+    expect(failed.stderr.match(/Recorded backup for/g)).toHaveLength(2);
+    expect(existsSync(statePath)).toBe(true);
+
+    mkdirSync(backupDirectory);
+    writeFileSync(path.join(backupDirectory, `LICENSE${backupSuffix}`), 'restored license\n');
+    writeFileSync(path.join(backupDirectory, `COPYING${backupSuffix}`), 'restored copying\n');
+
+    expect(run('postpack').succeeded).toBe(true);
+    expect(readFileSync(path.join(packageRoot, 'LICENSE'), 'utf8')).toBe('restored license\n');
+    expect(readFileSync(path.join(packageRoot, 'COPYING'), 'utf8')).toBe('restored copying\n');
+    expect(existsSync(statePath)).toBe(false);
+    expect(existsSync(backupDirectory)).toBe(false);
+  });
+
+  it('restores a recorded dangling backup symlink exactly', () => {
+    const backupDirectory = path.join(packageRoot, '.sync-licenses-backups');
+    const copyingBackup = path.join(backupDirectory, `COPYING${backupSuffix}`);
+    mkdirSync(backupDirectory, { recursive: true });
+    writeFileSync(path.join(packageRoot, 'COPYING'), 'temporary copied license\n');
+    symlinkSync('../missing-user-copying', copyingBackup);
+    writeFileSync(
+      path.join(packageRoot, '.sync-licenses-state.json'),
+      JSON.stringify({
+        version: 1,
+        createdBackupDirectory: true,
+        createdDirectories: [],
+        items: [{ target: 'COPYING', backup: `.sync-licenses-backups/COPYING${backupSuffix}` }],
+      }),
+    );
+
+    expect(run('postpack').succeeded).toBe(true);
+    const restored = path.join(packageRoot, 'COPYING');
+    expect(lexistsSync(restored)).toBe(true);
+    expect(lstatSync(restored).isSymbolicLink()).toBe(true);
+    expect(readlinkSync(restored)).toBe('../missing-user-copying');
+    expect(lexistsSync(path.join(packageRoot, '.sync-licenses-state.json'))).toBe(false);
+  });
+});

--- a/src/public/lib/hexo-renderer-asciidoc/test/validate-cleanup-errors.test.mjs
+++ b/src/public/lib/hexo-renderer-asciidoc/test/validate-cleanup-errors.test.mjs
@@ -1,0 +1,383 @@
+/**
+ * Copyright 2015 Shuai Zhang
+ * SPDX-License-Identifier: LGPL-3.0-or-later WITH LGPL-3.0-linking-exception
+ */
+
+import { spawnSync } from 'node:child_process';
+import {
+  cpSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  readlinkSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  captureCleanupFailure,
+  capturePathStates,
+  createCommandRunner,
+  createEvidenceRecorder,
+  PACK_LIFECYCLE_PATHS,
+  restorePathStates,
+  runPlain,
+  throwValidationFailures,
+  verifyPackCleanup,
+} from '../scripts/validation-utils.mjs';
+
+const packageRoot = path.resolve(import.meta.dirname, '..');
+const validationUtilsScript = path.join(packageRoot, 'scripts', 'validation-utils.mjs');
+const releasePackScript = path.join(packageRoot, 'scripts', 'validate-release-pack.mjs');
+const packedArtifactScript = path.join(packageRoot, 'scripts', 'validate-packed-artifact.mjs');
+const linkedExampleScript = path.join(packageRoot, 'scripts', 'validate-linked-example.mjs');
+
+const run = (command, args, cwd) => {
+  const result = spawnSync(command, args, { cwd, encoding: 'utf8' });
+  if (result.status !== 0) {
+    throw new Error(`${command} ${args.join(' ')} failed: ${result.stderr}`);
+  }
+  return result.stdout;
+};
+
+const createReleaseFixture = () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'release-pack-init-test-'));
+  const fixturePackageRoot = path.join(root, 'src', 'public', 'lib', 'hexo-renderer-asciidoc');
+  mkdirSync(path.join(fixturePackageRoot, 'scripts'), { recursive: true });
+  cpSync(validationUtilsScript, path.join(fixturePackageRoot, 'scripts', 'validation-utils.mjs'));
+  cpSync(releasePackScript, path.join(fixturePackageRoot, 'scripts', 'validate-release-pack.mjs'));
+  writeFileSync(path.join(root, 'pnpm-workspace.yaml'), 'packages: []\n');
+  writeFileSync(path.join(fixturePackageRoot, 'package.json'), '{"name":"fixture","version":"0.0.0-placeholder"}\n');
+  writeFileSync(path.join(fixturePackageRoot, 'README.md'), 'contributor readme\n');
+  writeFileSync(path.join(fixturePackageRoot, 'README.npm.md'), 'package readme\n');
+  run('git', ['init', '--quiet'], root);
+  run('git', ['config', 'user.email', 'test@example.invalid'], root);
+  run('git', ['config', 'user.name', 'Validation Test'], root);
+  run('git', ['add', '.'], root);
+  run('git', ['commit', '--quiet', '-m', 'fixture'], root);
+  return { fixturePackageRoot, root };
+};
+
+const listValidationTemps = (prefix) => new Set(readdirSync(tmpdir()).filter((entry) => entry.startsWith(prefix)));
+
+describe('validator cleanup failure handling', () => {
+  it.each([
+    ['evidence command runner', () => createCommandRunner().runResult],
+    ['plain command runner', () => runPlain],
+  ])('rejects a signaled child in the %s', (_label, getRunner) => {
+    const runner = getRunner();
+    expect(() => runner(process.execPath, ['-e', 'process.kill(process.pid, "SIGTERM")'])).toThrow(
+      /Command:.*Signal: SIGTERM.*Error: none.*Stderr: <empty>/s,
+    );
+  });
+
+  it.each([
+    ['evidence command runner', () => createCommandRunner().runResult],
+    ['plain command runner', () => runPlain],
+  ])('rejects a spawn error with null status in the %s', (_label, getRunner) => {
+    const runner = getRunner();
+    expect(() => runner('definitely-not-a-unit3-command', [])).toThrow(
+      /Command: definitely-not-a-unit3-command.*Context: cwd=.*Status: null.*Signal: none.*Error: Error: spawnSync definitely-not-a-unit3-command E(?:NOENT|A[C]{2}ES).*Stderr: <empty>/s,
+    );
+  });
+
+  it('rejects a null status even when no signal or spawn error is supplied', () => {
+    const spawnWithNullStatus = () => ({
+      error: undefined,
+      signal: null,
+      status: null,
+      stderr: 'injected stderr',
+      stdout: '',
+    });
+
+    expect(() => createCommandRunner(undefined, spawnWithNullStatus).runResult('injected', [])).toThrow(
+      /Status: null.*Signal: none.*Error: none.*Stderr: injected stderr/s,
+    );
+    expect(() => runPlain('injected', [], { spawn: spawnWithNullStatus })).toThrow(
+      /Status: null.*Signal: none.*Error: none.*Stderr: injected stderr/s,
+    );
+  });
+
+  it('preserves the primary error identity when no cleanup fails', () => {
+    const primary = new Error('primary details');
+    expect(() => throwValidationFailures(primary, [], 'validation failed')).toThrow(primary);
+  });
+
+  it('aggregates primary and cleanup failures without replacing the primary', () => {
+    const primary = new Error('primary details');
+    const cleanup = new Error('cleanup details');
+
+    let thrown;
+    try {
+      throwValidationFailures(primary, [cleanup], 'validation failed');
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(AggregateError);
+    expect(thrown.errors).toEqual([primary, cleanup]);
+    expect(thrown.cause).toBe(primary);
+    expect(thrown.errors[0]).toBe(primary);
+  });
+
+  it('reports cleanup-only failure', () => {
+    const cleanup = new Error('cleanup-only details');
+    expect(() => throwValidationFailures(undefined, [cleanup], 'cleanup failed')).toThrow(AggregateError);
+    try {
+      throwValidationFailures(undefined, [cleanup], 'cleanup failed');
+    } catch (error) {
+      expect(error.errors).toEqual([cleanup]);
+      expect(error.cause).toBeUndefined();
+    }
+  });
+
+  it('captures every cleanup operation after earlier failures', () => {
+    const errors = [];
+    const attempted = [];
+    for (const [name, fails] of [
+      ['restore', true],
+      ['remove-temp', false],
+      ['verify', true],
+    ]) {
+      captureCleanupFailure(errors, () => {
+        attempted.push(name);
+        if (fails) {
+          throw new Error(`${name} failed`);
+        }
+      });
+    }
+    expect(attempted).toEqual(['restore', 'remove-temp', 'verify']);
+    expect(errors.map((error) => error.message)).toEqual(['restore failed', 'verify failed']);
+  });
+
+  it('attempts every path restoration when an earlier path fails', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'restore-path-states-test-'));
+    try {
+      expect(() =>
+        restorePathStates(root, {
+          broken: { type: 'file' },
+          restored: { type: 'file', mode: 0o100644, contents: Buffer.from('restored\n') },
+        }),
+      ).toThrow(AggregateError);
+      expect(existsSync(path.join(root, 'restored'))).toBe(true);
+      expect(readFileSync(path.join(root, 'restored'), 'utf8')).toBe('restored\n');
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  it('captures and restores dangling symlink path state without dereferencing it', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'restore-symlink-state-test-'));
+    try {
+      const target = path.join(root, 'dangling');
+      symlinkSync('../missing-target', target);
+      const state = capturePathStates(root, ['dangling']);
+      rmSync(target);
+      writeFileSync(target, 'replacement\n');
+
+      restorePathStates(root, state);
+
+      expect(lstatSync(target).isSymbolicLink()).toBe(true);
+      expect(readlinkSync(target)).toBe('../missing-target');
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  it('normalizes absolute paths before writing evidence', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'normalized-evidence-test-'));
+    const repositoryRoot = path.join(root, 'repository');
+    const sessionRoot = path.join(root, 'session');
+    try {
+      const recorder = createEvidenceRecorder(root, { repositoryRoot, sessionRoot });
+      recorder.writeJson('result.json', {
+        homePath: path.join(process.env.HOME, 'candidate'),
+        repositoryPath: path.join(repositoryRoot, 'candidate'),
+        sessionPath: path.join(sessionRoot, 'candidate'),
+        temporaryPath: path.join(tmpdir(), 'candidate'),
+      });
+
+      const evidence = readFileSync(path.join(root, 'result.json'), 'utf8');
+      expect(evidence).not.toContain(process.env.HOME);
+      expect(evidence).not.toContain(repositoryRoot);
+      expect(evidence).not.toContain(sessionRoot);
+      expect(evidence).not.toContain(`${tmpdir()}/candidate`);
+      expect(evidence).toContain('<home>/candidate');
+      expect(evidence).toContain('<repo>/candidate');
+      expect(evidence).toContain('<session>/candidate');
+      expect(evidence).toContain('<tmp>/candidate');
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  it('normalizes repository, session, home, and temporary paths in child logs', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'normalized-command-log-test-'));
+    const repositoryRoot = path.join(root, 'repository');
+    const sessionRoot = path.join(root, 'session');
+    const output = [
+      path.join(repositoryRoot, 'file'),
+      path.join(sessionRoot, 'file'),
+      path.join(process.env.HOME, 'file'),
+      path.join(tmpdir(), 'file'),
+    ].join('\n');
+    const spawn = () => ({
+      error: undefined,
+      signal: null,
+      status: 0,
+      stderr: Buffer.from(output),
+      stdout: Buffer.from(output),
+    });
+    try {
+      createCommandRunner(root, spawn, { repositoryRoot, sessionRoot }).run('injected', [], {
+        binary: true,
+        label: 'path-output',
+      });
+      for (const stream of ['stdout', 'stderr']) {
+        const log = readFileSync(path.join(root, 'logs', `path-output.${stream}.log`), 'utf8');
+        expect(log).not.toContain(repositoryRoot);
+        expect(log).not.toContain(sessionRoot);
+        expect(log).not.toContain(process.env.HOME);
+        expect(log).not.toContain(tmpdir());
+        expect(log).toContain('<repo>/file');
+        expect(log).toContain('<session>/file');
+        expect(log).toContain('<home>/file');
+        expect(log).toContain('<tmp>/file');
+      }
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  it.each([
+    ['LICENSES', 'LICENSES', (root) => mkdirSync(path.join(root, 'LICENSES'))],
+    [
+      'sync state',
+      '.sync-licenses-state.json',
+      (root) => writeFileSync(path.join(root, '.sync-licenses-state.json'), '{}\n'),
+    ],
+    [
+      'README backup',
+      '.README.md.npm-backup',
+      (root) => writeFileSync(path.join(root, '.README.md.npm-backup'), 'leak\n'),
+    ],
+  ])('reports leaked %s without deleting or repairing it', (_label, leakPath, createLeak) => {
+    const root = mkdtempSync(path.join(tmpdir(), 'verify-pack-cleanup-test-'));
+    try {
+      writeFileSync(path.join(root, 'package.json'), '{"name":"fixture","version":"0.0.0-placeholder"}\n');
+      writeFileSync(path.join(root, 'README.md'), 'contributor readme\n');
+      writeFileSync(path.join(root, 'README.npm.md'), 'package readme\n');
+      writeFileSync(path.join(root, 'LICENSE'), 'package license\n');
+      const expectedLifecycleState = capturePathStates(root, PACK_LIFECYCLE_PATHS);
+      const expectedPackageJson = readFileSync(path.join(root, 'package.json'));
+      const expectedReadme = readFileSync(path.join(root, 'README.md'));
+      const expectedReadmeNpm = readFileSync(path.join(root, 'README.npm.md'));
+      createLeak(root);
+
+      expect(() =>
+        verifyPackCleanup({
+          expectedLifecycleState,
+          expectedPackageJson,
+          expectedReadme,
+          expectedReadmeNpm,
+          packageRoot: root,
+        }),
+      ).toThrow();
+      expect(existsSync(path.join(root, leakPath))).toBe(true);
+      if (_label === 'sync state') {
+        expect(readFileSync(path.join(root, '.sync-licenses-state.json'), 'utf8')).toBe('{}\n');
+      }
+      if (_label === 'README backup') {
+        expect(readFileSync(path.join(root, '.README.md.npm-backup'), 'utf8')).toBe('leak\n');
+      }
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  it('aggregates an early release initialization fault with cleanup failure and removes its temp directory', () => {
+    const fixture = createReleaseFixture();
+    const prefix = 'hexo-renderer-asciidoc-release-pack-';
+    const beforeTemps = listValidationTemps(prefix);
+    try {
+      const result = spawnSync(process.execPath, ['scripts/validate-release-pack.mjs'], {
+        cwd: fixture.fixturePackageRoot,
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          HEXO_RENDERER_ASCIIDOC_VALIDATION_FAULTS: 'release-pack:after-temp-directory,release-pack:after-temp-cleanup',
+        },
+      });
+
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain('Injected validation fault: release-pack:after-temp-directory');
+      expect(result.stderr).toContain('Injected validation fault: release-pack:after-temp-cleanup');
+      expect(listValidationTemps(prefix)).toEqual(beforeTemps);
+      expect(run('git', ['status', '--porcelain=v1'], fixture.root)).toBe('');
+    } finally {
+      rmSync(fixture.root, { force: true, recursive: true });
+    }
+  });
+
+  it('aggregates an early packed-artifact initialization fault with cleanup failure', () => {
+    const prefix = 'hexo-renderer-asciidoc-pack-';
+    const beforeTemps = listValidationTemps(prefix);
+    const result = spawnSync(process.execPath, [packedArtifactScript], {
+      cwd: packageRoot,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        HEXO_RENDERER_ASCIIDOC_VALIDATION_FAULTS:
+          'packed-artifact:after-temp-directory,packed-artifact:after-temp-cleanup',
+      },
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('Injected validation fault: packed-artifact:after-temp-directory');
+    expect(result.stderr).toContain('Injected validation fault: packed-artifact:after-temp-cleanup');
+    expect(listValidationTemps(prefix)).toEqual(beforeTemps);
+  });
+
+  it('aggregates an early linked-example state initialization fault with cleanup failure', () => {
+    const result = spawnSync(process.execPath, [linkedExampleScript], {
+      cwd: packageRoot,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        HEXO_RENDERER_ASCIIDOC_VALIDATION_FAULTS:
+          'linked-example:after-example-state,linked-example:after-example-state-cleanup',
+      },
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('Injected validation fault: linked-example:after-example-state');
+    expect(result.stderr).toContain('Injected validation fault: linked-example:after-example-state-cleanup');
+  });
+
+  it('refuses release validation from a dirty checkout before creating temporary state', () => {
+    const fixture = createReleaseFixture();
+    const prefix = 'hexo-renderer-asciidoc-release-pack-';
+    const beforeTemps = listValidationTemps(prefix);
+    try {
+      writeFileSync(path.join(fixture.root, 'dirty.txt'), 'dirty\n');
+      const result = spawnSync(process.execPath, ['scripts/validate-release-pack.mjs'], {
+        cwd: fixture.fixturePackageRoot,
+        encoding: 'utf8',
+        env: process.env,
+      });
+
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain('requires a clean worktree at start');
+      expect(listValidationTemps(prefix)).toEqual(beforeTemps);
+      expect(existsSync(path.join(fixture.root, 'dirty.txt'))).toBe(true);
+    } finally {
+      rmSync(fixture.root, { force: true, recursive: true });
+    }
+  });
+});

--- a/src/public/lib/hexo-renderer-asciidoc/tsconfig.json
+++ b/src/public/lib/hexo-renderer-asciidoc/tsconfig.json
@@ -27,6 +27,13 @@
     "rootDir": ".",
     "noEmit": true
   },
-  "include": ["src/**/*.ts", "src/**/*.d.ts", "test/**/*.ts", "tsdown.config.ts", "vitest.config.ts"],
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.d.ts",
+    "test/**/*.ts",
+    "tsdown.config.ts",
+    "vitest.config.ts",
+    "vitest.pipeline-failure.config.ts"
+  ],
   "exclude": ["dist", "node_modules"]
 }

--- a/src/public/lib/hexo-renderer-asciidoc/tsconfig.json
+++ b/src/public/lib/hexo-renderer-asciidoc/tsconfig.json
@@ -32,6 +32,8 @@
     "src/**/*.d.ts",
     "test/**/*.ts",
     "tsdown.config.ts",
+    "vitest.asciidoctor-runtime.config.ts",
+    "vitest.coldstart.config.ts",
     "vitest.config.ts",
     "vitest.pipeline-failure.config.ts"
   ],

--- a/src/public/lib/hexo-renderer-asciidoc/tsdown.config.ts
+++ b/src/public/lib/hexo-renderer-asciidoc/tsdown.config.ts
@@ -7,7 +7,7 @@ import { defineConfig } from 'tsdown';
 
 export default defineConfig({
   entry: 'src/index.ts',
-  format: 'cjs',
+  format: ['esm', 'cjs'],
   checks: { legacyCjs: false },
   dts: {
     sourcemap: true,

--- a/src/public/lib/hexo-renderer-asciidoc/version.json
+++ b/src/public/lib/hexo-renderer-asciidoc/version.json
@@ -1,5 +1,18 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "3.1.0-beta.{height}",
+  "version": "4.0.0-beta.{height}",
+  "pathFilters": [
+    ".",
+    ":/pnpm-lock.yaml",
+    ":/pnpm-workspace.yaml",
+    ":/version.json",
+    ":/LICENSE",
+    ":/COPYING",
+    ":/COPYING.LESSER",
+    ":/LICENSES/LGPL-3.0-linking-exception.txt",
+    ":/.github/workflows/release-build-node-pack.yml",
+    ":/.github/workflows/release-orchestrate.yml",
+    ":/eng/scripts/prepare_npm_publish.py"
+  ],
   "inherit": true
 }

--- a/src/public/lib/hexo-renderer-asciidoc/vitest.asciidoctor-runtime.config.ts
+++ b/src/public/lib/hexo-renderer-asciidoc/vitest.asciidoctor-runtime.config.ts
@@ -1,0 +1,15 @@
+/**
+ * Copyright 2015 Shuai Zhang
+ * SPDX-License-Identifier: LGPL-3.0-or-later WITH LGPL-3.0-linking-exception
+ */
+
+import { defineConfig, type ViteUserConfigExport } from 'vitest/config';
+
+const vitestConfig: ViteUserConfigExport = defineConfig({
+  test: {
+    include: ['test/asciidoctor.runtime.worker.ts'],
+    environment: 'node',
+  },
+});
+
+export default vitestConfig;

--- a/src/public/lib/hexo-renderer-asciidoc/vitest.coldstart.config.ts
+++ b/src/public/lib/hexo-renderer-asciidoc/vitest.coldstart.config.ts
@@ -1,0 +1,15 @@
+/**
+ * Copyright 2015 Shuai Zhang
+ * SPDX-License-Identifier: LGPL-3.0-or-later WITH LGPL-3.0-linking-exception
+ */
+
+import { defineConfig, type ViteUserConfigExport } from 'vitest/config';
+
+const vitestConfig: ViteUserConfigExport = defineConfig({
+  test: {
+    include: ['test/asciidoctor.coldstart.test.ts'],
+    environment: 'node',
+  },
+});
+
+export default vitestConfig;

--- a/src/public/lib/hexo-renderer-asciidoc/vitest.config.ts
+++ b/src/public/lib/hexo-renderer-asciidoc/vitest.config.ts
@@ -9,6 +9,7 @@ const vitestConfig: ViteUserConfigExport = defineConfig({
   test: {
     include: ['test/**/*.test.{js,mjs,ts}'],
     environment: 'node',
+    fileParallelism: false,
     coverage: {
       provider: 'v8',
       reporter: ['text', 'lcov'],

--- a/src/public/lib/hexo-renderer-asciidoc/vitest.pipeline-failure.config.ts
+++ b/src/public/lib/hexo-renderer-asciidoc/vitest.pipeline-failure.config.ts
@@ -9,6 +9,9 @@ const vitestConfig: ViteUserConfigExport = defineConfig({
   test: {
     include: ['test/pipeline-failure.worker.ts'],
     environment: 'node',
+    fileParallelism: false,
+    isolate: true,
+    pool: 'forks',
   },
 });
 

--- a/src/public/lib/hexo-renderer-asciidoc/vitest.pipeline-failure.config.ts
+++ b/src/public/lib/hexo-renderer-asciidoc/vitest.pipeline-failure.config.ts
@@ -1,0 +1,15 @@
+/**
+ * Copyright 2015 Shuai Zhang
+ * SPDX-License-Identifier: LGPL-3.0-or-later WITH LGPL-3.0-linking-exception
+ */
+
+import { defineConfig, type ViteUserConfigExport } from 'vitest/config';
+
+const vitestConfig: ViteUserConfigExport = defineConfig({
+  test: {
+    include: ['test/pipeline-failure.worker.ts'],
+    environment: 'node',
+  },
+});
+
+export default vitestConfig;


### PR DESCRIPTION
## Summary

- Migrate `hexo-renderer-asciidoc` from Asciidoctor.js 3.0.4 to exact `@asciidoctor/core` 4.0.4.
- Make the public renderer contract asynchronous and register all Hexo extensions with `sync: false`.
- Preserve the intentional rendering boundary with per-conversion logger isolation, canonical listing-block highlighting, and final brace encoding.
- Add native ESM/CommonJS packaging, declaration probes, packed-consumer validation, and the supported Node.js matrix.
- Move the package to the NBGV `4.0.0-beta.{height}` line and document the breaking contract and trust model.

This supersedes the dependency-only update in #360, which cannot pass CI without the corresponding major-version migration.

## Breaking Changes

- Renderer calls now return `Promise<string>` and must be awaited.
- The minimum supported Node.js version is 20.19.0.
- Asciidoctor 4 output differences are accepted only where explicitly characterized and dispositioned.
- Raw HTML and local includes remain trusted-input features; `safe: server` is not presented as a filesystem sandbox.

## Validation

- [x] AC-01 through AC-16 local obligations executed against one clean immutable candidate.
- [x] 333 default tests across 49 files, plus six isolated production failure-path cases.
- [x] Node.js 20.19.0, latest 20.x, 22.x, and 24.x build/test/pack/consumer probes.
- [x] ESM/CommonJS runtime and declaration probes from packed tarballs.
- [x] NBGV synthetic-history and clean replay validation.
- [x] Portable verifier, external Git-bundle verification, clean replay, and byte-tamper negative control.
- [x] Three independent final-local reviews completed with no findings.
- [ ] Required hosted checks pass on the exact candidate SHA.
- [ ] Immutable hosted evidence URLs and retention metadata are attached to this PR.

## Candidate Identity

| Field | Value |
|---|---|
| Commit | `1f48a3ec3c0e975da0900e1f0651614e02943374` |
| Tree | `2cec0b1332cb11484cacf6816dc13f6e2ecb02cc` |
| Version | `4.0.0-beta.4.g1f48a3e` |

## Evidence Digests

| Artifact | SHA-256 |
|---|---|
| Portable acceptance archive | `690ca58ee4cc1fbfba4c70eac1038b33a281382a40153197a6bf2e5d834c86d6` |
| Candidate Git bundle | `6d3ae674cac7bb75c15c98a3921f30935823fba8e54f23329cf73e6af1677882` |
| Synthetic NBGV-history bundle | `1eac863bd11b518209febe24bb177a33d407169734a8cab6c8ee3d7434cd9bae` |
| Canonical/NBGV package tarball | `38741526646d195763bef9972da454e8eb15d930642ca04e695a42ed0d5889ea` |
| GitHub Packages pack probe | `298afcb4eeb13c83d1d39702689fd0853e4451dcd4df14f01e0df6add4127d05` |
| npmjs pack probe | `9da922fb2d0c3b7a4a948d97ebc38fcc805d23f44d1a7a58e12b3c07a2d18557` |

The hosted evidence section will be updated without changing the candidate commit.