### PR TITLE
fix(hexo-renderer-asciidoc): Support Asciidoctor 4.0.5

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,8 +72,8 @@ importers:
   src/public/lib/hexo-renderer-asciidoc:
     dependencies:
       '@asciidoctor/core':
-        specifier: 4.0.4
-        version: 4.0.4
+        specifier: 4.0.5
+        version: 4.0.5
       cheerio:
         specifier: ^1.2.0
         version: 1.2.0
@@ -157,8 +157,8 @@ packages:
       rollup:
         optional: true
 
-  '@asciidoctor/core@4.0.4':
-    resolution: {integrity: sha512-U9oBUBxsUXKMAqaVgzKTw/SaZh9YoCNmpUon3WxSZzdNBq/q8WzxbeuJKqhHVUk3ztKu2jK7EpLB5XOwlrYgJA==}
+  '@asciidoctor/core@4.0.5':
+    resolution: {integrity: sha512-Rg6w6YHU1FqACkrE62f5oqI8LHhM7Dp9eWZFQfXl/0fCYYLgPSyNbGqBTpWbGYlSaNp3yfB0naeQhlWH1ZibPA==}
     engines: {node: '>=20'}
 
   '@babel/code-frame@7.29.7':
@@ -3563,7 +3563,7 @@ snapshots:
       source-map: 0.7.6
       yargs: 17.7.3
 
-  '@asciidoctor/core@4.0.4': {}
+  '@asciidoctor/core@4.0.5': {}
 
   '@babel/code-frame@7.29.7':
     dependencies:

--- a/src/public/lib/hexo-renderer-asciidoc/CHANGELOG.md
+++ b/src/public/lib/hexo-renderer-asciidoc/CHANGELOG.md
@@ -26,7 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Migrate the project repository to the `hcoona/three` monorepo and update
   documentation links accordingly.
 - Begin the `4.0.0-beta` major line by moving the runtime dependency from
-  `asciidoctor` 3.0.4 to exact `@asciidoctor/core` 4.0.4 / Asciidoctor.js 4.0.4.
+  `asciidoctor` 3.0.4 to exact `@asciidoctor/core` 4.0.5 / Asciidoctor.js 4.0.5.
+- Derive extension logger types from the official `Reader.getLogger()` contract.
 - Change the public renderer contract from `string` to `Promise<string>`.
   Programmatic consumers must `await renderer(...)`.
 - Register Hexo renderers for `.ad`, `.adoc`, and `.asciidoc` asynchronously.

--- a/src/public/lib/hexo-renderer-asciidoc/README.md
+++ b/src/public/lib/hexo-renderer-asciidoc/README.md
@@ -10,7 +10,7 @@
 [![Node support](https://img.shields.io/node/v/hexo-renderer-asciidoc.svg?logo=node.js)](package.json)
 [![License: LGPL-3.0-or-later](https://img.shields.io/badge/license-LGPL--3.0--or--later-0a76d5.svg)](LICENSE)
 
-Add first-class [AsciiDoc](https://asciidoc.org/) support to Hexo. This repository branch documents the 4.x migration, which uses `@asciidoctor/core` / Asciidoctor.js 4.0.4, returns `Promise<string>`, registers the Hexo renderer asynchronously, re-highlights recognized listing blocks with fixed `hexo-util.highlight` options, and encodes literal braces before returning the resulting HTML to Hexo.
+Add first-class [AsciiDoc](https://asciidoc.org/) support to Hexo. This repository branch documents the 4.x migration, which uses `@asciidoctor/core` / Asciidoctor.js 4.0.5, returns `Promise<string>`, registers the Hexo renderer asynchronously, re-highlights recognized listing blocks with fixed `hexo-util.highlight` options, and encodes literal braces before returning the resulting HTML to Hexo.
 
 ## Rendering contract
 

--- a/src/public/lib/hexo-renderer-asciidoc/README.npm.md
+++ b/src/public/lib/hexo-renderer-asciidoc/README.npm.md
@@ -5,7 +5,7 @@
 
 # hexo-renderer-asciidoc
 
-Add native [AsciiDoc](https://asciidoc.org/) rendering to Hexo using `@asciidoctor/core` / Asciidoctor.js 4.0.4. The plugin auto-registers asynchronous renderers for `.ad`, `.adoc`, and `.asciidoc`, re-highlights recognized AsciiDoc listing blocks with Hexo-compatible markup, and encodes literal `{` / `}` before returning HTML to Hexo.
+Add native [AsciiDoc](https://asciidoc.org/) rendering to Hexo using `@asciidoctor/core` / Asciidoctor.js 4.0.5. The plugin auto-registers asynchronous renderers for `.ad`, `.adoc`, and `.asciidoc`, re-highlights recognized listing blocks with Hexo-compatible markup, and encodes literal `{` / `}` before returning HTML to Hexo.
 
 ## Requirements
 
@@ -86,7 +86,7 @@ explicit `@beta` package as described in [Installation](#installation).
 
 ## Behavior summary
 
-- Uses exact runtime dependency `@asciidoctor/core` 4.0.4 and awaits Asciidoctor.js 4 conversion before any post-processing.
+- Uses exact runtime dependency `@asciidoctor/core` 4.0.5 and awaits Asciidoctor.js 4 conversion before any post-processing.
 - Registers `.ad`, `.adoc`, and `.asciidoc` with Hexo as asynchronous renderers.
 - Runs Asciidoctor with `doctype: article`, `safe: server`, and `to_file: false`. It does **not** set `base_dir`, so includes resolve from the conversion-time `process.cwd()`. `data.path` and the Hexo site root are not used as `base_dir`.
 - Is **not safe for untrusted AsciiDoc**. `safe: server` still permits local includes under these current-working-directory semantics, and symlink targets can escape an assumed directory boundary. The current working directory is not a jail. Render only trusted input, from an isolated or sandboxed working directory that contains no secrets.

--- a/src/public/lib/hexo-renderer-asciidoc/examples/hexo-site/README.md
+++ b/src/public/lib/hexo-renderer-asciidoc/examples/hexo-site/README.md
@@ -92,7 +92,7 @@ inputs.
 
 ## Behavior notes
 
-- The package uses `@asciidoctor/core` 4.0.4 and awaits conversion before
+- The package uses `@asciidoctor/core` 4.0.5 and awaits conversion before
   post-processing.
 - Includes resolve from the conversion-time current working directory because
   the renderer does not pass `base_dir`; neither `data.path` nor the Hexo site

--- a/src/public/lib/hexo-renderer-asciidoc/examples/hexo-site/source/_posts/hello-from-asciidoc.adoc
+++ b/src/public/lib/hexo-renderer-asciidoc/examples/hexo-site/source/_posts/hello-from-asciidoc.adoc
@@ -21,7 +21,7 @@ generates index, archive, category, tag, and theme pages separately.
 == Why this renderer
 
 * Converts `.ad`, `.adoc`, and `.asciidoc` sources with `@asciidoctor/core`
-  4.0.4 using `doctype=article`, `safe=server`, and `to_file=false`.
+  4.0.5 using `doctype=article`, `safe=server`, and `to_file=false`.
 * Registers asynchronously with Hexo, so normal Hexo rendering awaits the
   renderer and programmatic callers must `await renderer(...)`.
 * Re-runs Hexo's static syntax highlighter only for recognized AsciiDoc listing

--- a/src/public/lib/hexo-renderer-asciidoc/examples/hexo-site/source/_posts/renderer-tour.adoc
+++ b/src/public/lib/hexo-renderer-asciidoc/examples/hexo-site/source/_posts/renderer-tour.adoc
@@ -17,7 +17,7 @@ Want to see what happens between your `.adoc` file and the HTML that lands in
 
 == Step 1 – Asciidoctor conversion
 
-Each render awaits the named `convert()` API from `@asciidoctor/core` 4.0.4.
+Each render awaits the named `convert()` API from `@asciidoctor/core` 4.0.5.
 Every call uses:
 
 * `doctype=article`

--- a/src/public/lib/hexo-renderer-asciidoc/package.json
+++ b/src/public/lib/hexo-renderer-asciidoc/package.json
@@ -63,7 +63,7 @@
     "hexo": ">=8.0.0"
   },
   "dependencies": {
-    "@asciidoctor/core": "4.0.4",
+    "@asciidoctor/core": "4.0.5",
     "cheerio": "^1.2.0",
     "entities": "^8.0.0",
     "hexo-util": "^4.0.0"

--- a/src/public/lib/hexo-renderer-asciidoc/scripts/validate-packed-artifact.mjs
+++ b/src/public/lib/hexo-renderer-asciidoc/scripts/validate-packed-artifact.mjs
@@ -546,8 +546,8 @@ const main = () => {
     assert(packedManifest.types === './dist/index.d.ts', 'Packed types must point at the ESM declarations.');
     assert(packedManifest.engines?.node === '>=20.19.0', 'Packed engines.node must remain >=20.19.0.');
     assert(
-      packedManifest.dependencies?.['@asciidoctor/core'] === '4.0.4',
-      'Packed dependency @asciidoctor/core must be 4.0.4.',
+      packedManifest.dependencies?.['@asciidoctor/core'] === '4.0.5',
+      'Packed dependency @asciidoctor/core must be 4.0.5.',
     );
     assert(!('asciidoctor' in (packedManifest.dependencies ?? {})), 'Packed manifest must not depend on asciidoctor.');
     assert(

--- a/src/public/lib/hexo-renderer-asciidoc/scripts/validate-release-pack.mjs
+++ b/src/public/lib/hexo-renderer-asciidoc/scripts/validate-release-pack.mjs
@@ -58,8 +58,8 @@ const verifyTarballCommon = (tarballPath, expectedName, expectedVersion, expecte
   );
   assert(manifest.main === './dist/index.cjs', 'Packed main must stay on dist/index.cjs.');
   assert(
-    manifest.dependencies?.['@asciidoctor/core'] === '4.0.4',
-    'Packed dependency @asciidoctor/core must remain 4.0.4.',
+    manifest.dependencies?.['@asciidoctor/core'] === '4.0.5',
+    'Packed dependency @asciidoctor/core must remain 4.0.5.',
   );
   assert(!('asciidoctor' in (manifest.dependencies ?? {})), 'Packed manifest must not depend on asciidoctor.');
   assert(!entries.includes('package/README.npm.md'), 'README.npm.md must not be published.');

--- a/src/public/lib/hexo-renderer-asciidoc/test/asciidoctor.runtime.worker.ts
+++ b/src/public/lib/hexo-renderer-asciidoc/test/asciidoctor.runtime.worker.ts
@@ -192,13 +192,7 @@ type OverlapRenderCase = {
   optionSentinel: string;
 };
 
-type LoggerLike = {
-  warn(message: string): void;
-};
-
-type ReaderWithLogger = Reader & {
-  getLogger(): LoggerLike;
-};
+type ReaderLogger = ReturnType<Reader['getLogger']>;
 
 type DocumentWithAttributes = {
   getAttribute(name: string): unknown;
@@ -211,7 +205,7 @@ type ParentWithDocument = AbstractBlock & {
 type OverlapBarrierRegistration = {
   dispose: () => void;
   getActiveCount: () => number;
-  getLoggers: () => ReadonlyMap<string, LoggerLike>;
+  getLoggers: () => ReadonlyMap<string, ReaderLogger>;
   getMaxActiveCount: () => number;
 };
 
@@ -278,7 +272,7 @@ const registerOverlapBarrier = (expectedCount: number): OverlapBarrierRegistrati
   const extensionName = `unit2-overlap-barrier-${overlapExtensionSequence}`;
   let activeCount = 0;
   let maxActiveCount = 0;
-  const loggers = new Map<string, LoggerLike>();
+  const loggers = new Map<string, ReaderLogger>();
   let settleBarrier: ((error?: Error) => void) | undefined;
   const barrier = new Promise<void>((resolve, reject) => {
     settleBarrier = (error?: Error) => {
@@ -300,17 +294,14 @@ const registerOverlapBarrier = (expectedCount: number): OverlapBarrierRegistrati
       const optionSentinel = String(document.getAttribute('unit2-option-sentinel') ?? '');
       const loggerSentinel = String(document.getAttribute('unit2-logger-sentinel') ?? '');
       const errorSentinel = document.getAttribute('unit2-error-sentinel');
-      const logger =
-        typeof (reader as Partial<ReaderWithLogger>).getLogger === 'function'
-          ? (reader as ReaderWithLogger).getLogger()
-          : undefined;
+      const logger = reader.getLogger();
       if (!logger) {
         throw new TypeError(`conversion ${callId} did not expose its core logger`);
       }
       loggers.set(callId, logger);
       const barrierText = (await reader.readLines()).join('\n');
 
-      logger.warn(`UNIT2_LOG_SENTINEL:${loggerSentinel}`);
+      logger.warn(`UNIT2_LOG_SENTINEL:${loggerSentinel}`, undefined);
       activeCount += 1;
       maxActiveCount = Math.max(maxActiveCount, activeCount);
       if (activeCount === expectedCount) {

--- a/src/public/lib/hexo-renderer-asciidoc/test/packed-artifact.test.ts
+++ b/src/public/lib/hexo-renderer-asciidoc/test/packed-artifact.test.ts
@@ -156,7 +156,7 @@ describe('packed Asciidoctor v4 package import shapes', () => {
     expect(expectedHtml).toContain('<code class="highlight javascript">');
 
     expect(packedManifest.name).toBe('hexo-renderer-asciidoc');
-    expect(packedManifest.dependencies?.['@asciidoctor/core']).toBe('4.0.4');
+    expect(packedManifest.dependencies?.['@asciidoctor/core']).toBe('4.0.5');
     expect(packedManifest.main).toBe('./dist/index.cjs');
     expect(packedManifest.types).toBe('./dist/index.d.ts');
     expect(packedManifest.exports?.['.']?.import?.default).toBe('./dist/index.js');


### PR DESCRIPTION
## Summary

- upgrade `@asciidoctor/core` to 4.0.5
- derive logger typing from `Reader.getLogger()` and use the official logger call signature
- align package validation and documentation with the upgraded dependency

## Validation

- package typecheck
- 333 package tests
- package lint and build
- packed-artifact validation

Addresses the compatibility failure observed in #459.