### PR TITLE
fix(azureauth): Respect Python Interaction Policy

### DIFF
--- a/src/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform/AdapterHost/KeyringCliAdapter.cs
+++ b/src/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform/AdapterHost/KeyringCliAdapter.cs
@@ -21,24 +21,40 @@ public sealed class KeyringCliAdapter
     public KeyringCliAdapter()
         : this(CredentialProviderCompositionRoot.CreateProduction().AcquisitionService) { }
 
-    public KeyringCliAdapter(CredentialCoreService? credentialCore)
+    public KeyringCliAdapter(
+        CredentialCoreService? credentialCore,
+        Func<string, string?>? environmentVariableReader = null
+    )
         : this(
             credentialCore is null
                 ? CredentialProviderCompositionRoot.CreateProduction().AcquisitionService
-                : new LegacyV1CredentialAcquisitionService(credentialCore)
+                : new LegacyV1CredentialAcquisitionService(credentialCore),
+            environmentVariableReader
         )
     { }
 
-    public KeyringCliAdapter(ICredentialAcquisitionService credentialAcquisition)
+    public KeyringCliAdapter(
+        ICredentialAcquisitionService credentialAcquisition,
+        Func<string, string?>? environmentVariableReader = null
+    )
     {
         ArgumentNullException.ThrowIfNull(credentialAcquisition);
-        helperAdapter = new KeyringHelperAdapter(credentialAcquisition);
+        helperAdapter = new KeyringHelperAdapter(
+            credentialAcquisition,
+            environmentVariableReader
+        );
     }
 
-    public KeyringCliAdapter(BoundedCredentialAcquisitionAdapter credentialAcquisition)
+    public KeyringCliAdapter(
+        BoundedCredentialAcquisitionAdapter credentialAcquisition,
+        Func<string, string?>? environmentVariableReader = null
+    )
     {
         ArgumentNullException.ThrowIfNull(credentialAcquisition);
-        helperAdapter = new KeyringHelperAdapter(credentialAcquisition);
+        helperAdapter = new KeyringHelperAdapter(
+            credentialAcquisition,
+            environmentVariableReader
+        );
     }
 
     public static AdapterDescriptor Descriptor { get; } = CreateDescriptor();

--- a/src/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform/AdapterHost/KeyringHelperAdapter.cs
+++ b/src/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform/AdapterHost/KeyringHelperAdapter.cs
@@ -10,29 +10,54 @@ public sealed class KeyringHelperAdapter
 {
     public const string ProductExecutableName = "azureauth-credprovider";
 
+    private const string ArtifactsKeyringNonInteractiveEnvironmentVariable =
+        "ARTIFACTS_KEYRING_NONINTERACTIVE_MODE";
     private const string DefaultServiceIdentity = "default";
     private const string ProtocolViolationCode = "ProtocolViolation";
+    private const string ProductNoUserEnvironmentVariable = "AZUREAUTH_NO_USER";
     private const string UnsupportedHostCode = "UnsupportedHost";
 
     private readonly BoundedCredentialAcquisitionAdapter credentialAcquisition;
+    private readonly Func<string, string?> environmentVariableReader;
 
     public KeyringHelperAdapter()
-        : this(CredentialProviderCompositionRoot.CreateProduction().AcquisitionService) { }
+        : this(
+            CredentialProviderCompositionRoot.CreateProduction().AcquisitionService,
+            Environment.GetEnvironmentVariable
+        )
+    { }
 
-    public KeyringHelperAdapter(CredentialCoreService? credentialCore)
+    public KeyringHelperAdapter(
+        CredentialCoreService? credentialCore,
+        Func<string, string?>? environmentVariableReader = null
+    )
         : this(
             credentialCore is null
                 ? CredentialProviderCompositionRoot.CreateProduction().AcquisitionService
-                : new LegacyV1CredentialAcquisitionService(credentialCore)
-        ) { }
+                : new LegacyV1CredentialAcquisitionService(credentialCore),
+            environmentVariableReader
+        )
+    { }
 
-    public KeyringHelperAdapter(ICredentialAcquisitionService credentialAcquisition)
-        : this(new BoundedCredentialAcquisitionAdapter(credentialAcquisition)) { }
+    public KeyringHelperAdapter(
+        ICredentialAcquisitionService credentialAcquisition,
+        Func<string, string?>? environmentVariableReader = null
+    )
+        : this(
+            new BoundedCredentialAcquisitionAdapter(credentialAcquisition),
+            environmentVariableReader
+        )
+    { }
 
-    public KeyringHelperAdapter(BoundedCredentialAcquisitionAdapter credentialAcquisition)
+    public KeyringHelperAdapter(
+        BoundedCredentialAcquisitionAdapter credentialAcquisition,
+        Func<string, string?>? environmentVariableReader = null
+    )
     {
         ArgumentNullException.ThrowIfNull(credentialAcquisition);
         this.credentialAcquisition = credentialAcquisition;
+        this.environmentVariableReader =
+            environmentVariableReader ?? Environment.GetEnvironmentVariable;
     }
 
     public static AdapterDescriptor Descriptor { get; } = CreateDescriptor();
@@ -144,7 +169,11 @@ public sealed class KeyringHelperAdapter
             return CreateProtocolViolationOutput();
         }
 
-        CredentialRequestV2 credentialRequest = CreateCredentialRequest(helperRequest, resource);
+        CredentialRequestV2 credentialRequest = CreateCredentialRequest(
+            helperRequest,
+            resource,
+            IsNonInteractiveRequest()
+        );
         CredentialResult credentialResult = credentialAcquisition.Acquire(credentialRequest);
         KeyringHelperResponse response = KeyringHelperV2.ToResponse(
             helperRequest,
@@ -229,7 +258,8 @@ public sealed class KeyringHelperAdapter
 
     private static CredentialRequestV2 CreateCredentialRequest(
         KeyringHelperRequest helperRequest,
-        CanonicalResourceIdentity resource
+        CanonicalResourceIdentity resource,
+        bool isNonInteractive
     )
     {
         return new CredentialRequestV2
@@ -242,8 +272,12 @@ public sealed class KeyringHelperAdapter
             RequestedAudience = TokenAudience.AzureArtifacts,
             CredentialKind = CredentialKind.BasicPassword,
             IdentityFlow = IdentityFlow.InteractiveBrowser,
-            InteractivePolicy = InteractivePolicy.Never,
-            AcquisitionMode = AcquisitionMode.SilentOnly,
+            InteractivePolicy = isNonInteractive
+                ? InteractivePolicy.Never
+                : InteractivePolicy.UserAllowed,
+            AcquisitionMode = isNonInteractive
+                ? AcquisitionMode.SilentOnly
+                : AcquisitionMode.InteractionAllowed,
             CachePolicy = CachePolicyMode.ProductPersistentCacheDisabled,
             CiContext = new CiContext { ExplicitCiMode = false, AllowsPersistentWrites = false },
             ExtensionData = new Dictionary<string, string>(StringComparer.Ordinal)
@@ -253,6 +287,20 @@ public sealed class KeyringHelperAdapter
             },
         };
     }
+
+    private bool IsNonInteractiveRequest() =>
+        IsArtifactsKeyringNonInteractiveModeEnabled(
+            environmentVariableReader(ArtifactsKeyringNonInteractiveEnvironmentVariable)
+        )
+        || IsAzureAuthNoUserEnabled(
+            environmentVariableReader(ProductNoUserEnvironmentVariable)
+        );
+
+    private static bool IsArtifactsKeyringNonInteractiveModeEnabled(string? value) =>
+        string.Equals(value, "true", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsAzureAuthNoUserEnabled(string? value) =>
+        !string.IsNullOrEmpty(value);
 
     private static PythonFeedResourceClassification ClassifyPythonFeedResource(
         Uri service,

--- a/src/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform/Composition/CredentialProviderCompositionRoot.cs
+++ b/src/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform/Composition/CredentialProviderCompositionRoot.cs
@@ -268,9 +268,11 @@ public sealed class CredentialProviderCompositionRoot
 
     public NuGetPluginAdapter CreateNuGetPluginAdapter() => new(boundary);
 
-    public KeyringHelperAdapter CreateKeyringHelperAdapter() => new(boundary);
+    public KeyringHelperAdapter CreateKeyringHelperAdapter() =>
+        new(boundary, ProductionOptions.EnvironmentVariableReader);
 
-    public KeyringCliAdapter CreateKeyringCliAdapter() => new(boundary);
+    public KeyringCliAdapter CreateKeyringCliAdapter() =>
+        new(boundary, ProductionOptions.EnvironmentVariableReader);
 
     public GitPhase8VerticalSliceService CreateGitService(
         GitPhase8VerticalSliceOptions? options = null

--- a/src/private/app/azureauth-credprovider/docs/high-level-design.md
+++ b/src/private/app/azureauth-credprovider/docs/high-level-design.md
@@ -204,9 +204,10 @@ For an interactive request, `CanShowDialog=true` selects browser interaction.
 `CanShowDialog=false` selects device code, but the NuGet plugin process does not
 own a human terminal prompt stream and therefore rejects that flow before
 launch. Explicit native Linux CLI login does own such a stream and supports
-device code. Git and Python helper protocols do not authorize interaction, so
-those adapters remain silent-only rather than inferring permission from the
-environment.
+device code. Git helper requests remain silent-only. Python keyring requests
+allow browser interaction by default and become silent-only when
+`ARTIFACTS_KEYRING_NONINTERACTIVE_MODE` is exactly `true`, ignoring case, or
+when `AZUREAUTH_NO_USER` has any non-empty value.
 
 ## Python Adapter
 

--- a/src/private/app/azureauth-credprovider/docs/mid-level-design.md
+++ b/src/private/app/azureauth-credprovider/docs/mid-level-design.md
@@ -889,7 +889,14 @@ future flows.
 
 Ecosystem adapters inherit this policy from the credential core. They may further
 restrict interaction based on host-tool protocol flags, such as NuGet
-non-interactive restore settings or keyring subprocess behavior.
+non-interactive restore settings. Python keyring requests allow interactive
+browser acquisition by default. `ARTIFACTS_KEYRING_NONINTERACTIVE_MODE` enables
+silent-only behavior only when its value is `true`, ignoring case.
+`AZUREAUTH_NO_USER` retains AzureAuth's separate contract in which any non-empty
+value suppresses interaction. `PIP_NO_INPUT` and `TWINE_NON_INTERACTIVE` are not
+provider-wide signals because the shared keyring protocol cannot identify its
+pip, uv, or Twine caller. The adapter does not infer policy from TTY state or
+parent process arguments.
 
 ### Token Handling
 

--- a/src/private/app/azureauth-credprovider/docs/phase-wp6-production-composition.md
+++ b/src/private/app/azureauth-credprovider/docs/phase-wp6-production-composition.md
@@ -99,23 +99,35 @@ Interactive and silent readiness remain independent.
 
 ## Host interaction routing
 
-Interaction is authorized only by an explicit host protocol signal:
+Interaction is bounded by host protocol capabilities and explicit
+non-interactive environment signals:
 
-| Host request                                       | Identity flow | Policy           | Acquisition mode     |
-| -------------------------------------------------- | ------------- | ---------------- | -------------------- |
-| NuGet `IsNonInteractive=true`                      | Browser       | `Never`          | `SilentOnly`         |
-| NuGet interactive and `CanShowDialog=true`         | Browser       | `HostToolAllows` | `InteractionAllowed` |
-| NuGet interactive and `CanShowDialog=false`        | Device code   | `HostToolAllows` | `InteractionAllowed` |
-| Git credential helper or Python keyring subprocess | Browser       | `Never`          | `SilentOnly`         |
+| Host request                                                | Identity flow | Policy           | Acquisition mode     |
+| ----------------------------------------------------------- | ------------- | ---------------- | -------------------- |
+| NuGet `IsNonInteractive=true`                               | Browser       | `Never`          | `SilentOnly`         |
+| NuGet interactive and `CanShowDialog=true`                  | Browser       | `HostToolAllows` | `InteractionAllowed` |
+| NuGet interactive and `CanShowDialog=false`                 | Device code   | `HostToolAllows` | `InteractionAllowed` |
+| Git credential helper                                       | Browser       | `Never`          | `SilentOnly`         |
+| Python keyring default local request                        | Browser       | `UserAllowed`    | `InteractionAllowed` |
+| Python keyring with an explicit non-interactive environment | Browser       | `Never`          | `SilentOnly`         |
 
 NuGet's non-interactive flag overrides dialog capability. The product does not
 attach the CLI human prompt stream to NuGet plugin execution, so that NuGet
 request shape remains unavailable before process launch. Explicit native Linux
 `login --device-code` attaches the CLI stderr stream and tees AzureAuth's bounded
-device-code instructions in real time while keeping token stdout private. Git
-and Python expose no equivalent trustworthy interaction authorization signal;
-the product does not infer one from a terminal, environment variable, or process
-ancestry.
+device-code instructions in real time while keeping token stdout private.
+Python keyring follows the ecosystem's interactive-backend behavior by default.
+It becomes silent-only when `ARTIFACTS_KEYRING_NONINTERACTIVE_MODE` is `true`
+(case-insensitive), matching the upstream artifacts-keyring contract, or when
+the existing `AZUREAUTH_NO_USER` signal has any non-empty value. Unset, empty,
+`false`, `1`, and malformed dedicated-keyring values remain interactive.
+`PIP_NO_INPUT` and `TWINE_NON_INTERACTIVE` alone do not suppress requests:
+keyring's shared shim protocol exposes no trustworthy caller interaction bit,
+and the corresponding CLI options are not reliably exported. Forced
+non-interactive pip or Twine keyring calls must therefore set
+`ARTIFACTS_KEYRING_NONINTERACTIVE_MODE=true`. The product does not inspect
+parent process arguments, infer policy from a terminal, or select device code
+for keyring requests.
 
 ## Persistence
 

--- a/src/private/app/azureauth-credprovider/python/README.md
+++ b/src/private/app/azureauth-credprovider/python/README.md
@@ -24,3 +24,11 @@ backend manifest, while Windows subprocess mode remains deferred until a real
 `keyring.exe` launcher is implemented. Installing the deployment bundle copies
 this wheel into the product installation but does not install it into a Python
 environment automatically.
+
+Keyring requests allow browser interaction by default. Set
+`ARTIFACTS_KEYRING_NONINTERACTIVE_MODE=true` to force silent-only acquisition;
+other values do not enable that mode. `AZUREAUTH_NO_USER` also suppresses
+interaction when it has any non-empty value. `PIP_NO_INPUT` and
+`TWINE_NON_INTERACTIVE` are not sufficient because the shared keyring protocol
+does not expose a trustworthy pip, uv, or Twine interaction flag. Forced
+non-interactive pip and Twine calls must set the dedicated keyring variable.

--- a/src/private/app/azureauth-credprovider/python/tests/test_backend_and_shim.py
+++ b/src/private/app/azureauth-credprovider/python/tests/test_backend_and_shim.py
@@ -885,10 +885,10 @@ def _runtime_platform() -> str:
     return PLATFORM_LINUX
 
 
-def test_invoke_helper_executes_shared_cli_argv_without_auth(
+def test_invoke_helper_executes_shared_cli_argv_with_inherited_environment(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Invoke the validated apphost noninteractively with shared CLI argv."""
+    """Invoke the apphost without replacing its inherited environment."""
     contract = HelperContract(
         contract_major=CONTRACT_MAJOR,
         product_id=PRODUCT_ID,

--- a/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform.Tests/CredentialProviderCompositionRootKeyringTests.cs
+++ b/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform.Tests/CredentialProviderCompositionRootKeyringTests.cs
@@ -1,0 +1,115 @@
+using Hcoona.AzureAuth.CredProvider.Contracts;
+using Hcoona.AzureAuth.CredProvider.Platform.AdapterHost;
+using Hcoona.AzureAuth.CredProvider.Platform.Composition;
+using Hcoona.AzureAuth.CredProvider.Platform.CredentialCore;
+using Hcoona.AzureAuth.CredProvider.Platform.Diagnostics;
+using Hcoona.AzureAuth.CredProvider.Platform.Redaction;
+using Xunit;
+
+namespace Hcoona.AzureAuth.CredProvider.Platform.Tests;
+
+public sealed class CredentialProviderCompositionRootKeyringTests
+{
+    private const string ArtifactsKeyringNonInteractiveMode =
+        "ARTIFACTS_KEYRING_NONINTERACTIVE_MODE";
+    private const string Service = "https://pkgs.dev.azure.com/org/_packaging/feed/pypi/simple/";
+
+    [Fact]
+    public void CreateKeyringHelperAdapterUsesProductionEnvironmentVariableReader()
+    {
+        var acquisition = new RecordingAcquisitionService();
+        var environment = new RecordingEnvironmentVariableReader();
+        CredentialProviderCompositionRoot root = CreateRoot(acquisition, environment);
+        KeyringHelperRequest request = new()
+        {
+            Command = KeyringHelperV2.CommandName,
+            Service = new Uri(Service),
+            Mode = KeyringHelperMode.Password,
+        };
+
+        AdapterHostExecutionOutcome outcome = root.CreateKeyringHelperAdapter()
+            .Execute(
+                "/usr/local/bin/python-keyring",
+                KeyringHelperV2.BuildArguments(request).Skip(1).ToArray(),
+                new StringWriter(),
+                new StringWriter(),
+                CreateDiagnosticRouter()
+            );
+
+        Assert.Equal(AdapterHostExitCode.Success, outcome.Result.ExitCode);
+        AssertSilentRequest(acquisition);
+        Assert.Equal([ArtifactsKeyringNonInteractiveMode], environment.RequestedVariables);
+    }
+
+    [Fact]
+    public void CreateKeyringCliAdapterUsesProductionEnvironmentVariableReader()
+    {
+        var acquisition = new RecordingAcquisitionService();
+        var environment = new RecordingEnvironmentVariableReader();
+        CredentialProviderCompositionRoot root = CreateRoot(acquisition, environment);
+
+        AdapterHostExecutionOutcome outcome = root.CreateKeyringCliAdapter()
+            .Execute(
+                "/opt/azureauth-credprovider/app/azureauth-credprovider",
+                [KeyringCliAdapter.CommandName, "get", Service, "requested-user"],
+                new StringWriter(),
+                new StringWriter(),
+                CreateDiagnosticRouter()
+            );
+
+        Assert.Equal(AdapterHostExitCode.Success, outcome.Result.ExitCode);
+        AssertSilentRequest(acquisition);
+        Assert.Equal([ArtifactsKeyringNonInteractiveMode], environment.RequestedVariables);
+    }
+
+    private static CredentialProviderCompositionRoot CreateRoot(
+        RecordingAcquisitionService acquisition,
+        RecordingEnvironmentVariableReader environment
+    ) =>
+        CredentialProviderCompositionRoot.CreateExplicitTestScaffold(
+            acquisition,
+            new CredentialProviderProductionOptions { EnvironmentVariableReader = environment.Read }
+        );
+
+    private static DiagnosticRouter CreateDiagnosticRouter() => new([], SecretRedactor.Empty);
+
+    private static void AssertSilentRequest(RecordingAcquisitionService acquisition)
+    {
+        CredentialRequestV2 request = Assert.Single(acquisition.Requests);
+        Assert.Equal(InteractivePolicy.Never, request.InteractivePolicy);
+        Assert.Equal(AcquisitionMode.SilentOnly, request.AcquisitionMode);
+    }
+
+    private sealed class RecordingEnvironmentVariableReader
+    {
+        public List<string> RequestedVariables { get; } = [];
+
+        public string? Read(string name)
+        {
+            RequestedVariables.Add(name);
+            return name == ArtifactsKeyringNonInteractiveMode ? "true" : null;
+        }
+    }
+
+    private sealed class RecordingAcquisitionService : ICredentialAcquisitionService
+    {
+        public List<CredentialRequestV2> Requests { get; } = [];
+
+        public ValueTask<CredentialResult> AcquireAsync(
+            CredentialRequestV2 request,
+            CancellationToken cancellationToken = default
+        )
+        {
+            Requests.Add(request);
+            return ValueTask.FromResult(
+                new CredentialResult
+                {
+                    Status = CredentialResultStatus.Success,
+                    Username = "AzureDevOps",
+                    Password = "composition-secret",
+                    DiagnosticsCorrelationId = "composition-keyring-test",
+                }
+            );
+        }
+    }
+}

--- a/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform.Tests/KeyringHelperAdapterTests.cs
+++ b/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform.Tests/KeyringHelperAdapterTests.cs
@@ -41,8 +41,8 @@ public sealed class KeyringHelperAdapterTests
         Assert.Equal(TokenAudience.AzureArtifacts, credentialRequest.RequestedAudience);
         Assert.Null(credentialRequest.AccountHint);
         Assert.Equal(IdentityFlow.InteractiveBrowser, credentialRequest.IdentityFlow);
-        Assert.Equal(InteractivePolicy.Never, credentialRequest.InteractivePolicy);
-        Assert.Equal(AcquisitionMode.SilentOnly, credentialRequest.AcquisitionMode);
+        Assert.Equal(InteractivePolicy.UserAllowed, credentialRequest.InteractivePolicy);
+        Assert.Equal(AcquisitionMode.InteractionAllowed, credentialRequest.AcquisitionMode);
         Assert.False(provider.BindingMismatchDetected);
         Assert.DoesNotContain(
             "AzureAuthBindingAccountMismatch",
@@ -368,7 +368,7 @@ public sealed class KeyringHelperAdapterTests
     }
 
     [Fact]
-    public void KeyringCliCredentialsJsonModeUsesSharedSilentHelperPath()
+    public void KeyringCliCredentialsJsonModeAllowsUvBrowserInteraction()
     {
         var provider = new SuccessfulAcquisitionService(
             "Azure\"DevOps\\user",
@@ -401,8 +401,9 @@ public sealed class KeyringHelperAdapterTests
 
         CredentialRequestV2 request = Assert.Single(provider.Requests);
         Assert.Equal("creds", request.ExtensionData["python.keyring.mode"]);
-        Assert.Equal(InteractivePolicy.Never, request.InteractivePolicy);
-        Assert.Equal(AcquisitionMode.SilentOnly, request.AcquisitionMode);
+        Assert.Equal(IdentityFlow.InteractiveBrowser, request.IdentityFlow);
+        Assert.Equal(InteractivePolicy.UserAllowed, request.InteractivePolicy);
+        Assert.Equal(AcquisitionMode.InteractionAllowed, request.AcquisitionMode);
     }
 
     [Fact]
@@ -425,6 +426,136 @@ public sealed class KeyringHelperAdapterTests
         Assert.Equal(string.Empty, result.Stderr);
         CredentialRequestV2 request = Assert.Single(provider.Requests);
         Assert.Equal("password", request.ExtensionData["python.keyring.mode"]);
+        Assert.Equal(IdentityFlow.InteractiveBrowser, request.IdentityFlow);
+        Assert.Equal(InteractivePolicy.UserAllowed, request.InteractivePolicy);
+        Assert.Equal(AcquisitionMode.InteractionAllowed, request.AcquisitionMode);
+    }
+
+    [Theory]
+    [InlineData("true")]
+    [InlineData("TRUE")]
+    public void ArtifactsKeyringNonInteractiveModeTrueMakesSharedKeyringRequestSilent(
+        string value
+    )
+    {
+        var provider = new SuccessfulAcquisitionService();
+
+        AdapterRunResult result = ExecuteKeyringCli(
+            [
+                "get",
+                "https://pkgs.dev.azure.com/org/_packaging/feed/pypi/simple/",
+                "requested-user",
+            ],
+            provider,
+            new Dictionary<string, string?>
+            {
+                ["ARTIFACTS_KEYRING_NONINTERACTIVE_MODE"] = value,
+            }
+        );
+
+        Assert.Equal(AdapterHostExitCode.Success, result.Outcome.Result.ExitCode);
+        Assert.Equal("phase11-secret\n", result.ProtocolStdout);
+        CredentialRequestV2 request = Assert.Single(provider.Requests);
+        Assert.Equal(InteractivePolicy.Never, request.InteractivePolicy);
+        Assert.Equal(AcquisitionMode.SilentOnly, request.AcquisitionMode);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("false")]
+    [InlineData("1")]
+    [InlineData("unsupported")]
+    public void ArtifactsKeyringNonInteractiveModeOtherValuesKeepRequestInteractive(
+        string? value
+    )
+    {
+        var provider = new SuccessfulAcquisitionService();
+        KeyringHelperRequest helperRequest = CreateRequest(
+            "https://pkgs.dev.azure.com/org/_packaging/feed/pypi/simple/",
+            username: null,
+            KeyringHelperMode.Password
+        );
+
+        AdapterRunResult result = Execute(
+            KeyringHelperV2.BuildArguments(helperRequest).Skip(1).ToArray(),
+            credentialAcquisition: provider,
+            environment: new Dictionary<string, string?>
+            {
+                ["ARTIFACTS_KEYRING_NONINTERACTIVE_MODE"] = value,
+            }
+        );
+
+        Assert.Equal(AdapterHostExitCode.Success, result.Outcome.Result.ExitCode);
+        CredentialRequestV2 request = Assert.Single(provider.Requests);
+        Assert.Equal(InteractivePolicy.UserAllowed, request.InteractivePolicy);
+        Assert.Equal(AcquisitionMode.InteractionAllowed, request.AcquisitionMode);
+    }
+
+    [Theory]
+    [InlineData(null, false)]
+    [InlineData("", false)]
+    [InlineData("1", true)]
+    [InlineData("false", true)]
+    [InlineData("unsupported", true)]
+    public void AzureAuthNoUserUsesNonEmptyAzureAuthSemantics(
+        string? value,
+        bool expectSilent
+    )
+    {
+        var provider = new SuccessfulAcquisitionService();
+        KeyringHelperRequest helperRequest = CreateRequest(
+            "https://pkgs.dev.azure.com/org/_packaging/feed/pypi/simple/",
+            username: null,
+            KeyringHelperMode.Password
+        );
+
+        AdapterRunResult result = Execute(
+            KeyringHelperV2.BuildArguments(helperRequest).Skip(1).ToArray(),
+            credentialAcquisition: provider,
+            environment: new Dictionary<string, string?>
+            {
+                ["AZUREAUTH_NO_USER"] = value,
+            }
+        );
+
+        Assert.Equal(AdapterHostExitCode.Success, result.Outcome.Result.ExitCode);
+        CredentialRequestV2 request = Assert.Single(provider.Requests);
+        Assert.Equal(
+            expectSilent ? InteractivePolicy.Never : InteractivePolicy.UserAllowed,
+            request.InteractivePolicy
+        );
+        Assert.Equal(
+            expectSilent ? AcquisitionMode.SilentOnly : AcquisitionMode.InteractionAllowed,
+            request.AcquisitionMode
+        );
+    }
+
+    [Theory]
+    [InlineData("PIP_NO_INPUT", "1")]
+    [InlineData("TWINE_NON_INTERACTIVE", "true")]
+    public void CallerSpecificNonInteractiveSignalsDoNotSuppressSharedKeyringRequests(
+        string variable,
+        string value
+    )
+    {
+        var provider = new SuccessfulAcquisitionService();
+        KeyringHelperRequest helperRequest = CreateRequest(
+            "https://pkgs.dev.azure.com/org/_packaging/feed/pypi/simple/",
+            username: null,
+            KeyringHelperMode.Password
+        );
+
+        AdapterRunResult result = Execute(
+            KeyringHelperV2.BuildArguments(helperRequest).Skip(1).ToArray(),
+            credentialAcquisition: provider,
+            environment: new Dictionary<string, string?> { [variable] = value }
+        );
+
+        Assert.Equal(AdapterHostExitCode.Success, result.Outcome.Result.ExitCode);
+        CredentialRequestV2 request = Assert.Single(provider.Requests);
+        Assert.Equal(InteractivePolicy.UserAllowed, request.InteractivePolicy);
+        Assert.Equal(AcquisitionMode.InteractionAllowed, request.AcquisitionMode);
     }
 
     [Fact]
@@ -557,7 +688,8 @@ public sealed class KeyringHelperAdapterTests
         string[] args,
         string executablePath = "/usr/local/bin/python-keyring",
         CredentialCoreService? credentialCore = null,
-        ICredentialAcquisitionService? credentialAcquisition = null
+        ICredentialAcquisitionService? credentialAcquisition = null,
+        Dictionary<string, string?>? environment = null
     )
     {
         var protocolStdout = new StringWriter();
@@ -572,7 +704,11 @@ public sealed class KeyringHelperAdapterTests
                 ? credentialCore is null
                     ? CredentialProviderCompositionRoot.CreateProduction().AcquisitionService
                     : new LegacyV1CredentialAcquisitionService(credentialCore)
-                : credentialAcquisition
+                : credentialAcquisition,
+            name =>
+                environment is not null && environment.TryGetValue(name, out string? value)
+                    ? value
+                    : null
         ).Execute(executablePath, args, protocolStdout, humanStdout, diagnosticRouter);
 
         return new AdapterRunResult(
@@ -585,7 +721,8 @@ public sealed class KeyringHelperAdapterTests
 
     private static AdapterRunResult ExecuteKeyringCli(
         string[] args,
-        ICredentialAcquisitionService credentialAcquisition
+        ICredentialAcquisitionService credentialAcquisition,
+        Dictionary<string, string?>? environment = null
     )
     {
         var protocolStdout = new StringWriter();
@@ -596,7 +733,11 @@ public sealed class KeyringHelperAdapterTests
             SecretRedactor.Empty
         );
         AdapterHostExecutionOutcome outcome = new KeyringCliAdapter(
-            credentialAcquisition
+            credentialAcquisition,
+            name =>
+                environment is not null && environment.TryGetValue(name, out string? value)
+                    ? value
+                    : null
         ).Execute(
             "/opt/azureauth-credprovider/app/azureauth-credprovider",
             [KeyringCliAdapter.CommandName, .. args],
@@ -775,7 +916,7 @@ public sealed class KeyringHelperAdapterTests
     );
 
     [Fact]
-    public void GetPasswordKeepsSilentOnlyPolicyAndHumanStdoutEmpty()
+    public void GetPasswordAllowsBrowserInteractionAndKeepsHumanStdoutEmpty()
     {
         var credentialAcquisition = new SuccessfulAcquisitionService();
         KeyringHelperRequest helperRequest = CreateRequest(
@@ -803,8 +944,8 @@ public sealed class KeyringHelperAdapterTests
         Assert.Equal(CredentialKind.BasicPassword, request.CredentialKind);
         Assert.Equal(IdentityFlow.InteractiveBrowser, request.IdentityFlow);
         Assert.NotEqual(IdentityFlow.DeviceCode, request.IdentityFlow);
-        Assert.Equal(InteractivePolicy.Never, request.InteractivePolicy);
-        Assert.Equal(AcquisitionMode.SilentOnly, request.AcquisitionMode);
+        Assert.Equal(InteractivePolicy.UserAllowed, request.InteractivePolicy);
+        Assert.Equal(AcquisitionMode.InteractionAllowed, request.AcquisitionMode);
         Assert.Equal(CachePolicyMode.ProductPersistentCacheDisabled, request.CachePolicy);
         CiContext ciContext = Assert.IsType<CiContext>(request.CiContext);
         Assert.False(ciContext.ExplicitCiMode);
@@ -816,7 +957,7 @@ public sealed class KeyringHelperAdapterTests
     }
 
     [Fact]
-    public void GetPasswordSilentRequestPreservesDefaultServiceAndCanonicalResource()
+    public void GetPasswordInteractiveRequestPreservesDefaultServiceAndCanonicalResource()
     {
         var credentialAcquisition = new SuccessfulAcquisitionService();
         KeyringHelperRequest helperRequest = CreateRequest(
@@ -846,7 +987,8 @@ public sealed class KeyringHelperAdapterTests
             resource.ServiceEndpoint
         );
         Assert.Equal(IdentityFlow.InteractiveBrowser, request.IdentityFlow);
-        Assert.Equal(AcquisitionMode.SilentOnly, request.AcquisitionMode);
+        Assert.Equal(InteractivePolicy.UserAllowed, request.InteractivePolicy);
+        Assert.Equal(AcquisitionMode.InteractionAllowed, request.AcquisitionMode);
         Assert.Equal("phase11-secret\n", result.ProtocolStdout);
     }
 }


### PR DESCRIPTION
## Summary
- allow normal local Python keyring requests to use browser interaction
- honor only dedicated provider noninteractive signals and preserve AzureAuth any-nonempty semantics
- forward the configured environment boundary through composition-created keyring adapters

## Validation
- targeted Python and .NET scenarios
- Python workspace suite
- full AzureAuth platform suite
- HK PR gate
- multi-angle OCR review with no remaining findings