### PR TITLE
fix(azureauth): Bootstrap Uv Keyring Via Apphost

### DIFF
--- a/src/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Cli/CliApplication.cs
+++ b/src/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Cli/CliApplication.cs
@@ -3710,7 +3710,13 @@ internal static class CliApplication
             };
         }
 
-        if (registryEcosystem == CredentialEcosystem.Python)
+        bool explicitPythonImportPreflight =
+            options?.PythonDoctorService is not null
+            || runtimeOptions?.PythonPhase11Options is not null;
+        if (
+            registryEcosystem == CredentialEcosystem.Python
+            && (OperatingSystem.IsWindows() || explicitPythonImportPreflight)
+        )
         {
             options = (options ?? new ConfigurationPhase14VerticalSliceOptions()) with
             {

--- a/src/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Cli/Program.cs
+++ b/src/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Cli/Program.cs
@@ -1,3 +1,4 @@
+using Hcoona.AzureAuth.CredProvider.Contracts;
 using Hcoona.AzureAuth.CredProvider.Platform.AdapterHost;
 using Hcoona.AzureAuth.CredProvider.Platform.Composition;
 using Hcoona.AzureAuth.CredProvider.Platform.Diagnostics;
@@ -19,6 +20,27 @@ internal static class Program
         )
         {
             return RunProtocolWithProductionRoot(RunNuGetPlugin);
+        }
+
+        if (
+            KeyringCliAdapter.TryResolveProtocolInvocation(
+                invocationPath ?? "azureauth-credprovider",
+                args,
+                out AdapterInvocationContext? keyringContext
+            )
+        )
+        {
+            if (
+                keyringContext is not null
+                && KeyringCliAdapter.IsUnsupportedServiceInvocation(keyringContext)
+            )
+            {
+                return (int)AdapterHostExitCode.NoCredential;
+            }
+
+            return RunProtocolWithProductionRoot(root =>
+                RunKeyringCli(root, invocationPath, args)
+            );
         }
 
         if (
@@ -84,6 +106,40 @@ internal static class Program
                 .RunPluginAsync()
                 .GetAwaiter()
                 .GetResult();
+        }
+        catch (Exception)
+        {
+            StandardConsoleTextWriters
+                .StandardError()
+                .WriteLine("error: unexpected fatal failure.");
+            return 70;
+        }
+    }
+
+    private static int RunKeyringCli(
+        CredentialProviderCompositionRoot compositionRoot,
+        string? invocationPath,
+        string[] args
+    )
+    {
+        try
+        {
+            TextWriter protocolStdout = StandardConsoleTextWriters.StandardOutput();
+            TextWriter stderr = StandardConsoleTextWriters.StandardError();
+            var diagnosticRouter = new DiagnosticRouter(
+                [new TextWriterDiagnosticSink(stderr)],
+                SecretRedactor.Empty
+            );
+            AdapterHostExecutionOutcome outcome = compositionRoot
+                .CreateKeyringCliAdapter()
+                .Execute(
+                    invocationPath ?? KeyringHelperAdapter.ProductExecutableName,
+                    args,
+                    protocolStdout,
+                    humanStdout: protocolStdout,
+                    diagnosticRouter
+                );
+            return (int)outcome.Result.ExitCode;
         }
         catch (Exception)
         {

--- a/src/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform/AdapterHost/KeyringCliAdapter.cs
+++ b/src/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform/AdapterHost/KeyringCliAdapter.cs
@@ -1,0 +1,381 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Text.Json;
+using Hcoona.AzureAuth.CredProvider.Contracts;
+using Hcoona.AzureAuth.CredProvider.Platform.Composition;
+using Hcoona.AzureAuth.CredProvider.Platform.CredentialCore;
+using Hcoona.AzureAuth.CredProvider.Platform.Diagnostics;
+
+namespace Hcoona.AzureAuth.CredProvider.Platform.AdapterHost;
+
+public sealed class KeyringCliAdapter
+{
+    public const string CommandName = "keyring";
+
+    private const string GetVerb = "get";
+    private const string JsonOutput = "json";
+    private const string PlainOutput = "plain";
+
+    private readonly KeyringHelperAdapter helperAdapter;
+
+    public KeyringCliAdapter()
+        : this(CredentialProviderCompositionRoot.CreateProduction().AcquisitionService) { }
+
+    public KeyringCliAdapter(CredentialCoreService? credentialCore)
+        : this(
+            credentialCore is null
+                ? CredentialProviderCompositionRoot.CreateProduction().AcquisitionService
+                : new LegacyV1CredentialAcquisitionService(credentialCore)
+        )
+    { }
+
+    public KeyringCliAdapter(ICredentialAcquisitionService credentialAcquisition)
+    {
+        ArgumentNullException.ThrowIfNull(credentialAcquisition);
+        helperAdapter = new KeyringHelperAdapter(credentialAcquisition);
+    }
+
+    public KeyringCliAdapter(BoundedCredentialAcquisitionAdapter credentialAcquisition)
+    {
+        ArgumentNullException.ThrowIfNull(credentialAcquisition);
+        helperAdapter = new KeyringHelperAdapter(credentialAcquisition);
+    }
+
+    public static AdapterDescriptor Descriptor { get; } = CreateDescriptor();
+
+    public static bool TryResolveProtocolInvocation(
+        string? executablePath,
+        IEnumerable<string>? arguments,
+        out AdapterInvocationContext? context
+    )
+    {
+        bool resolved = AdapterHostBootstrap.TryResolveInvocation(
+            Descriptor,
+            executablePath,
+            arguments,
+            out context
+        );
+        if (!resolved || context is null || !context.IsProtocolInvocation)
+        {
+            context = null;
+            return false;
+        }
+
+        return true;
+    }
+
+    public static bool IsUnsupportedServiceInvocation(AdapterInvocationContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        return TryParseRequest(context.PayloadArguments, out KeyringCliRequest? request)
+            && Uri.TryCreate(request.Service, UriKind.Absolute, out Uri? service)
+            && !string.IsNullOrEmpty(service.Host)
+            && !IsPotentialAzureArtifactsHost(service.IdnHost);
+    }
+
+    public AdapterHostExecutionOutcome Execute(
+        string? executablePath,
+        IEnumerable<string>? arguments,
+        TextWriter protocolStdout,
+        TextWriter humanStdout,
+        DiagnosticRouter diagnosticRouter
+    )
+    {
+        ArgumentNullException.ThrowIfNull(protocolStdout);
+        ArgumentNullException.ThrowIfNull(humanStdout);
+        ArgumentNullException.ThrowIfNull(diagnosticRouter);
+
+        _ = humanStdout;
+        AdapterInvocationContext? context = null;
+        if (
+            !TryResolveProtocolInvocation(executablePath, arguments, out context)
+            || context is null
+        )
+        {
+            return ExecuteHelper(
+                context,
+                ["set"],
+                output: PlainOutput,
+                mode: KeyringHelperMode.Password,
+                protocolStdout,
+                diagnosticRouter
+            );
+        }
+
+        if (!TryParseRequest(context.PayloadArguments, out KeyringCliRequest? request))
+        {
+            return ExecuteHelper(
+                context,
+                ["set"],
+                output: PlainOutput,
+                mode: KeyringHelperMode.Password,
+                protocolStdout,
+                diagnosticRouter
+            );
+        }
+
+        return ExecuteHelper(
+            context,
+            BuildHelperArguments(request),
+            request.Output,
+            request.Mode,
+            protocolStdout,
+            diagnosticRouter
+        );
+    }
+
+    private static AdapterDescriptor CreateDescriptor()
+    {
+        AdapterEntrypointDescriptor sharedCliEntrypoint = new(
+            "KeyringCli",
+            AdapterInvocationMode.Protocol,
+            executableNames: [KeyringHelperAdapter.ProductExecutableName],
+            argumentTokens: [CommandName],
+            argumentMatchMode: AdapterArgumentMatchMode.Prefix
+        );
+        AdapterEntrypointDescriptor dedicatedExecutableEntrypoint = new(
+            "KeyringCliExecutable",
+            AdapterInvocationMode.Protocol,
+            executableNames: [CommandName]
+        );
+
+        return new AdapterDescriptor(
+            "Keyring CLI",
+            AdapterProtocol.KeyringHelper,
+            [sharedCliEntrypoint, dedicatedExecutableEntrypoint]
+        );
+    }
+
+    private AdapterHostExecutionOutcome ExecuteHelper(
+        AdapterInvocationContext? context,
+        IReadOnlyList<string> helperArguments,
+        string output,
+        KeyringHelperMode mode,
+        TextWriter protocolStdout,
+        DiagnosticRouter diagnosticRouter
+    )
+    {
+        using var helperStdout = new StringWriter(CultureInfo.InvariantCulture);
+        using var helperHumanStdout = new StringWriter(CultureInfo.InvariantCulture);
+        AdapterHostExecutionOutcome helperOutcome = helperAdapter.Execute(
+            KeyringHelperV2.CommandName,
+            helperArguments,
+            helperStdout,
+            helperHumanStdout,
+            diagnosticRouter
+        );
+        if (helperOutcome.Result.ExitCode == AdapterHostExitCode.Success)
+        {
+            WriteText(
+                protocolStdout,
+                output == JsonOutput
+                    ? ConvertToJson(helperStdout.ToString(), mode)
+                    : helperStdout.ToString()
+            );
+        }
+
+        return new AdapterHostExecutionOutcome(context, helperOutcome.Result);
+    }
+
+    private static bool TryParseRequest(
+        IReadOnlyList<string> arguments,
+        [NotNullWhen(true)] out KeyringCliRequest? request
+    )
+    {
+        request = null;
+        int index = 0;
+        string mode = "password";
+        string output = PlainOutput;
+        while (
+            index < arguments.Count
+            && arguments[index].StartsWith("--", StringComparison.Ordinal)
+        )
+        {
+            string option = arguments[index];
+            if (option.StartsWith("--mode=", StringComparison.Ordinal))
+            {
+                mode = option["--mode=".Length..];
+            }
+            else if (option.StartsWith("--output=", StringComparison.Ordinal))
+            {
+                output = option["--output=".Length..];
+            }
+            else
+            {
+                return false;
+            }
+
+            index++;
+        }
+
+        if (
+            arguments.Count - index < 2
+            || !string.Equals(arguments[index], GetVerb, StringComparison.Ordinal)
+            || string.IsNullOrWhiteSpace(arguments[index + 1])
+            || !string.Equals(
+                arguments[index + 1],
+                arguments[index + 1].Trim(),
+                StringComparison.Ordinal
+            )
+            || arguments[index + 1].Any(char.IsControl)
+        )
+        {
+            return false;
+        }
+
+        string service = arguments[index + 1];
+        index += 2;
+        string? username = null;
+        if (
+            index < arguments.Count
+            && arguments[index].StartsWith("--", StringComparison.Ordinal)
+            && !string.Equals(arguments[index], "--mode", StringComparison.Ordinal)
+        )
+        {
+            return false;
+        }
+        if (
+            index < arguments.Count
+            && !string.Equals(arguments[index], "--mode", StringComparison.Ordinal)
+        )
+        {
+            username = arguments[index];
+            if (IsInvalidUsername(username))
+            {
+                return false;
+            }
+            index++;
+        }
+
+        if (index < arguments.Count)
+        {
+            if (
+                arguments.Count - index != 2
+                || !string.Equals(arguments[index], "--mode", StringComparison.Ordinal)
+            )
+            {
+                return false;
+            }
+
+            mode = arguments[index + 1];
+            index += 2;
+        }
+
+        KeyringHelperMode parsedMode = mode switch
+        {
+            "password" => KeyringHelperMode.Password,
+            "creds" => KeyringHelperMode.Credentials,
+            _ => KeyringHelperMode.Unspecified,
+        };
+        if (
+            index != arguments.Count
+            || parsedMode == KeyringHelperMode.Unspecified
+            || output is not (PlainOutput or JsonOutput)
+            || (parsedMode == KeyringHelperMode.Password && username is null)
+        )
+        {
+            return false;
+        }
+
+        request = new KeyringCliRequest(service, username, parsedMode, output);
+        return true;
+    }
+
+    private static List<string> BuildHelperArguments(KeyringCliRequest request)
+    {
+        var arguments = new List<string>
+        {
+            KeyringHelperV2.GetVerb,
+            "--protocol-version",
+            ContractVersions.KeyringHelperMajor.ToString(CultureInfo.InvariantCulture),
+            "--service",
+            request.Service,
+        };
+        if (request.Username is not null)
+        {
+            arguments.Add("--username");
+            arguments.Add(request.Username);
+        }
+
+        arguments.Add("--mode");
+        arguments.Add(
+            request.Mode == KeyringHelperMode.Credentials ? "creds" : "password"
+        );
+        return arguments;
+    }
+
+    private static string ConvertToJson(string helperStdout, KeyringHelperMode mode)
+    {
+        string[] records = helperStdout.Split('\n');
+        if (records.Length > 0 && records[^1].Length == 0)
+        {
+            records = records[..^1];
+        }
+
+        return mode switch
+        {
+            KeyringHelperMode.Password when records.Length == 1 =>
+                "{\"password\":" + EncodeJsonString(records[0]) + "}\n",
+            KeyringHelperMode.Credentials when records.Length == 2 =>
+                "{\"username\":"
+                + EncodeJsonString(records[0])
+                + ",\"password\":"
+                + EncodeJsonString(records[1])
+                + "}\n",
+            _ => throw new InvalidOperationException(
+                "Keyring helper success output does not match the requested mode."
+            ),
+        };
+    }
+
+    private static string EncodeJsonString(string value) =>
+        "\"" + JsonEncodedText.Encode(value).ToString() + "\"";
+
+    private static bool IsInvalidUsername(string? username) =>
+        username is not null
+        && (string.IsNullOrWhiteSpace(username) || username.Any(char.IsControl));
+
+    private static bool IsPotentialAzureArtifactsHost(string host)
+    {
+        if (
+            string.Equals(host, "pkgs.dev.azure.com", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(host, "dev.azure.com", StringComparison.OrdinalIgnoreCase)
+        )
+        {
+            return true;
+        }
+
+        return HasSingleLabelPrefix(host, ".pkgs.visualstudio.com")
+            || HasSingleLabelPrefix(host, ".visualstudio.com");
+    }
+
+    private static bool HasSingleLabelPrefix(string host, string suffix)
+    {
+        if (
+            !host.EndsWith(suffix, StringComparison.OrdinalIgnoreCase)
+            || host.Length <= suffix.Length
+        )
+        {
+            return false;
+        }
+
+        string prefix = host[..^suffix.Length];
+        return !string.IsNullOrWhiteSpace(prefix)
+            && !prefix.Contains('.', StringComparison.Ordinal);
+    }
+
+    private static void WriteText(TextWriter writer, string value)
+    {
+        TextWriter synchronizedWriter = TextWriter.Synchronized(writer);
+        synchronizedWriter.Write(value);
+        synchronizedWriter.Flush();
+    }
+
+    private sealed record KeyringCliRequest(
+        string Service,
+        string? Username,
+        KeyringHelperMode Mode,
+        string Output
+    );
+
+}

--- a/src/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform/Composition/CredentialProviderCompositionRoot.cs
+++ b/src/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform/Composition/CredentialProviderCompositionRoot.cs
@@ -270,6 +270,8 @@ public sealed class CredentialProviderCompositionRoot
 
     public KeyringHelperAdapter CreateKeyringHelperAdapter() => new(boundary);
 
+    public KeyringCliAdapter CreateKeyringCliAdapter() => new(boundary);
+
     public GitPhase8VerticalSliceService CreateGitService(
         GitPhase8VerticalSliceOptions? options = null
     ) =>

--- a/src/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform/VerticalSlice/ConfigurationPhase14VerticalSliceService.cs
+++ b/src/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform/VerticalSlice/ConfigurationPhase14VerticalSliceService.cs
@@ -3172,8 +3172,13 @@ public sealed class ConfigurationPhase14VerticalSliceService
         + GetPythonHelperPlatform()
         + "\"}\n";
 
-    private static string CreatePosixKeyringShimValue() =>
-        "#!/bin/sh\nexec azureauth-keyring \"$@\"\n";
+    private string CreatePosixKeyringShimValue() =>
+        "#!/bin/sh\nexec "
+        + QuotePosixShellArgument(GetRequiredProductExecutablePath())
+        + " keyring \"$@\"\n";
+
+    private static string QuotePosixShellArgument(string value) =>
+        "'" + value.Replace("'", "'\"'\"'", StringComparison.Ordinal) + "'";
 
     private string GetRequiredProductExecutablePath() =>
         productExecutablePath

--- a/src/private/app/azureauth-credprovider/docs/high-level-design.md
+++ b/src/private/app/azureauth-credprovider/docs/high-level-design.md
@@ -243,10 +243,10 @@ keyring get <service> <username>    # stdout is the password
 keyring get <service> --mode creds  # stdout is newline-separated username and password
 ```
 
-The product-owned shim delegates to the wheel-provided `azureauth-keyring`
-console script. This separates uv and pip's PATH-based executable discovery from
-the backend's absolute product-apphost invocation. It must print only the
-expected keyring response to stdout.
+The product-owned shim delegates directly to the installed apphost's `keyring`
+protocol entry point. This removes the project-environment bootstrap cycle for
+uv and pip subprocess mode while keeping import-mode backend installation
+explicit. It must print only the expected keyring response to stdout.
 
 The current production shim is POSIX-only. Windows import-mode configuration
 still writes the backend manifest, but Windows subprocess mode remains deferred

--- a/src/private/app/azureauth-credprovider/docs/mid-level-design.md
+++ b/src/private/app/azureauth-credprovider/docs/mid-level-design.md
@@ -640,8 +640,9 @@ isolation.
 ### Keyring Executable Shim
 
 On POSIX platforms, `configure python` also creates a product-owned `keyring`
-shim. The shim delegates to the wheel-provided `azureauth-keyring` console script
-from the activated Python environment. It is activated through controlled PATH
+shim. The shim delegates directly to the installed product apphost's `keyring`
+protocol entry point, so uv and pip subprocess mode do not depend on an already
+synchronized project environment. It is activated through controlled PATH
 ordering; it is not the absolute credential helper recorded in the backend
 manifest.
 
@@ -656,11 +657,12 @@ The shim must support the command forms observed in local experiments:
 ```text
 keyring get <service> <username>
 keyring get <service> --mode creds
+keyring --mode=creds --output=json get <service> [<username>]
 ```
 
 For password-only mode, stdout is the password. For `--mode creds`, stdout is
-newline-separated username and password. No diagnostics may be written to
-stdout.
+newline-separated username and password unless JSON output is requested. No
+diagnostics may be written to stdout.
 
 ### Request Mapping
 
@@ -669,7 +671,7 @@ stdout.
 | `service` URL             | Host, organization, project, feed, endpoint kind, and token audience. |
 | `username`                | Account hint or protocol username depending on tool mode.             |
 | `--mode creds`            | Request both username and password material.                          |
-| Active Python environment | Bootstrap and doctor target scope.                                    |
+| Active Python environment | Import-mode backend and doctor target scope.                          |
 
 pip subprocess mode requires a username in the index URL and may ignore a shim
 installed only into the current Python environment's scripts directory. uv

--- a/src/private/app/azureauth-credprovider/docs/phase-wp16-deployment-validation-bundle.md
+++ b/src/private/app/azureauth-credprovider/docs/phase-wp16-deployment-validation-bundle.md
@@ -58,8 +58,10 @@ Physical installation does not mutate global PATH, shell profiles, the Windows
 registry, Git configuration, NuGet configuration, or Python environments. The
 wheel must be installed into the exact Python environment that imports the
 backend. On Linux, `configure python` then writes the backend manifest and
-controlled-PATH `keyring` shim. Default installation roots are disjoint from
-those configuration targets, so payload replacement does not erase owned Python
+controlled-PATH `keyring` shim. The shim invokes the installed apphost directly,
+so uv and pip subprocess mode can authenticate before a project environment has
+been synchronized. Default installation roots are disjoint from those
+configuration targets, so payload replacement does not erase owned Python
 configuration.
 
 ## Lifecycle

--- a/src/private/app/azureauth-credprovider/docs/requirements.md
+++ b/src/private/app/azureauth-credprovider/docs/requirements.md
@@ -121,10 +121,10 @@ Host tools own:
 5. Support Azure Artifacts Python simple-index and upload endpoints in both organization-scoped and project-scoped forms.
 6. Provide supported bootstrap paths that make the Python keyring backend discoverable in the exact Python environment running pip or twine, including virtual environments, pipx-managed tools, and isolated CI environments.
 7. Configure the backend with the installed product apphost's absolute path and
-   provide a separate controlled-PATH `keyring` shim that delegates to the
-   wheel-provided `azureauth-keyring` console script; Windows subprocess mode
-   requires a real `.exe` launcher and remains deferred until that launcher is
-   implemented and validated.
+   provide a separate controlled-PATH `keyring` shim that delegates directly to
+   the installed apphost without requiring a project Python environment; Windows
+   subprocess mode requires a real `.exe` launcher and remains deferred until
+   that launcher is implemented and validated.
 
 ### npm, pnpm, and Yarn
 

--- a/src/private/app/azureauth-credprovider/python/README.md
+++ b/src/private/app/azureauth-credprovider/python/README.md
@@ -15,10 +15,12 @@ protocol major, product ID, current platform, and absolute path to the installed
 <absolute-product-apphost> python-keyring get ...
 ```
 
-The wheel provides the `azureauth-keyring` console script. Product configuration
-also creates a controlled-PATH POSIX `keyring` shim that delegates uv and pip
-subprocess calls to that script. Windows import mode is supported by the backend
-manifest, while Windows subprocess mode remains deferred until a real
+The wheel provides the `azureauth-keyring` console script for direct package
+testing and import-mode environments. Product configuration creates a
+controlled-PATH POSIX `keyring` shim that delegates uv and pip subprocess calls
+directly to the installed product apphost, avoiding a dependency on the project
+environment being synchronized first. Windows import mode is supported by the
+backend manifest, while Windows subprocess mode remains deferred until a real
 `keyring.exe` launcher is implemented. Installing the deployment bundle copies
 this wheel into the product installation but does not install it into a Python
 environment automatically.

--- a/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Cli.Tests/CliApplicationTests.cs
+++ b/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Cli.Tests/CliApplicationTests.cs
@@ -1050,6 +1050,27 @@ public sealed class CliApplicationTests
                 ),
                 TestContext.Current.CancellationToken
             );
+            ProcessResult unsupportedKeyringHost = await runner.RunAsync(
+                new ProcessStartSpec(
+                    CliAppHostPath(),
+                    ["keyring", "get", "https://example.com/simple/", "requested-user"],
+                    environment: environment
+                ),
+                TestContext.Current.CancellationToken
+            );
+            ProcessResult unsupportedLegacyKeyringHost = await runner.RunAsync(
+                new ProcessStartSpec(
+                    CliAppHostPath(),
+                    [
+                        "keyring",
+                        "get",
+                        "https://foo.bar.visualstudio.com/_packaging/feed/pypi/simple/",
+                        "requested-user",
+                    ],
+                    environment: environment
+                ),
+                TestContext.Current.CancellationToken
+            );
             ProcessResult help = await runner.RunAsync(
                 new ProcessStartSpec(CliAppHostPath(), ["--help"], environment: environment),
                 TestContext.Current.CancellationToken
@@ -1146,6 +1167,12 @@ public sealed class CliApplicationTests
                 StringComparison.Ordinal
             );
             Assert.DoesNotContain(SecretMarker, protocol.StandardError, StringComparison.Ordinal);
+            Assert.Equal(1, unsupportedKeyringHost.ExitCode);
+            Assert.Equal(string.Empty, unsupportedKeyringHost.StandardOutput);
+            Assert.Equal(string.Empty, unsupportedKeyringHost.StandardError);
+            Assert.Equal(1, unsupportedLegacyKeyringHost.ExitCode);
+            Assert.Equal(string.Empty, unsupportedLegacyKeyringHost.StandardOutput);
+            Assert.Equal(string.Empty, unsupportedLegacyKeyringHost.StandardError);
             Assert.Equal(0, help.ExitCode);
             Assert.Contains("Usage:", help.StandardOutput, StringComparison.Ordinal);
             Assert.DoesNotContain(SecretMarker, help.StandardError, StringComparison.Ordinal);
@@ -8101,6 +8128,46 @@ public sealed class CliApplicationTests
         Assert.DoesNotContain("export PATH=", result.StdErr, StringComparison.Ordinal);
         Assert.Equal(before, fixture.GetFileSystemEntries());
         Assert.Equal(2, fixture.Runner.StartSpecs.Count);
+    }
+
+    [Fact(
+        Skip = "POSIX keyring subprocess bootstrap is unsupported on Windows.",
+        SkipWhen = nameof(IsWindows)
+    )]
+    public void HandleConfigure_OnPosixWithoutExplicitImportPreflight_ConfiguresBootstrapShim()
+    {
+        using var fixture = new Phase3ConfigureFixture(productHealthy: false);
+        ConfigurationPhase14VerticalSliceOptions configurationOptions =
+            fixture.ConfigurationOptions with
+            {
+                PythonDoctorService = null,
+            };
+        var runtime = new CliRuntimeOptions
+        {
+            CompositionRoot = CreateTestCompositionRoot(),
+            ConfigurationPhase14Options = configurationOptions,
+        };
+
+        CommandResult result = InvokeWithRuntime(runtime, "configure", "python");
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal(string.Empty, result.StdErr);
+        Assert.Empty(fixture.Runner.StartSpecs);
+        string shimPath = Path.Combine(
+            fixture.HomePath,
+            ".local",
+            "share",
+            "azureauth-credprovider",
+            "keyring-shim",
+            "keyring"
+        );
+        Assert.Equal(
+            "#!/bin/sh\nexec '/opt/azureauth-credprovider/azureauth-credprovider' "
+                + "keyring \"$@\"\n",
+            File.ReadAllText(shimPath)
+        );
+        Assert.Contains("export PATH=", result.StdOut, StringComparison.Ordinal);
+        Assert.DoesNotContain("bootstrap-command:", result.StdErr, StringComparison.Ordinal);
     }
 
     [Theory(

--- a/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform.Tests/ConfigurationPhase14VerticalSliceServiceTests.cs
+++ b/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform.Tests/ConfigurationPhase14VerticalSliceServiceTests.cs
@@ -1839,10 +1839,45 @@ public sealed class ConfigurationPhase14VerticalSliceServiceTests
         {
             ConfigurationPlannedChange shimChange = Assert.Single(result.PlanResults[1].Changes);
             Assert.Equal(
-                "#!/bin/sh\nexec azureauth-keyring \"$@\"\n",
+                "#!/bin/sh\nexec '/opt/azureauth-credprovider/azureauth-credprovider' "
+                    + "keyring \"$@\"\n",
                 fileSystem.ReadAllText(shimChange.TargetPathOrName)
             );
         }
+    }
+
+    [Fact]
+    public async Task ConfigurePythonQuotesInstalledApphostPathInPosixShim()
+    {
+        var fileSystem = new InMemoryFileSystem(InMemoryPathSemantics.Posix);
+        const string ProductPath =
+            "/opt/azure auth/owner's tools/azureauth-credprovider";
+        var service = new ConfigurationPhase14VerticalSliceService(
+            new ConfigurationPhase14VerticalSliceOptions
+            {
+                FileSystem = fileSystem,
+                StateDirectoryPath = "/state/phase14",
+                EnvironmentVariableReader = name =>
+                    string.Equals(name, "HOME", StringComparison.Ordinal)
+                        ? "/home/test"
+                        : null,
+                ProductExecutablePath = ProductPath,
+                WorkspaceDirectoryPath = "/workspace",
+            }
+        );
+
+        ConfigurationPhase14PlanResult result = await service.ConfigureAsync(
+            CredentialEcosystem.Python,
+            ConfigurationPhase14Scope.User,
+            TestContext.Current.CancellationToken
+        );
+
+        ConfigurationPlannedChange shimChange = Assert.Single(result.PlanResults[1].Changes);
+        Assert.Equal(
+            "#!/bin/sh\nexec '/opt/azure auth/owner'\"'\"'s tools/"
+                + "azureauth-credprovider' keyring \"$@\"\n",
+            fileSystem.ReadAllText(shimChange.TargetPathOrName)
+        );
     }
 
     [Fact]

--- a/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform.Tests/KeyringHelperAdapterTests.cs
+++ b/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform.Tests/KeyringHelperAdapterTests.cs
@@ -4,6 +4,7 @@ using Hcoona.AzureAuth.CredProvider.Platform.Composition;
 using Hcoona.AzureAuth.CredProvider.Platform.CredentialCore;
 using Hcoona.AzureAuth.CredProvider.Platform.Diagnostics;
 using Hcoona.AzureAuth.CredProvider.Platform.Redaction;
+using System.Text.Json;
 using Xunit;
 
 namespace Hcoona.AzureAuth.CredProvider.Platform.Tests;
@@ -366,6 +367,192 @@ public sealed class KeyringHelperAdapterTests
         );
     }
 
+    [Fact]
+    public void KeyringCliCredentialsJsonModeUsesSharedSilentHelperPath()
+    {
+        var provider = new SuccessfulAcquisitionService(
+            "Azure\"DevOps\\user",
+            "phase11-\"secret\\value"
+        );
+
+        AdapterRunResult result = ExecuteKeyringCli(
+            [
+                "--mode=creds",
+                "--output=json",
+                "get",
+                "https://pkgs.dev.azure.com/org/_packaging/feed/pypi/simple/",
+            ],
+            provider
+        );
+
+        Assert.Equal(AdapterHostExitCode.Success, result.Outcome.Result.ExitCode);
+        Assert.Empty(result.HumanStdout);
+        Assert.Equal(string.Empty, result.Stderr);
+        using JsonDocument payload = JsonDocument.Parse(result.ProtocolStdout);
+        Assert.Equal(
+            "Azure\"DevOps\\user",
+            payload.RootElement.GetProperty("username").GetString()
+        );
+        Assert.Equal(
+            "phase11-\"secret\\value",
+            payload.RootElement.GetProperty("password").GetString()
+        );
+        Assert.DoesNotContain("phase11-", result.Stderr, StringComparison.Ordinal);
+
+        CredentialRequestV2 request = Assert.Single(provider.Requests);
+        Assert.Equal("creds", request.ExtensionData["python.keyring.mode"]);
+        Assert.Equal(InteractivePolicy.Never, request.InteractivePolicy);
+        Assert.Equal(AcquisitionMode.SilentOnly, request.AcquisitionMode);
+    }
+
+    [Fact]
+    public void KeyringCliPasswordModeSupportsPipSubprocessShape()
+    {
+        var provider = new SuccessfulAcquisitionService();
+
+        AdapterRunResult result = ExecuteKeyringCli(
+            [
+                "get",
+                "https://pkgs.dev.azure.com/org/_packaging/feed/pypi/simple/",
+                "requested-user",
+            ],
+            provider
+        );
+
+        Assert.Equal(AdapterHostExitCode.Success, result.Outcome.Result.ExitCode);
+        Assert.Equal("phase11-secret\n", result.ProtocolStdout);
+        Assert.Empty(result.HumanStdout);
+        Assert.Equal(string.Empty, result.Stderr);
+        CredentialRequestV2 request = Assert.Single(provider.Requests);
+        Assert.Equal("password", request.ExtensionData["python.keyring.mode"]);
+    }
+
+    [Fact]
+    public void KeyringCliPasswordModeWithoutUsernameFailsClosed()
+    {
+        var provider = new SuccessfulAcquisitionService();
+
+        AdapterRunResult result = ExecuteKeyringCli(
+            [
+                "get",
+                "https://pkgs.dev.azure.com/org/_packaging/feed/pypi/simple/",
+            ],
+            provider
+        );
+
+        Assert.Equal(AdapterHostExitCode.ConfigurationError, result.Outcome.Result.ExitCode);
+        Assert.Equal(string.Empty, result.ProtocolStdout);
+        Assert.Empty(result.HumanStdout);
+        Assert.Contains("code=ProtocolViolation", result.Stderr, StringComparison.Ordinal);
+        Assert.Equal(0, provider.InvocationCount);
+    }
+
+    [Fact]
+    public void KeyringCliUnsupportedHostReturnsNoCredentialWithoutAcquisition()
+    {
+        var provider = new SuccessfulAcquisitionService();
+
+        AdapterRunResult result = ExecuteKeyringCli(
+            ["--mode=creds", "get", "https://example.com/simple/"],
+            provider
+        );
+
+        Assert.Equal(AdapterHostExitCode.NoCredential, result.Outcome.Result.ExitCode);
+        Assert.Equal(string.Empty, result.ProtocolStdout);
+        Assert.Empty(result.HumanStdout);
+        Assert.Equal(string.Empty, result.Stderr);
+        Assert.Equal(0, provider.InvocationCount);
+    }
+
+    [Theory]
+    [InlineData("unrelated-service")]
+    [InlineData(" https://pkgs.dev.azure.com/org/_packaging/feed/pypi/simple/ ")]
+    public void KeyringCliMalformedServiceFailsClosed(string service)
+    {
+        var provider = new SuccessfulAcquisitionService();
+
+        AdapterRunResult result = ExecuteKeyringCli(
+            ["get", service, "requested-user"],
+            provider
+        );
+
+        Assert.Equal(AdapterHostExitCode.ConfigurationError, result.Outcome.Result.ExitCode);
+        Assert.Equal(string.Empty, result.ProtocolStdout);
+        Assert.Empty(result.HumanStdout);
+        Assert.Contains("code=ProtocolViolation", result.Stderr, StringComparison.Ordinal);
+        Assert.Equal(0, provider.InvocationCount);
+    }
+
+    [Theory]
+    [InlineData("   ")]
+    [InlineData("bad\u0001user")]
+    public void KeyringCliInvalidUsernameFailsClosed(string username)
+    {
+        var provider = new SuccessfulAcquisitionService();
+
+        AdapterRunResult result = ExecuteKeyringCli(
+            [
+                "get",
+                "https://pkgs.dev.azure.com/org/_packaging/feed/pypi/simple/",
+                username,
+            ],
+            provider
+        );
+
+        Assert.Equal(AdapterHostExitCode.ConfigurationError, result.Outcome.Result.ExitCode);
+        Assert.Equal(string.Empty, result.ProtocolStdout);
+        Assert.Empty(result.HumanStdout);
+        Assert.Contains("code=ProtocolViolation", result.Stderr, StringComparison.Ordinal);
+        Assert.Equal(0, provider.InvocationCount);
+    }
+
+    [Fact]
+    public void KeyringCliInvalidArgumentsFailWithoutEchoingUserInput()
+    {
+        const string SecretUsername = "must-not-leak-keyring-argument";
+        var provider = new SuccessfulAcquisitionService();
+
+        AdapterRunResult result = ExecuteKeyringCli(
+            [
+                "--output=plaintext",
+                "get",
+                "https://pkgs.dev.azure.com/org/_packaging/feed/pypi/simple/",
+                SecretUsername,
+            ],
+            provider
+        );
+
+        Assert.Equal(AdapterHostExitCode.ConfigurationError, result.Outcome.Result.ExitCode);
+        Assert.Equal(string.Empty, result.ProtocolStdout);
+        Assert.Empty(result.HumanStdout);
+        Assert.DoesNotContain(SecretUsername, result.Stderr, StringComparison.Ordinal);
+        Assert.Equal(0, provider.InvocationCount);
+    }
+
+    [Fact]
+    public void KeyringCliSharedApphostEntrypointStripsCommandToken()
+    {
+        string[] arguments =
+        [
+            "keyring",
+            "--mode=creds",
+            "get",
+            "https://pkgs.dev.azure.com/org/_packaging/feed/pypi/simple/",
+        ];
+
+        bool resolved = KeyringCliAdapter.TryResolveProtocolInvocation(
+            "/opt/azureauth-credprovider/app/azureauth-credprovider",
+            arguments,
+            out AdapterInvocationContext? context
+        );
+
+        Assert.True(resolved);
+        Assert.NotNull(context);
+        Assert.Equal(["keyring"], context.MatchedArguments);
+        Assert.Equal(arguments[1..], context.PayloadArguments);
+        Assert.Equal(AdapterProtocol.KeyringHelper, context.Protocol);
+    }
+
     private static AdapterRunResult Execute(
         string[] args,
         string executablePath = "/usr/local/bin/python-keyring",
@@ -387,6 +574,36 @@ public sealed class KeyringHelperAdapterTests
                     : new LegacyV1CredentialAcquisitionService(credentialCore)
                 : credentialAcquisition
         ).Execute(executablePath, args, protocolStdout, humanStdout, diagnosticRouter);
+
+        return new AdapterRunResult(
+            outcome,
+            protocolStdout.ToString(),
+            humanStdout.ToString(),
+            stderr.ToString()
+        );
+    }
+
+    private static AdapterRunResult ExecuteKeyringCli(
+        string[] args,
+        ICredentialAcquisitionService credentialAcquisition
+    )
+    {
+        var protocolStdout = new StringWriter();
+        var humanStdout = new StringWriter();
+        var stderr = new StringWriter();
+        var diagnosticRouter = new DiagnosticRouter(
+            [new TextWriterDiagnosticSink(stderr)],
+            SecretRedactor.Empty
+        );
+        AdapterHostExecutionOutcome outcome = new KeyringCliAdapter(
+            credentialAcquisition
+        ).Execute(
+            "/opt/azureauth-credprovider/app/azureauth-credprovider",
+            [KeyringCliAdapter.CommandName, .. args],
+            protocolStdout,
+            humanStdout,
+            diagnosticRouter
+        );
 
         return new AdapterRunResult(
             outcome,
@@ -421,7 +638,10 @@ public sealed class KeyringHelperAdapterTests
         );
     }
 
-    private sealed class SuccessfulAcquisitionService : ICredentialAcquisitionService
+    private sealed class SuccessfulAcquisitionService(
+        string username = "AzureDevOps",
+        string password = "phase11-secret"
+    ) : ICredentialAcquisitionService
     {
         public int InvocationCount => Requests.Count;
 
@@ -437,8 +657,8 @@ public sealed class KeyringHelperAdapterTests
                 new CredentialResult
                 {
                     Status = CredentialResultStatus.Success,
-                    Username = "AzureDevOps",
-                    Password = "phase11-secret",
+                    Username = username,
+                    Password = password,
                     DiagnosticsCorrelationId = "keyring-test",
                 }
             );

--- a/tests/private/app/azureauth-credprovider/Install-DeploymentValidationBundle.Tests.ps1
+++ b/tests/private/app/azureauth-credprovider/Install-DeploymentValidationBundle.Tests.ps1
@@ -467,6 +467,45 @@ function Invoke-ActualUninstallRegression {
             -NuGetPluginRoot $pluginRoot | Out-Null
 
         $productExecutablePath = Join-Path $installRoot "app/$productExecutableName"
+        if (-not $runningOnWindows) {
+            & $productExecutablePath configure python | Out-Null
+            Assert-Equal `
+                -Expected 0 `
+                -Actual $LASTEXITCODE `
+                -Message 'Actual Python subprocess bootstrap configuration failed.'
+
+            $keyringShimPath = Join-Path (
+                Join-Path $environment['XDG_DATA_HOME'] 'azureauth-credprovider/keyring-shim'
+            ) 'keyring'
+            Assert-True (
+                Test-Path -LiteralPath $keyringShimPath -PathType Leaf
+            ) 'Actual Python configuration did not create the keyring shim.'
+            Assert-True (
+                [System.IO.File]::GetUnixFileMode($keyringShimPath).HasFlag(
+                    [System.IO.UnixFileMode]::UserExecute
+                )
+            ) 'Actual Python keyring shim is not executable.'
+            $keyringShimContent = Get-Content -LiteralPath $keyringShimPath -Raw
+            Assert-True (
+                $keyringShimContent.Contains(
+                    $productExecutablePath,
+                    [System.StringComparison]::Ordinal
+                )
+            ) 'Actual Python keyring shim does not bind to the installed apphost.'
+            Assert-True (
+                -not $keyringShimContent.Contains(
+                    'azureauth-keyring',
+                    [System.StringComparison]::Ordinal
+                )
+            ) 'Actual Python keyring shim still depends on a Python environment console script.'
+
+            & $keyringShimPath get 'https://example.com/simple/' 'requested-user' | Out-Null
+            Assert-Equal `
+                -Expected 1 `
+                -Actual $LASTEXITCODE `
+                -Message 'The installed keyring shim did not return no-credential for an unrelated host.'
+        }
+
         $registryUrl = 'https://pkgs.dev.azure.com/example/project/_packaging/feed/npm/registry/'
         Move-Item -LiteralPath $gitMarkerPath -Destination $heldGitMarkerPath
         try {


### PR DESCRIPTION
Route the POSIX keyring subprocess shim through the installed credential-provider apphost so private Python dependencies can authenticate before project packages are synchronized.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>