### PR TITLE
fix(renovate): Skip Git LFS object downloads

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -54,6 +54,7 @@ jobs:
         with:
           ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 0
+          lfs: false
           persist-credentials: false
 
       - name: Configure Git LFS for pointer-only clones


### PR DESCRIPTION
## Summary

- make the initial `actions/checkout` explicitly skip Git LFS object downloads
- keep pointer files available to Renovate
- complement #464, which configures global skip-smudge for Renovate's separate internal clone

## Validation

- actionlint
- targeted HK workflow validation
- independent code review with no findings