### PR TITLE
fix(vscode-copilot-telegram-hook): Address Post-Merge Review Feedback

### DIFF
--- a/src/private/app/vscode-copilot-telegram-hook/AppPaths.cs
+++ b/src/private/app/vscode-copilot-telegram-hook/AppPaths.cs
@@ -246,9 +246,12 @@ internal static class AppPaths
         ];
 
         StringComparer comparer = GetPlatformPathComparer();
+        string normalizedEventSpoolDirectory = Path.GetFullPath(eventSpoolDirectory);
         foreach ((string label, string path) in managedArtifactPaths)
         {
-            if (label == "Copilot CLI event spool directory")
+            if (comparer.Equals(
+                    Path.GetFullPath(path),
+                    normalizedEventSpoolDirectory))
             {
                 continue;
             }
@@ -260,7 +263,7 @@ internal static class AppPaths
                     path,
                     "Copilot CLI event spool directory",
                     eventSpoolDirectory,
-                    Path.GetFullPath(eventSpoolDirectory));
+                    normalizedEventSpoolDirectory);
             }
         }
 

--- a/src/private/app/vscode-copilot-telegram-hook/TelegramCredentialProvider.cs
+++ b/src/private/app/vscode-copilot-telegram-hook/TelegramCredentialProvider.cs
@@ -282,48 +282,52 @@ internal sealed class TelegramCredentialProvider(
         CancellationToken cancellationToken,
         bool failOnReadError = false)
     {
+        ProcessExecutionResult result;
         try
         {
-            ProcessExecutionResult result = await processRunner.RunAsync(
+            result = await processRunner.RunAsync(
                 "gopass",
                 ["show", secretPath],
                 workingDirectory: null,
                 standardInput: null,
                 SensitiveProcessLogOptions,
                 cancellationToken);
-
-            if (!result.Succeeded)
-            {
-                if (IsMissingSecretError(result.StandardError))
-                {
-                    AppLog.MissingSecretValue(logger, secretPath);
-                    return null;
-                }
-
-                if (failOnReadError)
-                {
-                    throw CreateReadSecretException(secretPath, result);
-                }
-
-                AppLog.ReadSecretFailed(
-                    logger,
-                    CreateReadSecretException(secretPath, result),
-                    secretPath);
-                return null;
-            }
-
-            return result.Succeeded ? NullIfWhitespace(result.StandardOutput.Trim()) : null;
         }
         catch (InvalidOperationException ex)
         {
+            InvalidOperationException contextualException = new(
+                $"Failed to read secret '{secretPath}': {ex.Message}",
+                ex);
             if (failOnReadError)
             {
-                throw;
+                throw contextualException;
             }
 
-            AppLog.ReadSecretFailed(logger, ex, secretPath);
+            AppLog.ReadSecretFailed(logger, contextualException, secretPath);
             return null;
         }
+
+        if (!result.Succeeded)
+        {
+            if (IsMissingSecretError(result.StandardError))
+            {
+                AppLog.MissingSecretValue(logger, secretPath);
+                return null;
+            }
+
+            if (failOnReadError)
+            {
+                throw CreateReadSecretException(secretPath, result);
+            }
+
+            AppLog.ReadSecretFailed(
+                logger,
+                CreateReadSecretException(secretPath, result),
+                secretPath);
+            return null;
+        }
+
+        return NullIfWhitespace(result.StandardOutput.Trim());
     }
 
     private async Task StoreSecretAsync(

--- a/tests/private/app/vscode-copilot-telegram-hook/AppPathsTests.cs
+++ b/tests/private/app/vscode-copilot-telegram-hook/AppPathsTests.cs
@@ -218,6 +218,28 @@ public sealed class AppPathsTests
     }
 
     [Fact]
+    public void ValidateUserArtifactPathCollisionsAcceptsNonCollidingManagedLayout()
+    {
+        string root = Path.Combine(Path.GetTempPath(), "copilot-valid-layout");
+        UserInstallationPaths paths = new(
+            root,
+            Path.Combine(root, AppPaths.GetManagedExecutableName()),
+            Path.Combine(root, AppConstants.ManagedHookFileName),
+            Path.Combine(root, "copilot", "hooks", AppConstants.CopilotCliHookFileName),
+            [
+                new VsCodeSettingsTarget(
+                    Path.Combine(root, "settings.json"),
+                    IsApplicable: true,
+                    DisplayName: "VS Code settings"),
+            ],
+            AppPaths.GetUserLogPath(root));
+
+        string? validationError = AppPaths.ValidateUserArtifactPathCollisions(paths);
+
+        Assert.Null(validationError);
+    }
+
+    [Fact]
     public void ValidateUserArtifactPathCollisionsRejectsFilesInsideEventSpool()
     {
         string root = Path.Combine(Path.GetTempPath(), "copilot-spool-collision");

--- a/tests/private/app/vscode-copilot-telegram-hook/TelegramCredentialProviderTests.cs
+++ b/tests/private/app/vscode-copilot-telegram-hook/TelegramCredentialProviderTests.cs
@@ -1,5 +1,6 @@
 using Hcoona.VsCodeCopilotTelegramHook.Logging;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 namespace Hcoona.VsCodeCopilotTelegramHook.Tests;
@@ -68,6 +69,24 @@ public sealed class TelegramCredentialProviderTests
         }
     }
 
+    [Fact]
+    public async Task ReadStoredSecretsAsyncAddsSecretPathToProcessFailure()
+    {
+        TelegramCredentialProvider provider = new(
+            new ThrowingReadProcessRunner(),
+            new NonInteractiveConsole(),
+            NullLogger<TelegramCredentialProvider>.Instance);
+
+        InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => provider.ReadStoredSecretsAsync(CancellationToken.None));
+
+        Assert.Contains(
+            AppPaths.GetTelegramBotTokenSecretPath(),
+            exception.Message,
+            StringComparison.Ordinal);
+        Assert.IsType<InvalidOperationException>(exception.InnerException);
+    }
+
     private sealed class FailingReadProcessRunner : IProcessRunner
     {
         public Task<ProcessExecutionResult> RunAsync(
@@ -82,6 +101,26 @@ public sealed class TelegramCredentialProviderTests
                     2,
                     string.Empty,
                     "gopass backend unavailable"));
+    }
+
+    private sealed class ThrowingReadProcessRunner : IProcessRunner
+    {
+        public Task<ProcessExecutionResult> RunAsync(
+            string fileName,
+            IReadOnlyList<string> arguments,
+            string? workingDirectory,
+            string? standardInput,
+            ProcessLogOptions? logOptions,
+            CancellationToken cancellationToken)
+        {
+            if (arguments.Count == 1 && arguments[0] == "version")
+            {
+                return Task.FromResult(
+                    new ProcessExecutionResult(0, "gopass 1.0.0", string.Empty));
+            }
+
+            throw new InvalidOperationException("Failed to start process 'gopass'.");
+        }
     }
 
     private sealed class NonInteractiveConsole : IInteractiveConsole


### PR DESCRIPTION
Addendum to #442.

## Summary

- Add secret-path context when gopass process execution throws while preserving the original exception.
- Replace label-dependent spool collision handling with normalized, platform-aware path comparison.
- Add focused regression coverage for both review findings.

## Validation

- `dotnet build tests/private/app/vscode-copilot-telegram-hook/Hcoona.VsCodeCopilotTelegramHook.Tests.csproj --no-restore --verbosity minimal`
- `dotnet vstest tests/private/app/vscode-copilot-telegram-hook/bin/Debug/net10.0/Hcoona.VsCodeCopilotTelegramHook.Tests.dll` (472 passed)