### PR TITLE
Configure ShellCheck for all supported platforms

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -157,76 +157,70 @@ version = "0.11.0"
 backend = "github:koalaman/shellcheck"
 
 [tools."github:koalaman/shellcheck".options]
-asset_pattern = "shellcheck-*.zip"
-
-[tools."github:koalaman/shellcheck"."platforms.linux-arm64"]
-checksum = "sha256:68a8133197a50beb8803f8d42f9908d1af1c5540d4bb05fdfca8c1fa47decefc"
-url = "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.linux.aarch64.tar.gz"
-url_api = "https://api.github.com/repos/koalaman/shellcheck/releases/assets/336391401"
-
-[tools."github:koalaman/shellcheck"."platforms.linux-arm64-musl"]
-checksum = "sha256:68a8133197a50beb8803f8d42f9908d1af1c5540d4bb05fdfca8c1fa47decefc"
-url = "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.linux.aarch64.tar.gz"
-url_api = "https://api.github.com/repos/koalaman/shellcheck/releases/assets/336391401"
+asset_pattern = "shellcheck-*.linux.x86_64.tar.xz"
 
 [tools."github:koalaman/shellcheck"."platforms.linux-x64"]
-checksum = "sha256:b7af85e41cc99489dcc21d66c6d5f3685138f06d34651e6d34b42ec6d54fe6f6"
-url = "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.linux.x86_64.tar.gz"
-url_api = "https://api.github.com/repos/koalaman/shellcheck/releases/assets/336391469"
+checksum = "sha256:8c3be12b05d5c177a04c29e3c78ce89ac86f1595681cab149b65b97c4e227198"
+url = "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.linux.x86_64.tar.xz"
+url_api = "https://api.github.com/repos/koalaman/shellcheck/releases/assets/279056942"
 
 [tools."github:koalaman/shellcheck"."platforms.linux-x64-musl"]
-checksum = "sha256:b7af85e41cc99489dcc21d66c6d5f3685138f06d34651e6d34b42ec6d54fe6f6"
-url = "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.linux.x86_64.tar.gz"
-url_api = "https://api.github.com/repos/koalaman/shellcheck/releases/assets/336391469"
-
-[tools."github:koalaman/shellcheck"."platforms.macos-arm64"]
-checksum = "sha256:339b930feb1ea764467013cc1f72d09cd6b869ebf1013296ba9055ab2ffbd26f"
-url = "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.darwin.aarch64.tar.gz"
-url_api = "https://api.github.com/repos/koalaman/shellcheck/releases/assets/336391359"
-
-[tools."github:koalaman/shellcheck"."platforms.macos-x64"]
-checksum = "sha256:c2c15e08df0e8fbc374c335b230a7ee958c313fa5714817a59aa59f1aa594f51"
-url = "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.darwin.x86_64.tar.gz"
-url_api = "https://api.github.com/repos/koalaman/shellcheck/releases/assets/336391375"
-
-[tools."github:koalaman/shellcheck"."platforms.windows-x64"]
-checksum = "sha256:8a4e35ab0b331c85d73567b12f2a444df187f483e5079ceffa6bda1faa2e740e"
-url = "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.zip"
-url_api = "https://api.github.com/repos/koalaman/shellcheck/releases/assets/279056944"
+checksum = "sha256:8c3be12b05d5c177a04c29e3c78ce89ac86f1595681cab149b65b97c4e227198"
+url = "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.linux.x86_64.tar.xz"
+url_api = "https://api.github.com/repos/koalaman/shellcheck/releases/assets/279056942"
 
 [[tools."github:koalaman/shellcheck"]]
 version = "0.11.0"
 backend = "github:koalaman/shellcheck"
 
+[tools."github:koalaman/shellcheck".options]
+asset_pattern = "shellcheck-*.linux.aarch64.tar.xz"
+
 [tools."github:koalaman/shellcheck"."platforms.linux-arm64"]
-checksum = "sha256:68a8133197a50beb8803f8d42f9908d1af1c5540d4bb05fdfca8c1fa47decefc"
-url = "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.linux.aarch64.tar.gz"
-url_api = "https://api.github.com/repos/koalaman/shellcheck/releases/assets/336391401"
+checksum = "sha256:12b331c1d2db6b9eb13cfca64306b1b157a86eb69db83023e261eaa7e7c14588"
+url = "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.linux.aarch64.tar.xz"
+url_api = "https://api.github.com/repos/koalaman/shellcheck/releases/assets/279056934"
 
 [tools."github:koalaman/shellcheck"."platforms.linux-arm64-musl"]
-checksum = "sha256:68a8133197a50beb8803f8d42f9908d1af1c5540d4bb05fdfca8c1fa47decefc"
-url = "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.linux.aarch64.tar.gz"
-url_api = "https://api.github.com/repos/koalaman/shellcheck/releases/assets/336391401"
+checksum = "sha256:12b331c1d2db6b9eb13cfca64306b1b157a86eb69db83023e261eaa7e7c14588"
+url = "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.linux.aarch64.tar.xz"
+url_api = "https://api.github.com/repos/koalaman/shellcheck/releases/assets/279056934"
 
-[tools."github:koalaman/shellcheck"."platforms.linux-x64"]
-checksum = "sha256:b7af85e41cc99489dcc21d66c6d5f3685138f06d34651e6d34b42ec6d54fe6f6"
-url = "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.linux.x86_64.tar.gz"
-url_api = "https://api.github.com/repos/koalaman/shellcheck/releases/assets/336391469"
+[[tools."github:koalaman/shellcheck"]]
+version = "0.11.0"
+backend = "github:koalaman/shellcheck"
 
-[tools."github:koalaman/shellcheck"."platforms.linux-x64-musl"]
-checksum = "sha256:b7af85e41cc99489dcc21d66c6d5f3685138f06d34651e6d34b42ec6d54fe6f6"
-url = "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.linux.x86_64.tar.gz"
-url_api = "https://api.github.com/repos/koalaman/shellcheck/releases/assets/336391469"
+[tools."github:koalaman/shellcheck".options]
+asset_pattern = "shellcheck-*.darwin.aarch64.tar.xz"
 
 [tools."github:koalaman/shellcheck"."platforms.macos-arm64"]
-checksum = "sha256:339b930feb1ea764467013cc1f72d09cd6b869ebf1013296ba9055ab2ffbd26f"
-url = "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.darwin.aarch64.tar.gz"
-url_api = "https://api.github.com/repos/koalaman/shellcheck/releases/assets/336391359"
+checksum = "sha256:56affdd8de5527894dca6dc3d7e0a99a873b0f004d7aabc30ae407d3f48b0a79"
+url = "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.darwin.aarch64.tar.xz"
+url_api = "https://api.github.com/repos/koalaman/shellcheck/releases/assets/279056932"
+
+[[tools."github:koalaman/shellcheck"]]
+version = "0.11.0"
+backend = "github:koalaman/shellcheck"
+
+[tools."github:koalaman/shellcheck".options]
+asset_pattern = "shellcheck-*.darwin.x86_64.tar.xz"
 
 [tools."github:koalaman/shellcheck"."platforms.macos-x64"]
-checksum = "sha256:c2c15e08df0e8fbc374c335b230a7ee958c313fa5714817a59aa59f1aa594f51"
-url = "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.darwin.x86_64.tar.gz"
-url_api = "https://api.github.com/repos/koalaman/shellcheck/releases/assets/336391375"
+checksum = "sha256:3c89db4edcab7cf1c27bff178882e0f6f27f7afdf54e859fa041fca10febe4c6"
+url = "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.darwin.x86_64.tar.xz"
+url_api = "https://api.github.com/repos/koalaman/shellcheck/releases/assets/279056930"
+
+[[tools."github:koalaman/shellcheck"]]
+version = "0.11.0"
+backend = "github:koalaman/shellcheck"
+
+[tools."github:koalaman/shellcheck".options]
+asset_pattern = "shellcheck-*.zip"
+
+[tools."github:koalaman/shellcheck"."platforms.windows-x64"]
+checksum = "sha256:8a4e35ab0b331c85d73567b12f2a444df187f483e5079ceffa6bda1faa2e740e"
+url = "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.zip"
+url_api = "https://api.github.com/repos/koalaman/shellcheck/releases/assets/279056944"
 
 [[tools."github:microsoft/apm"]]
 version = "0.22.0"

--- a/mise.toml
+++ b/mise.toml
@@ -39,13 +39,12 @@ typos = "latest"
 "go:github.com/rhysd/actionlint/cmd/actionlint" = "latest"
 
 # Bash
-"github:koalaman/shellcheck" = { version = "latest", platforms = {
-  "linux-arm64" = { asset_pattern = "shellcheck-*.linux.aarch64.tar.xz" },
-  "linux-x64" = { asset_pattern = "shellcheck-*.linux.x86_64.tar.xz" },
-  "macos-arm64" = { asset_pattern = "shellcheck-*.darwin.aarch64.tar.xz" },
-  "macos-x64" = { asset_pattern = "shellcheck-*.darwin.x86_64.tar.xz" },
-  "windows-x64" = { asset_pattern = "shellcheck-*.zip" },
-} }
+"github:koalaman/shellcheck".version = "latest"
+"github:koalaman/shellcheck".platforms.linux-arm64 = { asset_pattern = "shellcheck-*.linux.aarch64.tar.xz" }
+"github:koalaman/shellcheck".platforms.linux-x64 = { asset_pattern = "shellcheck-*.linux.x86_64.tar.xz" }
+"github:koalaman/shellcheck".platforms.macos-arm64 = { asset_pattern = "shellcheck-*.darwin.aarch64.tar.xz" }
+"github:koalaman/shellcheck".platforms.macos-x64 = { asset_pattern = "shellcheck-*.darwin.x86_64.tar.xz" }
+"github:koalaman/shellcheck".platforms.windows-x64 = { asset_pattern = "shellcheck-*.zip" }
 "go:mvdan.cc/sh/v3/cmd/shfmt" = "latest"
 
 # Dockerfile

--- a/mise.toml
+++ b/mise.toml
@@ -39,7 +39,13 @@ typos = "latest"
 "go:github.com/rhysd/actionlint/cmd/actionlint" = "latest"
 
 # Bash
-"github:koalaman/shellcheck" = { version = "latest", platforms = { "windows-x64" = { asset_pattern = "shellcheck-*.zip" } } }
+"github:koalaman/shellcheck" = { version = "latest", platforms = {
+  "linux-arm64" = { asset_pattern = "shellcheck-*.linux.aarch64.tar.xz" },
+  "linux-x64" = { asset_pattern = "shellcheck-*.linux.x86_64.tar.xz" },
+  "macos-arm64" = { asset_pattern = "shellcheck-*.darwin.aarch64.tar.xz" },
+  "macos-x64" = { asset_pattern = "shellcheck-*.darwin.x86_64.tar.xz" },
+  "windows-x64" = { asset_pattern = "shellcheck-*.zip" },
+} }
 "go:mvdan.cc/sh/v3/cmd/shfmt" = "latest"
 
 # Dockerfile


### PR DESCRIPTION
## Summary

- keep ShellCheck on the existing GitHub backend
- select release assets for Linux and macOS on x64 and arm64
- retain the Windows x64 release asset configuration
- refresh the cross-platform mise lock entries