### PR TITLE
fix(renovate): Skip Git LFS object downloads

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -56,6 +56,13 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Configure Git LFS for pointer-only clones
+        run: |
+          set -Eeuo pipefail
+
+          # Renovate performs its own clone, so configure the runner globally.
+          git lfs install --skip-smudge --skip-repo --force
+
       - name: Set up Node.js
         uses: actions/setup-node@v7
         with:


### PR DESCRIPTION
## Summary

- configure Git LFS skip-smudge in the runner global Git configuration
- apply pointer-only behavior to Renovate's internal repository clone
- retain the existing environment-level skip-smudge safeguard

## Validation

- actionlint
- targeted HK workflow validation

This prevents Renovate runs from failing when Git LFS bandwidth is unavailable.