### PR TITLE
fix(azureauth): Align Git Interaction and Discovery

### DIFF
--- a/src/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Cli/CliApplication.cs
+++ b/src/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Cli/CliApplication.cs
@@ -3170,7 +3170,11 @@ internal static class CliApplication
             $"owned-git-entries: {GetPresenceText(doctorResult.OwnedGitEntriesPresent)}",
             $"ownership-manifest: {GetPresenceText(doctorResult.OwnershipManifestPresent)}",
             "dev.azure.com-useHttpPath: "
-                + GetPresenceText(doctorResult.DevAzureUseHttpPathPresent),
+                + GetGitUseHttpPathInspectionText(
+                    doctorResult.DevAzureUseHttpPath.State
+                ),
+            "dev.azure.com-useHttpPath-truncated: "
+                + GetYesNo(doctorResult.DevAzureUseHttpPath.OutputTruncated),
             $"credential-core: {GetCheckStatusText(doctorResult.CredentialCoreSuccess)}",
             "git-credential-helper-get: "
                 + GetCheckStatusText(doctorResult.GitCredentialHelperGetSuccess),
@@ -3179,6 +3183,24 @@ internal static class CliApplication
             "git-credential-helper-erase: "
                 + GetCheckStatusText(doctorResult.GitCredentialHelperEraseSuccess),
             "local-shell-helper-shorthand: " + GetLocalShellHelperShorthandStatusText(doctorResult),
+            "git-effective-credential-helper: "
+                + GetGitEffectiveCredentialHelperStateText(
+                    doctorResult.EffectiveCredentialHelper.State
+                ),
+            "git-effective-credential-helper-order: "
+                + GetGitEffectiveCredentialHelperOrderText(
+                    doctorResult.EffectiveCredentialHelper.EffectiveOrder
+                ),
+            "git-effective-credential-helper-truncated: "
+                + GetYesNo(doctorResult.EffectiveCredentialHelper.ConfigurationTruncated),
+            "git-effective-credential-helper-conflict: "
+                + GetGitCredentialHelperConflictText(
+                    doctorResult.EffectiveCredentialHelper.Conflict
+                ),
+            "git-effective-credential-helper-remediation: "
+                + GetGitCredentialHelperRemediationText(
+                    doctorResult.EffectiveCredentialHelper.State
+                ),
             "protocol-payload: "
                 + (doctorResult.ProtocolPayloadCaptured ? "captured-not-printed" : "not-captured"),
             "auth-accepted-identity-flows: "
@@ -3535,6 +3557,109 @@ internal static class CliApplication
         return GetCheckStatusText(doctorResult.LocalShellHelperShorthandSuccess);
     }
 
+    private static string GetGitEffectiveCredentialHelperStateText(
+        GitEffectiveCredentialHelperState state
+    ) =>
+        state switch
+        {
+            GitEffectiveCredentialHelperState.NotConfigured => "not-configured",
+            GitEffectiveCredentialHelperState.Active => "active",
+            GitEffectiveCredentialHelperState.Reset => "reset",
+            GitEffectiveCredentialHelperState.Bypassed => "bypassed",
+            GitEffectiveCredentialHelperState.Shadowed => "shadowed",
+            GitEffectiveCredentialHelperState.DiscoveryDeferred => "unsupported-mvp",
+            GitEffectiveCredentialHelperState.DiscoveryFailed => "discovery-failed",
+            _ => throw new ArgumentOutOfRangeException(nameof(state), state, null),
+        };
+
+    private static string GetGitEffectiveCredentialHelperOrderText(
+        IReadOnlyList<GitEffectiveCredentialHelperEntryKind> order
+    ) =>
+        order.Count == 0
+            ? "none"
+            : string.Join(
+                ", ",
+                order.Select(entry =>
+                    entry switch
+                    {
+                        GitEffectiveCredentialHelperEntryKind.Product => "product",
+                        GitEffectiveCredentialHelperEntryKind.Other => "other",
+                        _ => throw new ArgumentOutOfRangeException(nameof(order), entry, null),
+                    }
+                )
+            );
+
+    private static string GetGitCredentialHelperConflictText(
+        GitCredentialHelperConflictDescriptor? conflict
+    )
+    {
+        if (conflict is null)
+        {
+            return "none";
+        }
+
+        string scope = conflict.Scope switch
+        {
+            GitConfigurationScope.System => "system",
+            GitConfigurationScope.Global => "global",
+            GitConfigurationScope.Local => "local",
+            GitConfigurationScope.Worktree => "worktree",
+            GitConfigurationScope.Command => "command",
+            GitConfigurationScope.Unknown => "unknown",
+            _ => "unknown",
+        };
+        string selector = conflict.Selector switch
+        {
+            GitCredentialHelperSelectorKind.Unknown => "unknown",
+            GitCredentialHelperSelectorKind.Generic => "generic",
+            GitCredentialHelperSelectorKind.UrlSpecific => "url-specific",
+            _ => "unknown",
+        };
+        string directive = conflict.Directive switch
+        {
+            GitCredentialHelperConflictDirective.Reset => "reset",
+            GitCredentialHelperConflictDirective.OtherHelper => "other-helper",
+            GitCredentialHelperConflictDirective.ActivationBypassed =>
+                "activation-bypassed",
+            _ => "unknown",
+        };
+        return $"scope={scope}; selector={selector}; directive={directive}";
+    }
+
+    private static string GetGitCredentialHelperRemediationText(
+        GitEffectiveCredentialHelperState state
+    ) =>
+        state switch
+        {
+            GitEffectiveCredentialHelperState.NotConfigured =>
+                "run configure git to add the product-managed helper",
+            GitEffectiveCredentialHelperState.Active => "none",
+            GitEffectiveCredentialHelperState.Reset =>
+                "remove the conflicting reset or configure the product helper after it",
+            GitEffectiveCredentialHelperState.Bypassed =>
+                "make the product-managed Git include effective and check Git configuration "
+                + "overrides such as GIT_CONFIG_GLOBAL",
+            GitEffectiveCredentialHelperState.Shadowed =>
+                "remove the conflicting reset or configure the product helper after it",
+            GitEffectiveCredentialHelperState.DiscoveryDeferred =>
+                "run doctor where local Git discovery is supported",
+            GitEffectiveCredentialHelperState.DiscoveryFailed =>
+                "fix Git configuration discovery and rerun doctor",
+            _ => throw new ArgumentOutOfRangeException(nameof(state), state, null),
+        };
+
+    private static string GetGitUseHttpPathInspectionText(
+        GitUseHttpPathInspectionState state
+    ) =>
+        state switch
+        {
+            GitUseHttpPathInspectionState.Present => "present",
+            GitUseHttpPathInspectionState.Absent => "absent",
+            GitUseHttpPathInspectionState.InspectionIncomplete =>
+                "inspection-incomplete",
+            _ => throw new ArgumentOutOfRangeException(nameof(state), state, null),
+        };
+
     private static string[] GetPlannedActions(
         CliCommand command,
         CredentialEcosystem ecosystem,
@@ -3800,7 +3925,10 @@ internal static class CliApplication
             && doctorResult.GitCredentialHelperStoreSuccess
             && doctorResult.GitCredentialHelperEraseSuccess
             && doctorResult.LocalShellHelperShorthandSuccess
-            && doctorResult.DevAzureUseHttpPathPresent;
+            && doctorResult.EffectiveCredentialHelper.State
+                == GitEffectiveCredentialHelperState.Active
+            && doctorResult.DevAzureUseHttpPath.State
+                == GitUseHttpPathInspectionState.Present;
     }
 
     private static bool IsNuGetDoctorSuccess(NuGetPhase10DoctorResult doctorResult)

--- a/src/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform/AdapterHost/GitCredentialHelperAdapter.cs
+++ b/src/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform/AdapterHost/GitCredentialHelperAdapter.cs
@@ -13,6 +13,7 @@ public sealed class GitCredentialHelperAdapter
 
     private const int MaxCredentialRecordCharacters = 16 * 1024;
     private const string DefaultServiceIdentity = "default";
+    private const string GitTerminalPromptEnvironmentVariable = "GIT_TERMINAL_PROMPT";
     private const string ProtocolViolationCode = "ProtocolViolation";
     private const string NoCredentialCode = "NoCredential";
 
@@ -26,6 +27,7 @@ public sealed class GitCredentialHelperAdapter
     ];
 
     private readonly BoundedCredentialAcquisitionAdapter credentialAcquisition;
+    private readonly Func<string, string?> environmentVariableReader;
 
     public GitCredentialHelperAdapter()
         : this(CredentialProviderCompositionRoot.CreateProduction().AcquisitionService) { }
@@ -42,9 +44,27 @@ public sealed class GitCredentialHelperAdapter
         : this(new BoundedCredentialAcquisitionAdapter(credentialAcquisition)) { }
 
     public GitCredentialHelperAdapter(BoundedCredentialAcquisitionAdapter credentialAcquisition)
+        : this(credentialAcquisition, environmentVariableReader: null) { }
+
+    internal GitCredentialHelperAdapter(
+        ICredentialAcquisitionService credentialAcquisition,
+        Func<string, string?> environmentVariableReader
+    )
+        : this(
+            new BoundedCredentialAcquisitionAdapter(credentialAcquisition),
+            environmentVariableReader
+        )
+    { }
+
+    internal GitCredentialHelperAdapter(
+        BoundedCredentialAcquisitionAdapter credentialAcquisition,
+        Func<string, string?>? environmentVariableReader
+    )
     {
         ArgumentNullException.ThrowIfNull(credentialAcquisition);
         this.credentialAcquisition = credentialAcquisition;
+        this.environmentVariableReader =
+            environmentVariableReader ?? Environment.GetEnvironmentVariable;
     }
 
     public static AdapterDescriptor Descriptor { get; } = CreateDescriptor();
@@ -491,8 +511,12 @@ public sealed class GitCredentialHelperAdapter
         return null;
     }
 
-    private static CredentialRequestV2 CreateGetRequest(CanonicalResourceIdentity resource)
+    private CredentialRequestV2 CreateGetRequest(CanonicalResourceIdentity resource)
     {
+        bool interactionAllowed = !IsGitTerminalPromptDisabled(
+            environmentVariableReader(GitTerminalPromptEnvironmentVariable)
+        );
+
         return new CredentialRequestV2
         {
             Ecosystem = CredentialEcosystem.Git,
@@ -503,12 +527,26 @@ public sealed class GitCredentialHelperAdapter
             RequestedAudience = TokenAudience.AzureDevOps,
             CredentialKind = CredentialKind.BasicPassword,
             IdentityFlow = IdentityFlow.InteractiveBrowser,
-            InteractivePolicy = InteractivePolicy.Never,
-            AcquisitionMode = AcquisitionMode.SilentOnly,
+            InteractivePolicy = interactionAllowed
+                ? InteractivePolicy.HostToolAllows
+                : InteractivePolicy.Never,
+            AcquisitionMode = interactionAllowed
+                ? AcquisitionMode.InteractionAllowed
+                : AcquisitionMode.SilentOnly,
             CachePolicy = CachePolicyMode.ProductPersistentCacheDisabled,
             CiContext = new CiContext { ExplicitCiMode = false, AllowsPersistentWrites = false },
         };
     }
+
+    private static bool IsGitTerminalPromptDisabled(string? value) =>
+        value is not null
+        && (
+            value.Length == 0
+            || string.Equals(value, "0", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(value, "false", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(value, "no", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(value, "off", StringComparison.OrdinalIgnoreCase)
+        );
 
     private static AdapterHostHandlerOutput CreateSuccessOutput(CredentialOperation operation)
     {

--- a/src/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform/AdapterHost/GitCredentialHelperAdapter.cs
+++ b/src/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform/AdapterHost/GitCredentialHelperAdapter.cs
@@ -14,6 +14,9 @@ public sealed class GitCredentialHelperAdapter
     private const int MaxCredentialRecordCharacters = 16 * 1024;
     private const string DefaultServiceIdentity = "default";
     private const string GitTerminalPromptEnvironmentVariable = "GIT_TERMINAL_PROMPT";
+    private const string GitTerminalPromptDisabledGuidance =
+        "Git credential interaction is disabled by GIT_TERMINAL_PROMPT. Retry this Git "
+        + "operation from an interactive session with GIT_TERMINAL_PROMPT unset or enabled.";
     private const string ProtocolViolationCode = "ProtocolViolation";
     private const string NoCredentialCode = "NoCredential";
 
@@ -227,8 +230,28 @@ public sealed class GitCredentialHelperAdapter
         {
             return CreateProtocolViolationOutput(CredentialOperation.Get);
         }
-        CredentialRequestV2 request = CreateGetRequest(resourceParseResult.Resource);
+        bool interactionAllowed = !IsGitTerminalPromptDisabled(
+            environmentVariableReader(GitTerminalPromptEnvironmentVariable)
+        );
+        CredentialRequestV2 request = CreateGetRequest(
+            resourceParseResult.Resource,
+            interactionAllowed
+        );
         CredentialResult result = credentialAcquisition.Acquire(request, cancellationToken);
+        if (
+            !interactionAllowed
+            && result.Status
+                is CredentialResultStatus.InteractionRequired
+                    or CredentialResultStatus.InteractionBlocked
+            && result.Error is not null
+        )
+        {
+            result = result with
+            {
+                Error = result.Error with { SafeMessage = GitTerminalPromptDisabledGuidance },
+            };
+        }
+
         return new AdapterHostHandlerOutput(
             credentialResult: result,
             operation: CredentialOperation.Get,
@@ -511,12 +534,11 @@ public sealed class GitCredentialHelperAdapter
         return null;
     }
 
-    private CredentialRequestV2 CreateGetRequest(CanonicalResourceIdentity resource)
+    private static CredentialRequestV2 CreateGetRequest(
+        CanonicalResourceIdentity resource,
+        bool interactionAllowed
+    )
     {
-        bool interactionAllowed = !IsGitTerminalPromptDisabled(
-            environmentVariableReader(GitTerminalPromptEnvironmentVariable)
-        );
-
         return new CredentialRequestV2
         {
             Ecosystem = CredentialEcosystem.Git,

--- a/src/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform/Composition/CredentialProviderCompositionRoot.cs
+++ b/src/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform/Composition/CredentialProviderCompositionRoot.cs
@@ -264,7 +264,8 @@ public sealed class CredentialProviderCompositionRoot
         );
     }
 
-    public GitCredentialHelperAdapter CreateGitCredentialHelperAdapter() => new(boundary);
+    public GitCredentialHelperAdapter CreateGitCredentialHelperAdapter() =>
+        new(boundary, ProductionOptions.EnvironmentVariableReader);
 
     public NuGetPluginAdapter CreateNuGetPluginAdapter() => new(boundary);
 

--- a/src/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform/VerticalSlice/GitPhase8VerticalSliceService.cs
+++ b/src/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform/VerticalSlice/GitPhase8VerticalSliceService.cs
@@ -21,6 +21,8 @@ public sealed record GitPhase8VerticalSliceOptions
 
     public string? XdgConfigHomeDirectoryPath { get; init; }
 
+    public string? GitConfigurationProbeWorkingDirectoryPath { get; init; }
+
     public IProcessRunner? ProcessRunner { get; init; }
 
     public string? GitExecutablePath { get; init; }
@@ -73,6 +75,85 @@ public sealed record GitPhase8ConfigureResult
     public required bool OwnershipManifestPresent { get; init; }
 }
 
+public enum GitEffectiveCredentialHelperState
+{
+    NotConfigured = 0,
+    Active = 1,
+    Reset = 2,
+    Bypassed = 3,
+    Shadowed = 4,
+    DiscoveryDeferred = 5,
+    DiscoveryFailed = 6,
+}
+
+public enum GitEffectiveCredentialHelperEntryKind
+{
+    Product = 1,
+    Other = 2,
+}
+
+public enum GitConfigurationScope
+{
+    Unknown = 0,
+    System = 1,
+    Global = 2,
+    Local = 3,
+    Worktree = 4,
+    Command = 5,
+}
+
+public enum GitCredentialHelperSelectorKind
+{
+    Unknown = 0,
+    Generic = 1,
+    UrlSpecific = 2,
+}
+
+public enum GitCredentialHelperConflictDirective
+{
+    Reset = 1,
+    OtherHelper = 2,
+    ActivationBypassed = 3,
+}
+
+public sealed record GitCredentialHelperConflictDescriptor
+{
+    public required GitConfigurationScope Scope { get; init; }
+
+    public required GitCredentialHelperSelectorKind Selector { get; init; }
+
+    public required GitCredentialHelperConflictDirective Directive { get; init; }
+}
+
+public sealed record GitEffectiveCredentialHelperDiagnostics
+{
+    public required GitEffectiveCredentialHelperState State { get; init; }
+
+    public required IReadOnlyList<GitEffectiveCredentialHelperEntryKind> EffectiveOrder
+    {
+        get;
+        init;
+    }
+
+    public required bool ConfigurationTruncated { get; init; }
+
+    public required GitCredentialHelperConflictDescriptor? Conflict { get; init; }
+}
+
+public enum GitUseHttpPathInspectionState
+{
+    Present = 1,
+    Absent = 2,
+    InspectionIncomplete = 3,
+}
+
+public sealed record GitUseHttpPathDiagnostics
+{
+    public required GitUseHttpPathInspectionState State { get; init; }
+
+    public required bool OutputTruncated { get; init; }
+}
+
 public sealed record GitPhase8DoctorResult
 {
     public required GitPhase8VerticalSliceResolvedPaths Paths { get; init; }
@@ -95,7 +176,13 @@ public sealed record GitPhase8DoctorResult
 
     public required bool LocalShellHelperShorthandDeferred { get; init; }
 
-    public required bool DevAzureUseHttpPathPresent { get; init; }
+    public required GitEffectiveCredentialHelperDiagnostics EffectiveCredentialHelper
+    {
+        get;
+        init;
+    }
+
+    public required GitUseHttpPathDiagnostics DevAzureUseHttpPath { get; init; }
 
     public required bool ProtocolPayloadCaptured { get; init; }
 }
@@ -129,6 +216,22 @@ public sealed class GitPhase8VerticalSliceService
     private const string ManifestId = "phase8-git-configuration";
     private const string ConfigurePlanId = "phase8-git-configure-plan";
     private const string EntrySelector = "git.config";
+    private const int GitDiscoveryMaximumHelperEntries = 128;
+    private const int GitDiscoveryOutputByteLimit = 64 * 1024;
+    private const string GitUseHttpPathProbeUsernamePresent =
+        "azureauth-use-http-path-present";
+    private const string GitUseHttpPathProbeUsernameAbsent =
+        "azureauth-use-http-path-absent";
+    private const string GitUseHttpPathProbeHelper =
+        "!f() { p=absent; while IFS= read -r line; do case \"$line\" in path=*) "
+        + "p=present;; esac; done; echo username=azureauth-use-http-path-$p; "
+        + "echo password=azureauth-use-http-path-probe; }; f";
+    private const string GitUseHttpPathProbeInput =
+        "protocol=https\n"
+        + "host=dev.azure.com\n"
+        + "path=org/project/_git/repository\n"
+        + "\n";
+    private static readonly TimeSpan GitDiscoveryTimeout = TimeSpan.FromSeconds(10);
     internal const string GitCredentialHelperKey = "credential.helper";
     internal const string GitUseHttpPathKey = "credential.https://dev.azure.com.useHttpPath";
     internal const string GitUseHttpPathValue = "true";
@@ -142,6 +245,7 @@ public sealed class GitPhase8VerticalSliceService
         new("https://dev.azure.com/org/project/_git/repository");
     private readonly IFileSystem fileSystem;
     private readonly GitUserGlobalConfigActivation gitActivation;
+    private readonly string gitConfigurationProbeWorkingDirectoryPath;
     private readonly string gitExecutablePath;
     private readonly bool localShellGitDiscoverySupported;
     private readonly GitPhase8VerticalSliceResolvedPaths paths;
@@ -161,6 +265,10 @@ public sealed class GitPhase8VerticalSliceService
         fileSystem = options?.FileSystem ?? new SystemFileSystem();
         gitActivation = new GitUserGlobalConfigActivation(fileSystem);
         paths = ResolvePaths(options);
+        gitConfigurationProbeWorkingDirectoryPath = GetFullPath(
+            options?.GitConfigurationProbeWorkingDirectoryPath
+                ?? Environment.CurrentDirectory
+        );
         processRunner = options?.ProcessRunner ?? new SystemProcessRunner();
         gitExecutablePath = string.IsNullOrWhiteSpace(options?.GitExecutablePath)
             ? "git"
@@ -331,7 +439,14 @@ public sealed class GitPhase8VerticalSliceService
         var localShellHelperShorthandSuccess = false;
         var localShellHelperShorthandDeferred = false;
         var protocolPayloadCaptured = false;
-        var devAzureUseHttpPathPresent = false;
+        GitUseHttpPathDiagnostics devAzureUseHttpPath =
+            CreateUseHttpPathDiagnostics(
+                GitUseHttpPathInspectionState.InspectionIncomplete
+            );
+        GitEffectiveCredentialHelperDiagnostics effectiveCredentialHelper =
+            CreateEffectiveCredentialHelperDiagnostics(
+                GitEffectiveCredentialHelperState.NotConfigured
+            );
         try
         {
             (gitCredentialHelperGetSuccess, protocolPayloadCaptured) =
@@ -362,28 +477,46 @@ public sealed class GitPhase8VerticalSliceService
             protocolPayloadCaptured = false;
         }
 
-        if (TryInspectOwnedGitActivation())
+        bool ownedGitActivationPresent = TryInspectOwnedGitActivation();
+        bool productGitConfigurationPresent =
+            ownedGitActivationPresent
+            || ownedState.OwnedGitEntriesPresent
+            || ownedState.OwnershipManifestPresent;
+        bool productHelperExecutable = CanExecuteStateGitHelperShim();
+        try
         {
-            try
+            GitEffectiveConfigurationInspection inspection =
+                await InspectEffectiveGitConfigurationAsync(
+                    productGitConfigurationPresent,
+                    cancellationToken
+                );
+            devAzureUseHttpPath = inspection.UseHttpPath;
+            effectiveCredentialHelper = inspection.CredentialHelper;
+            if (
+                configurationPlanValid
+                && ownedState.OwnedGitEntriesPresent
+                && ownedState.OwnershipManifestPresent
+            )
             {
-                GitEffectiveConfigurationInspection inspection =
-                    await InspectEffectiveGitConfigurationAsync(cancellationToken);
-                devAzureUseHttpPathPresent = inspection.UseHttpPathEnabled;
-                if (
-                    configurationPlanValid
-                    && ownedState.OwnedGitEntriesPresent
-                    && ownedState.OwnershipManifestPresent
-                )
-                {
-                    localShellHelperShorthandSuccess = inspection.ExpectedHelperPresent;
-                    localShellHelperShorthandDeferred = inspection.Deferred;
-                }
+                localShellHelperShorthandSuccess =
+                    productHelperExecutable
+                    && inspection.CredentialHelper.State
+                        == GitEffectiveCredentialHelperState.Active;
+                localShellHelperShorthandDeferred =
+                    inspection.CredentialHelper.State
+                    == GitEffectiveCredentialHelperState.DiscoveryDeferred;
             }
-            catch (Exception exception) when (IsExpectedDoctorCheckFailure(exception))
-            {
-                localShellHelperShorthandSuccess = false;
-                localShellHelperShorthandDeferred = false;
-            }
+        }
+        catch (Exception exception) when (IsExpectedDoctorCheckFailure(exception))
+        {
+            localShellHelperShorthandSuccess = false;
+            localShellHelperShorthandDeferred = false;
+            effectiveCredentialHelper = CreateEffectiveCredentialHelperDiagnostics(
+                GitEffectiveCredentialHelperState.DiscoveryFailed
+            );
+            devAzureUseHttpPath = CreateUseHttpPathDiagnostics(
+                GitUseHttpPathInspectionState.InspectionIncomplete
+            );
         }
 
         return new GitPhase8DoctorResult
@@ -398,7 +531,8 @@ public sealed class GitPhase8VerticalSliceService
             GitCredentialHelperEraseSuccess = gitCredentialHelperEraseSuccess,
             LocalShellHelperShorthandSuccess = localShellHelperShorthandSuccess,
             LocalShellHelperShorthandDeferred = localShellHelperShorthandDeferred,
-            DevAzureUseHttpPathPresent = devAzureUseHttpPathPresent,
+            EffectiveCredentialHelper = effectiveCredentialHelper,
+            DevAzureUseHttpPath = devAzureUseHttpPath,
             ProtocolPayloadCaptured = protocolPayloadCaptured,
         };
     }
@@ -957,49 +1091,42 @@ public sealed class GitPhase8VerticalSliceService
     }
 
     private async ValueTask<GitEffectiveConfigurationInspection>
-        InspectEffectiveGitConfigurationAsync(CancellationToken cancellationToken)
+        InspectEffectiveGitConfigurationAsync(
+            bool productGitConfigurationPresent,
+            CancellationToken cancellationToken
+        )
     {
         if (!localShellGitDiscoverySupported)
         {
             return new GitEffectiveConfigurationInspection(
-                ExpectedHelperPresent: false,
-                UseHttpPathEnabled: false,
-                Deferred: true
-            );
-        }
-
-        if (!CanExecuteStateGitHelperShim())
-        {
-            return new GitEffectiveConfigurationInspection(
-                ExpectedHelperPresent: false,
-                UseHttpPathEnabled: false,
-                Deferred: false
+                CreateEffectiveCredentialHelperDiagnostics(
+                    GitEffectiveCredentialHelperState.DiscoveryDeferred
+                ),
+                CreateUseHttpPathDiagnostics(
+                    GitUseHttpPathInspectionState.InspectionIncomplete
+                )
             );
         }
 
         ProcessResult helperResult = await processRunner
             .RunAsync(CreateEffectiveHelperInspectionStartSpec(), cancellationToken)
             .ConfigureAwait(false);
+        GitEffectiveCredentialHelperDiagnostics credentialHelper =
+            await InspectEffectiveCredentialHelpersAsync(
+                    helperResult,
+                    productGitConfigurationPresent,
+                    cancellationToken
+                )
+                .ConfigureAwait(false);
         ProcessResult useHttpPathResult = await processRunner
             .RunAsync(CreateEffectiveUseHttpPathInspectionStartSpec(), cancellationToken)
             .ConfigureAwait(false);
 
-        bool expectedHelperPresent =
-            helperResult.ExitCode is 0 or 1
-            && helperResult.StandardError.Length == 0
-            && ContainsExpectedEffectiveHelper(helperResult.StandardOutput);
-        bool useHttpPathEnabled =
-            useHttpPathResult.ExitCode == 0
-            && useHttpPathResult.StandardError.Length == 0
-            && string.Equals(
-                useHttpPathResult.StandardOutput.Trim(),
-                GitUseHttpPathValue,
-                StringComparison.OrdinalIgnoreCase
-            );
+        GitUseHttpPathDiagnostics useHttpPath =
+            InspectEffectiveUseHttpPath(useHttpPathResult);
         return new GitEffectiveConfigurationInspection(
-            expectedHelperPresent,
-            useHttpPathEnabled,
-            Deferred: false
+            credentialHelper,
+            useHttpPath
         );
     }
 
@@ -1132,43 +1259,165 @@ public sealed class GitPhase8VerticalSliceService
         return string.Concat("'", value.Replace("'", "'\"'\"'", StringComparison.Ordinal), "'");
     }
 
-    private bool ContainsExpectedEffectiveHelper(string standardOutput)
+    private async ValueTask<GitEffectiveCredentialHelperDiagnostics>
+        InspectEffectiveCredentialHelpersAsync(
+        ProcessResult result,
+        bool productGitConfigurationPresent,
+        CancellationToken cancellationToken
+    )
     {
+        if (!IsNormalGitConfigQueryResult(result))
+        {
+            return new GitEffectiveCredentialHelperDiagnostics
+            {
+                State = GitEffectiveCredentialHelperState.DiscoveryFailed,
+                EffectiveOrder = Array.Empty<GitEffectiveCredentialHelperEntryKind>(),
+                ConfigurationTruncated =
+                    result.Status == ProcessExecutionStatus.OutputTooLarge,
+                Conflict = null,
+            };
+        }
+
+        if (!TryParseCredentialHelperRecords(result.StandardOutput, out var records))
+        {
+            return CreateEffectiveCredentialHelperDiagnostics(
+                GitEffectiveCredentialHelperState.DiscoveryFailed
+            );
+        }
+
+        if (records.Count > GitDiscoveryMaximumHelperEntries)
+        {
+            return new GitEffectiveCredentialHelperDiagnostics
+            {
+                State = GitEffectiveCredentialHelperState.DiscoveryFailed,
+                EffectiveOrder = Array.Empty<GitEffectiveCredentialHelperEntryKind>(),
+                ConfigurationTruncated = true,
+                Conflict = null,
+            };
+        }
+
+        IReadOnlySet<string> applicableUrlPatterns;
+        string[] urlPatterns = records
+            .Where(record => record.UrlPattern is not null)
+            .Select(record => record.UrlPattern!)
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+        if (urlPatterns.Length == 0)
+        {
+            applicableUrlPatterns = new HashSet<string>(StringComparer.Ordinal);
+        }
+        else
+        {
+            if (
+                !TryCreateCredentialUrlApplicabilityStartSpec(
+                    urlPatterns,
+                    out ProcessStartSpec? applicabilityStartSpec
+                )
+            )
+            {
+                return CreateEffectiveCredentialHelperDiagnostics(
+                    GitEffectiveCredentialHelperState.DiscoveryFailed
+                );
+            }
+            ProcessResult applicabilityResult = await processRunner
+                .RunAsync(applicabilityStartSpec, cancellationToken)
+                .ConfigureAwait(false);
+            if (
+                !TryInspectApplicableCredentialUrlPatterns(
+                    applicabilityResult,
+                    urlPatterns,
+                    out applicableUrlPatterns
+                )
+            )
+            {
+                return new GitEffectiveCredentialHelperDiagnostics
+                {
+                    State = GitEffectiveCredentialHelperState.DiscoveryFailed,
+                    EffectiveOrder =
+                        Array.Empty<GitEffectiveCredentialHelperEntryKind>(),
+                    ConfigurationTruncated =
+                        applicabilityResult.Status
+                        == ProcessExecutionStatus.OutputTooLarge,
+                    Conflict = null,
+                };
+            }
+        }
+
         string expected = GitConfigPhysicalTargetWriter.RenderCredentialHelperCommandValue(
             CreateGitCredentialHelperValue()
         );
-        var effectiveHelpers = new List<string>();
-        foreach (
-            string record in standardOutput.Split(
-                '\0',
-                StringSplitOptions.RemoveEmptyEntries
-            )
-        )
+        var effectiveHelpers = new List<GitEffectiveCredentialHelperEntry>();
+        var expectedHelperObserved = false;
+        GitCredentialHelperConflictDescriptor? lastReset = null;
+        foreach (GitCredentialHelperRecord record in records)
         {
-            int separator = record.IndexOf('\n');
-            if (separator < 0)
-            {
-                return false;
-            }
-
-            string key = record[..separator];
-            string value = record[(separator + 1)..];
-            if (!IsCredentialHelperKeyApplicable(key, GitConfigurationProbeUrl))
+            if (
+                record.UrlPattern is not null
+                && !applicableUrlPatterns.Contains(record.UrlPattern)
+            )
             {
                 continue;
             }
 
-            if (value.Length == 0)
+            if (record.Value.Length == 0)
             {
                 effectiveHelpers.Clear();
+                lastReset = CreateConflictDescriptor(
+                    record,
+                    GitCredentialHelperConflictDirective.Reset
+                );
             }
             else
             {
-                effectiveHelpers.Add(value);
+                bool isExpected = string.Equals(
+                    record.Value,
+                    expected,
+                    StringComparison.Ordinal
+                );
+                expectedHelperObserved |= isExpected;
+                effectiveHelpers.Add(
+                    new GitEffectiveCredentialHelperEntry(
+                        isExpected
+                            ? GitEffectiveCredentialHelperEntryKind.Product
+                            : GitEffectiveCredentialHelperEntryKind.Other,
+                        record
+                    )
+                );
             }
         }
 
-        return effectiveHelpers.Contains(expected, StringComparer.Ordinal);
+        GitEffectiveCredentialHelperState state =
+            effectiveHelpers.Any(entry =>
+                entry.Kind == GitEffectiveCredentialHelperEntryKind.Product
+            )
+                ? GitEffectiveCredentialHelperState.Active
+            : expectedHelperObserved
+                ? effectiveHelpers.Count == 0
+                    ? GitEffectiveCredentialHelperState.Reset
+                    : GitEffectiveCredentialHelperState.Shadowed
+            : productGitConfigurationPresent
+                ? GitEffectiveCredentialHelperState.Bypassed
+                : GitEffectiveCredentialHelperState.NotConfigured;
+        GitCredentialHelperConflictDescriptor? conflict = state switch
+        {
+            GitEffectiveCredentialHelperState.Reset => lastReset,
+            GitEffectiveCredentialHelperState.Shadowed => lastReset,
+            GitEffectiveCredentialHelperState.Bypassed =>
+                new GitCredentialHelperConflictDescriptor
+                {
+                    Scope = GitConfigurationScope.Unknown,
+                    Selector = GitCredentialHelperSelectorKind.Unknown,
+                    Directive = GitCredentialHelperConflictDirective.ActivationBypassed,
+                },
+            _ => null,
+        };
+        return new GitEffectiveCredentialHelperDiagnostics
+        {
+            State = state,
+            EffectiveOrder = effectiveHelpers.Select(entry => entry.Kind).ToArray(),
+            ConfigurationTruncated = false,
+            Conflict = conflict,
+        };
     }
 
     private ProcessStartSpec CreateEffectiveHelperInspectionStartSpec() =>
@@ -1176,31 +1425,130 @@ public sealed class GitPhase8VerticalSliceService
             gitExecutablePath,
             [
                 "config",
-                "--global",
                 "--includes",
+                "--show-scope",
                 "--null",
                 "--get-regexp",
                 @"^credential(\..*)?\.helper$",
             ],
-            workingDirectory: paths.StateDirectoryPath,
-            environment: CreateGitInspectionEnvironment()
+            workingDirectory: gitConfigurationProbeWorkingDirectoryPath,
+            environment: CreateGitInspectionEnvironment(),
+            timeout: GitDiscoveryTimeout,
+            outputCaptureOptions: new ProcessOutputCaptureOptions
+            {
+                StandardOutputByteLimit = GitDiscoveryOutputByteLimit,
+                StandardErrorByteLimit = GitDiscoveryOutputByteLimit,
+            }
         );
+
+    private bool TryCreateCredentialUrlApplicabilityStartSpec(
+        string[] urlPatterns,
+        [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out ProcessStartSpec? startSpec
+    )
+    {
+        startSpec = null;
+        if (!TryGetInheritedGitConfigCount(out int inheritedCount))
+        {
+            return false;
+        }
+
+        var environment = CreateGitInspectionEnvironment();
+        for (var index = 0; index < urlPatterns.Length; index++)
+        {
+            int configIndex = inheritedCount + index;
+            environment["GIT_CONFIG_KEY_" + configIndex] =
+                "credential."
+                    + urlPatterns[index]
+                    + "."
+                    + CreateCredentialUrlProbeVariable(urlPatterns[index], index);
+            environment["GIT_CONFIG_VALUE_" + configIndex] = "true";
+        }
+        environment["GIT_CONFIG_COUNT"] = (inheritedCount + urlPatterns.Length).ToString(
+            System.Globalization.CultureInfo.InvariantCulture
+        );
+        startSpec = new ProcessStartSpec(
+            gitExecutablePath,
+            [
+                "config",
+                "--includes",
+                "--null",
+                "--get-urlmatch",
+                "credential",
+                GitConfigurationProbeUrl.AbsoluteUri,
+            ],
+            workingDirectory: gitConfigurationProbeWorkingDirectoryPath,
+            environment: environment,
+            timeout: GitDiscoveryTimeout,
+            outputCaptureOptions: CreateGitDiscoveryOutputCaptureOptions()
+        );
+        return true;
+    }
+
+    private static bool TryGetInheritedGitConfigCount(out int count)
+    {
+        string? value = Environment.GetEnvironmentVariable("GIT_CONFIG_COUNT");
+        if (value is null)
+        {
+            count = 0;
+            return true;
+        }
+
+        return int.TryParse(
+                value,
+                System.Globalization.NumberStyles.None,
+                System.Globalization.CultureInfo.InvariantCulture,
+                out count
+            )
+            && count >= 0
+            && count <= GitDiscoveryMaximumHelperEntries;
+    }
 
     private ProcessStartSpec CreateEffectiveUseHttpPathInspectionStartSpec() =>
         new(
             gitExecutablePath,
             [
-                "config",
-                "--global",
-                "--includes",
-                "--type=bool",
-                "--get-urlmatch",
-                "credential.useHttpPath",
-                GitConfigurationProbeUrl.AbsoluteUri,
+                "-c",
+                "credential.helper=",
+                "-c",
+                "credential.helper=" + GitUseHttpPathProbeHelper,
+                "credential",
+                "fill",
             ],
-            workingDirectory: paths.StateDirectoryPath,
-            environment: CreateGitInspectionEnvironment()
+            workingDirectory: gitConfigurationProbeWorkingDirectoryPath,
+            environment: CreateGitInspectionEnvironment(),
+            standardInput: GitUseHttpPathProbeInput,
+            timeout: GitDiscoveryTimeout,
+            outputCaptureOptions: CreateGitDiscoveryOutputCaptureOptions()
         );
+
+    private static ProcessOutputCaptureOptions CreateGitDiscoveryOutputCaptureOptions() =>
+        new()
+        {
+            StandardOutputByteLimit = GitDiscoveryOutputByteLimit,
+            StandardErrorByteLimit = GitDiscoveryOutputByteLimit,
+        };
+
+    private static GitEffectiveCredentialHelperDiagnostics
+        CreateEffectiveCredentialHelperDiagnostics(
+            GitEffectiveCredentialHelperState state
+        ) =>
+        new()
+        {
+            State = state,
+            EffectiveOrder = Array.Empty<GitEffectiveCredentialHelperEntryKind>(),
+            ConfigurationTruncated = false,
+            Conflict = null,
+        };
+
+    private static GitUseHttpPathDiagnostics CreateUseHttpPathDiagnostics(
+        GitUseHttpPathInspectionState state,
+        bool outputTruncated = false
+    ) =>
+        new()
+        {
+            State = state,
+            OutputTruncated = outputTruncated,
+        };
 
     private Dictionary<string, string?> CreateGitInspectionEnvironment()
     {
@@ -1211,10 +1559,105 @@ public sealed class GitPhase8VerticalSliceService
         };
     }
 
-    private static bool IsCredentialHelperKeyApplicable(string key, Uri target)
+    private static bool IsNormalGitConfigQueryResult(ProcessResult result)
+    {
+        if (result.StandardError.Length != 0 || !result.HasExitCode)
+        {
+            return false;
+        }
+
+        return result.Status switch
+        {
+            ProcessExecutionStatus.Success => result.ExitCode == 0,
+            ProcessExecutionStatus.NonZeroExit =>
+                result.ExitCode == 1 && result.StandardOutput.Length == 0,
+            _ => false,
+        };
+    }
+
+    private static bool TryParseCredentialHelperRecords(
+        string output,
+        out IReadOnlyList<GitCredentialHelperRecord> records
+    )
+    {
+        records = Array.Empty<GitCredentialHelperRecord>();
+        if (output.Length == 0)
+        {
+            return true;
+        }
+
+        string[] parts = output.Split('\0', StringSplitOptions.None);
+        if (parts[^1].Length != 0 || (parts.Length - 1) % 2 != 0)
+        {
+            return false;
+        }
+
+        var parsed = new List<GitCredentialHelperRecord>((parts.Length - 1) / 2);
+        for (var index = 0; index < parts.Length - 1; index += 2)
+        {
+            if (!TryParseGitConfigurationScope(parts[index], out GitConfigurationScope scope))
+            {
+                return false;
+            }
+
+            string record = parts[index + 1];
+            int separator = record.IndexOf('\n');
+            if (separator < 0)
+            {
+                return false;
+            }
+
+            string key = record[..separator];
+            string value = record[(separator + 1)..];
+            if (!TryParseCredentialHelperKey(key, out string? urlPattern))
+            {
+                return false;
+            }
+
+            parsed.Add(
+                new GitCredentialHelperRecord(
+                    scope,
+                    urlPattern is null
+                        ? GitCredentialHelperSelectorKind.Generic
+                        : GitCredentialHelperSelectorKind.UrlSpecific,
+                    urlPattern,
+                    value
+                )
+            );
+        }
+
+        records = parsed;
+        return true;
+    }
+
+    private static bool TryParseGitConfigurationScope(
+        string token,
+        out GitConfigurationScope scope
+    )
+    {
+        scope = token switch
+        {
+            "system" => GitConfigurationScope.System,
+            "global" => GitConfigurationScope.Global,
+            "local" => GitConfigurationScope.Local,
+            "worktree" => GitConfigurationScope.Worktree,
+            "command" => GitConfigurationScope.Command,
+            _ => GitConfigurationScope.Unknown,
+        };
+        return token.Length is > 0 and <= 32
+            && token.All(character =>
+                character is >= 'a' and <= 'z' || character == '-'
+            );
+    }
+
+    private static bool TryParseCredentialHelperKey(
+        string key,
+        out string? urlPattern
+    )
     {
         const string Prefix = "credential.";
         const string Suffix = ".helper";
+        urlPattern = null;
         if (string.Equals(key, GitCredentialHelperKey, StringComparison.OrdinalIgnoreCase))
         {
             return true;
@@ -1229,27 +1672,168 @@ public sealed class GitPhase8VerticalSliceService
             return false;
         }
 
-        string patternText = key[Prefix.Length..^Suffix.Length];
-        if (!Uri.TryCreate(patternText, UriKind.Absolute, out Uri? pattern))
+        urlPattern = key[Prefix.Length..^Suffix.Length];
+        return urlPattern.Length <= GitDiscoveryOutputByteLimit
+            && !urlPattern.Contains('\0')
+            && !urlPattern.Contains('\n')
+            && !urlPattern.Contains('\r');
+    }
+
+    private static string CreateCredentialUrlProbeVariable(string pattern, int index)
+    {
+        byte[] digest = SHA256.HashData(
+            System.Text.Encoding.UTF8.GetBytes(index.ToString() + "\0" + pattern)
+        );
+        return "azureauthdiscovery" + Convert.ToHexString(digest.AsSpan(0, 12)).ToLowerInvariant();
+    }
+
+    private static bool TryInspectApplicableCredentialUrlPatterns(
+        ProcessResult result,
+        string[] urlPatterns,
+        out IReadOnlySet<string> applicablePatterns
+    )
+    {
+        applicablePatterns = new HashSet<string>(StringComparer.Ordinal);
+        if (!IsNormalGitConfigQueryResult(result))
         {
             return false;
         }
 
+        var variables = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        for (var index = 0; index < urlPatterns.Length; index++)
+        {
+            variables.Add(
+                "credential." + CreateCredentialUrlProbeVariable(urlPatterns[index], index),
+                urlPatterns[index]
+            );
+        }
+
+        if (result.StandardOutput.Length == 0)
+        {
+            return true;
+        }
+
+        string[] records = result.StandardOutput.Split('\0', StringSplitOptions.None);
+        if (records[^1].Length != 0)
+        {
+            return false;
+        }
+
+        var matched = new HashSet<string>(StringComparer.Ordinal);
+        foreach (string record in records[..^1])
+        {
+            int separator = record.IndexOf('\n');
+            if (separator < 0)
+            {
+                return false;
+            }
+
+            string key = record[..separator];
+            string value = record[(separator + 1)..];
+            if (!variables.TryGetValue(key, out string? pattern))
+            {
+                continue;
+            }
+            if (
+                !string.Equals(value, "true", StringComparison.OrdinalIgnoreCase)
+                || !matched.Add(pattern)
+            )
+            {
+                return false;
+            }
+        }
+
+        applicablePatterns = matched;
+        return true;
+    }
+
+    private static GitCredentialHelperConflictDescriptor CreateConflictDescriptor(
+        GitCredentialHelperRecord record,
+        GitCredentialHelperConflictDirective directive
+    ) =>
+        new()
+        {
+            Scope = record.Scope,
+            Selector = record.Selector,
+            Directive = directive,
+        };
+
+    private static GitUseHttpPathDiagnostics InspectEffectiveUseHttpPath(
+        ProcessResult result
+    )
+    {
         if (
-            !string.Equals(pattern.Scheme, target.Scheme, StringComparison.OrdinalIgnoreCase)
-            || !string.Equals(pattern.IdnHost, target.IdnHost, StringComparison.OrdinalIgnoreCase)
-            || pattern.Port != target.Port
-            || !string.Equals(pattern.UserInfo, target.UserInfo, StringComparison.Ordinal)
+            result.Status != ProcessExecutionStatus.Success
+            || !result.HasExitCode
+            || result.ExitCode != 0
+            || result.StandardError.Length != 0
         )
         {
-            return false;
+            return CreateUseHttpPathDiagnostics(
+                GitUseHttpPathInspectionState.InspectionIncomplete,
+                outputTruncated:
+                    result.Status == ProcessExecutionStatus.OutputTooLarge
+            );
         }
 
-        string patternPath = pattern.AbsolutePath.TrimEnd('/');
-        string targetPath = target.AbsolutePath.TrimEnd('/');
-        return patternPath.Length == 0
-            || string.Equals(patternPath, targetPath, StringComparison.Ordinal)
-            || targetPath.StartsWith(patternPath + "/", StringComparison.Ordinal);
+        var fields = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (string rawLine in SplitLines(result.StandardOutput))
+        {
+            string line = rawLine.TrimEnd('\r');
+            if (line.Length == 0)
+            {
+                continue;
+            }
+
+            int separator = line.IndexOf('=');
+            if (
+                separator <= 0
+                || !fields.TryAdd(line[..separator], line[(separator + 1)..])
+            )
+            {
+                return CreateUseHttpPathDiagnostics(
+                    GitUseHttpPathInspectionState.InspectionIncomplete
+                );
+            }
+        }
+
+        string? username = null;
+        bool valid =
+            fields.TryGetValue("protocol", out string? protocol)
+            && string.Equals(protocol, "https", StringComparison.Ordinal)
+            && fields.TryGetValue("host", out string? host)
+            && string.Equals(host, "dev.azure.com", StringComparison.OrdinalIgnoreCase)
+            && fields.TryGetValue("username", out username)
+            && fields.TryGetValue("password", out string? password)
+            && password.Length != 0
+            && (
+                string.Equals(
+                    username,
+                    GitUseHttpPathProbeUsernamePresent,
+                    StringComparison.Ordinal
+                )
+                || string.Equals(
+                    username,
+                    GitUseHttpPathProbeUsernameAbsent,
+                    StringComparison.Ordinal
+                )
+            );
+        if (!valid)
+        {
+            return CreateUseHttpPathDiagnostics(
+                GitUseHttpPathInspectionState.InspectionIncomplete
+            );
+        }
+
+        return CreateUseHttpPathDiagnostics(
+            string.Equals(
+                username,
+                GitUseHttpPathProbeUsernamePresent,
+                StringComparison.Ordinal
+            )
+                ? GitUseHttpPathInspectionState.Present
+                : GitUseHttpPathInspectionState.Absent
+        );
     }
 
     private static bool ContainsDevAzureUseHttpPathState(string gitConfig)
@@ -1953,8 +2537,19 @@ public sealed class GitPhase8VerticalSliceService
     );
 
     private sealed record GitEffectiveConfigurationInspection(
-        bool ExpectedHelperPresent,
-        bool UseHttpPathEnabled,
-        bool Deferred
+        GitEffectiveCredentialHelperDiagnostics CredentialHelper,
+        GitUseHttpPathDiagnostics UseHttpPath
+    );
+
+    private sealed record GitCredentialHelperRecord(
+        GitConfigurationScope Scope,
+        GitCredentialHelperSelectorKind Selector,
+        string? UrlPattern,
+        string Value
+    );
+
+    private sealed record GitEffectiveCredentialHelperEntry(
+        GitEffectiveCredentialHelperEntryKind Kind,
+        GitCredentialHelperRecord Record
     );
 }

--- a/src/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform/VerticalSlice/GitPhase8VerticalSliceService.cs
+++ b/src/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform/VerticalSlice/GitPhase8VerticalSliceService.cs
@@ -931,7 +931,9 @@ public sealed class GitPhase8VerticalSliceService
     {
         var protocolStdout = new StringWriter();
         AdapterHostExecutionOutcome outcome = new GitCredentialHelperAdapter(
-            GetCredentialAcquisition()
+            GetCredentialAcquisition(),
+            static name =>
+                string.Equals(name, "GIT_TERMINAL_PROMPT", StringComparison.Ordinal) ? "0" : null
         ).Execute(
             executablePath,
             arguments,

--- a/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Cli.Tests/CliApplicationTests.cs
+++ b/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Cli.Tests/CliApplicationTests.cs
@@ -2050,6 +2050,7 @@ public sealed class CliApplicationTests
                 GitPhase8Options = new GitPhase8VerticalSliceOptions
                 {
                     StateDirectoryPath = stateDirectory,
+                    GitConfigurationProbeWorkingDirectoryPath = stateDirectory,
                     ProcessRunner = new PassingGitDiscoveryProcessRunner(),
                     ProductExecutablePath = CreateFakeProductExecutable(stateDirectory),
                 },
@@ -2092,6 +2093,7 @@ public sealed class CliApplicationTests
             GitPhase8Options = new GitPhase8VerticalSliceOptions
             {
                 StateDirectoryPath = stateDirectory,
+                GitConfigurationProbeWorkingDirectoryPath = stateDirectory,
                 ProcessRunner = new PassingGitDiscoveryProcessRunner(),
                 LocalShellGitDiscoverySupported = false,
                 ProductExecutablePath = CreateFakeProductExecutable(stateDirectory),
@@ -2144,7 +2146,8 @@ public sealed class CliApplicationTests
                     ownershipManifestPresent: false,
                     configurationPlanValid: false,
                     localShellHelperShorthandSuccess: false,
-                    devAzureUseHttpPathPresent: true
+                    devAzureUseHttpPathPresent: true,
+                    productHelperActive: true
                 ),
                 doctorResult.StdOut
             );
@@ -2179,7 +2182,8 @@ public sealed class CliApplicationTests
                     ownershipManifestPresent: true,
                     configurationPlanValid: false,
                     localShellHelperShorthandSuccess: false,
-                    devAzureUseHttpPathPresent: true
+                    devAzureUseHttpPathPresent: true,
+                    productHelperActive: true
                 ),
                 doctorResult.StdOut
             );
@@ -4748,11 +4752,13 @@ public sealed class CliApplicationTests
         bool ownershipManifestPresent,
         bool configurationPlanValid = true,
         bool? localShellHelperShorthandSuccess = null,
-        bool? devAzureUseHttpPathPresent = null
+        bool? devAzureUseHttpPathPresent = null,
+        bool? productHelperActive = null
     )
     {
         bool useHttpPathPresent = devAzureUseHttpPathPresent ?? ownedGitEntriesPresent;
         bool localShellSuccess = localShellHelperShorthandSuccess ?? ownedGitEntriesPresent;
+        bool effectiveProductHelperActive = productHelperActive ?? ownedGitEntriesPresent;
         return Normalize(
             string.Join(
                 "\n",
@@ -4775,11 +4781,24 @@ public sealed class CliApplicationTests
                     $"owned-git-entries: {(ownedGitEntriesPresent ? "present" : "absent")}",
                     $"ownership-manifest: {(ownershipManifestPresent ? "present" : "absent")}",
                     "dev.azure.com-useHttpPath: " + (useHttpPathPresent ? "present" : "absent"),
+                    "dev.azure.com-useHttpPath-truncated: no",
                     "credential-core: pass",
                     "git-credential-helper-get: pass",
                     "git-credential-helper-store: pass",
                     "git-credential-helper-erase: pass",
                     "local-shell-helper-shorthand: " + (localShellSuccess ? "pass" : "fail"),
+                    "git-effective-credential-helper: "
+                        + (effectiveProductHelperActive ? "active" : "not-configured"),
+                    "git-effective-credential-helper-order: "
+                        + (effectiveProductHelperActive ? "product" : "none"),
+                    "git-effective-credential-helper-truncated: no",
+                    "git-effective-credential-helper-conflict: none",
+                    "git-effective-credential-helper-remediation: "
+                        + (
+                            effectiveProductHelperActive
+                                ? "none"
+                                : "run configure git to add the product-managed helper"
+                        ),
                     "protocol-payload: captured-not-printed",
                     "auth-accepted-identity-flows: browser, azure-pipelines",
                     "auth-unavailable-identity-flows: device-code",
@@ -5013,6 +5032,7 @@ public sealed class CliApplicationTests
             GitPhase8Options = new GitPhase8VerticalSliceOptions
             {
                 StateDirectoryPath = stateDirectory,
+                GitConfigurationProbeWorkingDirectoryPath = stateDirectory,
                 ProcessRunner = new PassingGitDiscoveryProcessRunner(),
                 LocalShellGitDiscoverySupported = true,
                 ProductExecutablePath = CreateFakeProductExecutable(stateDirectory),
@@ -5122,6 +5142,7 @@ public sealed class CliApplicationTests
             new GitPhase8VerticalSliceOptions
             {
                 StateDirectoryPath = stateDirectory,
+                GitConfigurationProbeWorkingDirectoryPath = stateDirectory,
                 ProcessRunner = new PassingGitDiscoveryProcessRunner(),
                 LocalShellGitDiscoverySupported = true,
                 ProductExecutablePath = CreateFakeProductExecutable(stateDirectory),
@@ -5256,8 +5277,95 @@ public sealed class CliApplicationTests
         public override DateTimeOffset GetUtcNow() => Now;
     }
 
-    private sealed class PassingGitDiscoveryProcessRunner : IProcessRunner
+    private static Dictionary<string, string?> CreateIsolatedGitEnvironment(
+        IReadOnlyDictionary<string, string?> explicitEnvironment,
+        IEnumerable<string>? inheritedGitConfigVariables = null
+    )
     {
+        var environment = new Dictionary<string, string?>(StringComparer.Ordinal)
+        {
+            ["GIT_CONFIG"] = null,
+            ["GIT_CONFIG_COUNT"] = null,
+            ["GIT_CONFIG_GLOBAL"] = null,
+            ["GIT_CONFIG_PARAMETERS"] = null,
+            ["GIT_CONFIG_SYSTEM"] = null,
+        };
+        IEnumerable<string> inheritedVariables =
+            inheritedGitConfigVariables
+            ?? Environment
+                .GetEnvironmentVariables()
+                .Keys
+                .OfType<string>();
+        foreach (string variable in inheritedVariables)
+        {
+            if (variable.StartsWith("GIT_CONFIG_", StringComparison.Ordinal))
+            {
+                environment[variable] = null;
+            }
+        }
+        environment["GIT_CONFIG_NOSYSTEM"] = "1";
+        foreach ((string key, string? value) in explicitEnvironment)
+        {
+            if (
+                !string.Equals(key, "GIT_CONFIG_COUNT", StringComparison.Ordinal)
+                && !key.StartsWith("GIT_CONFIG_KEY_", StringComparison.Ordinal)
+                && !key.StartsWith("GIT_CONFIG_VALUE_", StringComparison.Ordinal)
+            )
+            {
+                environment[key] = value;
+            }
+        }
+
+        var entries = new List<(string Key, string Value)>();
+        if (
+            explicitEnvironment.TryGetValue(
+                "GIT_CONFIG_COUNT",
+                out string? countValue
+            )
+            && int.TryParse(
+                countValue,
+                System.Globalization.NumberStyles.None,
+                System.Globalization.CultureInfo.InvariantCulture,
+                out int count
+            )
+        )
+        {
+            for (var index = 0; index < count; index++)
+            {
+                if (
+                    explicitEnvironment.TryGetValue(
+                        "GIT_CONFIG_KEY_" + index,
+                        out string? key
+                    )
+                    && key is not null
+                    && explicitEnvironment.TryGetValue(
+                        "GIT_CONFIG_VALUE_" + index,
+                        out string? value
+                    )
+                    && value is not null
+                )
+                {
+                    entries.Add((key, value));
+                }
+            }
+            environment["GIT_CONFIG_COUNT"] = entries.Count.ToString(
+                System.Globalization.CultureInfo.InvariantCulture
+            );
+            for (var index = 0; index < entries.Count; index++)
+            {
+                environment["GIT_CONFIG_KEY_" + index] = entries[index].Key;
+                environment["GIT_CONFIG_VALUE_" + index] = entries[index].Value;
+            }
+        }
+        return environment;
+    }
+
+    private sealed class PassingGitDiscoveryProcessRunner(
+        IEnumerable<string>? inheritedGitConfigVariables = null
+    ) : IProcessRunner
+    {
+        public List<ProcessStartSpec> EffectiveGitStartSpecs { get; } = [];
+
         public Task<ProcessResult> RunAsync(
             ProcessStartSpec startSpec,
             CancellationToken cancellationToken = default
@@ -5266,18 +5374,26 @@ public sealed class CliApplicationTests
             ArgumentNullException.ThrowIfNull(startSpec);
             cancellationToken.ThrowIfCancellationRequested();
 
-            if (startSpec.Arguments.Contains("config"))
+            if (
+                startSpec.Arguments.Contains("config")
+                || startSpec.Arguments.Contains("credential")
+            )
             {
-                return new SystemProcessRunner().RunAsync(
-                    new ProcessStartSpec(
-                        "git",
-                        startSpec.Arguments,
-                        startSpec.WorkingDirectory,
+                var effectiveStartSpec = new ProcessStartSpec(
+                    "git",
+                    startSpec.Arguments,
+                    startSpec.WorkingDirectory,
+                    CreateIsolatedGitEnvironment(
                         startSpec.Environment,
-                        startSpec.StandardInput,
-                        startSpec.Timeout,
-                        startSpec.OutputCaptureOptions
+                        inheritedGitConfigVariables
                     ),
+                    startSpec.StandardInput,
+                    startSpec.Timeout,
+                    startSpec.OutputCaptureOptions
+                );
+                EffectiveGitStartSpecs.Add(effectiveStartSpec);
+                return new SystemProcessRunner().RunAsync(
+                    effectiveStartSpec,
                     cancellationToken
                 );
             }
@@ -5287,7 +5403,7 @@ public sealed class CliApplicationTests
                 new ProcessResult(
                     0,
                     "protocol=https\nhost=dev.azure.com\npath=org/project/_git/repository\n"
-                        + "username=AzureDevOps\n"
+                        + "username=azureauth-use-http-path-present\n"
                         + "password=fake-secret-phase9-probe\n",
                     string.Empty
                 )
@@ -6407,6 +6523,7 @@ public sealed class CliApplicationTests
             var gitOptions = new GitPhase8VerticalSliceOptions
             {
                 StateDirectoryPath = rootPath,
+                GitConfigurationProbeWorkingDirectoryPath = rootPath,
                 ProcessRunner = gitDiscoveryRunner,
                 GitExecutablePath = "fake-git",
                 LocalShellGitDiscoverySupported = true,
@@ -6589,8 +6706,8 @@ public sealed class CliApplicationTests
             Assert.Equal(
                 [
                     "config",
-                    "--global",
                     "--includes",
+                    "--show-scope",
                     "--null",
                     "--get-regexp",
                     @"^credential(\..*)?\.helper$",
@@ -6744,6 +6861,12 @@ public sealed class CliApplicationTests
     {
         public string ExpectedHelperCommand { private get; set; } = null!;
 
+        public string? ConflictingHelperValue { private get; set; }
+
+        public string? BypassHelperValue { private get; set; }
+
+        public ProcessResult? UseHttpPathResultOverride { private get; set; }
+
         public List<ProcessStartSpec> StartSpecs { get; } = [];
 
         public Task<ProcessResult> RunAsync(
@@ -6754,18 +6877,231 @@ public sealed class CliApplicationTests
             ArgumentNullException.ThrowIfNull(startSpec);
             cancellationToken.ThrowIfCancellationRequested();
             StartSpecs.Add(startSpec);
+            if (startSpec.Arguments.Contains("fill"))
+            {
+                if (UseHttpPathResultOverride is not null)
+                {
+                    return Task.FromResult(UseHttpPathResultOverride);
+                }
+                return Task.FromResult(
+                    new ProcessResult(
+                        0,
+                        "protocol=https\n"
+                            + "host=dev.azure.com\n"
+                            + "path=org/project/_git/repository\n"
+                            + "username=azureauth-use-http-path-present\n"
+                            + "password=azureauth-use-http-path-probe\n",
+                        string.Empty
+                    )
+                );
+            }
+
             if (startSpec.Arguments.Contains("--get-urlmatch"))
             {
-                return Task.FromResult(new ProcessResult(0, "true\n", string.Empty));
+                string probeKey = startSpec.Environment
+                    .Where(pair =>
+                        pair.Key.StartsWith(
+                            "GIT_CONFIG_KEY_",
+                            StringComparison.Ordinal
+                        )
+                        && pair.Value?.StartsWith(
+                            "credential.https://dev.azure.com/org.azureauthdiscovery",
+                            StringComparison.Ordinal
+                        ) == true
+                    )
+                    .Select(pair => pair.Value!)
+                    .Single();
+                string variable = probeKey[(probeKey.LastIndexOf('.') + 1)..];
+                return Task.FromResult(
+                    new ProcessResult(
+                        0,
+                        "credential." + variable + "\ntrue\0",
+                        string.Empty
+                    )
+                );
             }
 
             return Task.FromResult(
                 new ProcessResult(
                     0,
-                    "credential.helper\n" + ExpectedHelperCommand + "\0",
+                    BypassHelperValue is not null
+                        ? "local\0credential.helper\n"
+                            + BypassHelperValue
+                            + "\0"
+                        : "global\0credential.helper\n"
+                            + ExpectedHelperCommand
+                            + "\0"
+                            + (
+                                ConflictingHelperValue is null
+                                    ? string.Empty
+                                    : "global\0credential.https://dev.azure.com/org.helper\n\0"
+                                        + "global\0credential.https://dev.azure.com/org.helper\n"
+                                        + ConflictingHelperValue
+                                        + "\0"
+                            ),
                     string.Empty
                 )
             );
+        }
+    }
+
+    [Fact]
+    public void DoctorPrintsOnlySanitizedGitConflictProvenance()
+    {
+        const string SensitiveHelper =
+            "!provider --token secret-value --path /private/provider/location";
+        using var pythonFixture = new PythonDoctorFixture(PythonDoctorFixtureMode.Healthy);
+        CliRuntimeOptions runtime = CreateHealthyDoctorRuntimeOptions(
+            pythonFixture,
+            new ProcessResult(0, "unused-private-token", "unused-private-diagnostic"),
+            out _,
+            out HealthyDoctorGitDiscoveryProcessRunner gitDiscoveryRunner
+        );
+
+        Assert.Equal(0, InvokeWithRuntime(runtime, "configure", "git").ExitCode);
+        gitDiscoveryRunner.ConflictingHelperValue = SensitiveHelper;
+
+        CommandResult doctor = InvokeWithRuntime(runtime, "doctor");
+
+        Assert.Equal(1, doctor.ExitCode);
+        AssertDoctorCheck(
+            doctor.StdOut,
+            "git-effective-credential-helper-conflict",
+            "scope=global; selector=url-specific; directive=reset"
+        );
+        AssertDoctorCheck(
+            doctor.StdOut,
+            "git-effective-credential-helper-remediation",
+            "remove the conflicting reset or configure the product helper after it"
+        );
+        Assert.DoesNotContain(SensitiveHelper, doctor.StdOut, StringComparison.Ordinal);
+        Assert.DoesNotContain("secret-value", doctor.StdErr, StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "/private/provider/location",
+            doctor.StdOut,
+            StringComparison.Ordinal
+        );
+    }
+
+    [Fact]
+    public void DoctorDoesNotAttributeBypassToObservedThirdPartyHelper()
+    {
+        const string SensitiveHelper =
+            "!local-provider --token bypass-secret --path /private/local/provider";
+        using var pythonFixture = new PythonDoctorFixture(PythonDoctorFixtureMode.Healthy);
+        CliRuntimeOptions runtime = CreateHealthyDoctorRuntimeOptions(
+            pythonFixture,
+            new ProcessResult(0, "unused-private-token", "unused-private-diagnostic"),
+            out _,
+            out HealthyDoctorGitDiscoveryProcessRunner gitDiscoveryRunner
+        );
+
+        Assert.Equal(0, InvokeWithRuntime(runtime, "configure", "git").ExitCode);
+        gitDiscoveryRunner.BypassHelperValue = SensitiveHelper;
+
+        CommandResult doctor = InvokeWithRuntime(runtime, "doctor");
+
+        Assert.Equal(1, doctor.ExitCode);
+        AssertDoctorCheck(doctor.StdOut, "git-effective-credential-helper", "bypassed");
+        AssertDoctorCheck(doctor.StdOut, "git-effective-credential-helper-order", "other");
+        AssertDoctorCheck(
+            doctor.StdOut,
+            "git-effective-credential-helper-conflict",
+            "scope=unknown; selector=unknown; directive=activation-bypassed"
+        );
+        AssertDoctorCheck(
+            doctor.StdOut,
+            "git-effective-credential-helper-remediation",
+            "make the product-managed Git include effective and check Git configuration "
+                + "overrides such as GIT_CONFIG_GLOBAL"
+        );
+        Assert.DoesNotContain(SensitiveHelper, doctor.StdOut, StringComparison.Ordinal);
+        Assert.DoesNotContain("bypass-secret", doctor.StdErr, StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "/private/local/provider",
+            doctor.StdOut,
+            StringComparison.Ordinal
+        );
+    }
+
+    [Fact]
+    public void DoctorReportsIncompleteTruncatedUseHttpPathInspection()
+    {
+        using var pythonFixture = new PythonDoctorFixture(PythonDoctorFixtureMode.Healthy);
+        CliRuntimeOptions runtime = CreateHealthyDoctorRuntimeOptions(
+            pythonFixture,
+            new ProcessResult(0, "unused-private-token", "unused-private-diagnostic"),
+            out _,
+            out HealthyDoctorGitDiscoveryProcessRunner gitDiscoveryRunner
+        );
+
+        Assert.Equal(0, InvokeWithRuntime(runtime, "configure", "git").ExitCode);
+        gitDiscoveryRunner.UseHttpPathResultOverride = ProcessResult.OutputTooLarge(
+            "protocol=https\nhost=dev.azure.com\n"
+                + "username=azureauth-use-http-path-present\n"
+                + "******",
+            string.Empty,
+            exitCode: 0
+        );
+
+        CommandResult doctor = InvokeWithRuntime(runtime, "doctor");
+
+        Assert.Equal(1, doctor.ExitCode);
+        AssertDoctorCheck(
+            doctor.StdOut,
+            "dev.azure.com-useHttpPath",
+            "inspection-incomplete"
+        );
+        AssertDoctorCheck(
+            doctor.StdOut,
+            "dev.azure.com-useHttpPath-truncated",
+            "yes"
+        );
+        AssertDoctorCheck(doctor.StdOut, "git-effective-credential-helper-truncated", "no");
+    }
+
+    [Fact]
+    public async Task PassingGitDiscoveryRunnerIsolatesAndAppliesExplicitConfig()
+    {
+        string directory = CreateTestDirectory();
+        string globalConfig = Path.Combine(directory, "global.gitconfig");
+        File.WriteAllText(globalConfig, string.Empty);
+        var runner = new PassingGitDiscoveryProcessRunner(
+            ["GIT_CONFIG_NOSYSTEM", "GIT_CONFIG_KEY_99"]
+        );
+
+        try
+        {
+            _ = await runner.RunAsync(
+                new ProcessStartSpec(
+                    "ignored-git",
+                    ["config", "--get-all", "credential.helper"],
+                    directory,
+                    new Dictionary<string, string?>
+                    {
+                        ["GIT_CONFIG_GLOBAL"] = globalConfig,
+                        ["GIT_CONFIG_COUNT"] = "1",
+                        ["GIT_CONFIG_KEY_0"] = "credential.helper",
+                        ["GIT_CONFIG_VALUE_0"] = "manager",
+                    }
+                ),
+                TestContext.Current.CancellationToken
+            );
+
+            ProcessStartSpec effective = Assert.Single(runner.EffectiveGitStartSpecs);
+            Assert.Null(effective.Environment["GIT_CONFIG"]);
+            Assert.Equal(globalConfig, effective.Environment["GIT_CONFIG_GLOBAL"]);
+            Assert.Equal("1", effective.Environment["GIT_CONFIG_NOSYSTEM"]);
+            Assert.Null(effective.Environment["GIT_CONFIG_KEY_99"]);
+            Assert.Equal("1", effective.Environment["GIT_CONFIG_COUNT"]);
+            Assert.Equal(
+                "credential.helper",
+                effective.Environment["GIT_CONFIG_KEY_0"]
+            );
+        }
+        finally
+        {
+            DeleteDirectoryIfExists(directory);
         }
     }
 
@@ -6800,6 +7136,19 @@ public sealed class CliApplicationTests
         PythonDoctorFixture pythonFixture,
         ProcessResult healthProbeResult,
         out PromptingResultProcessRunner healthProbeRunner
+    ) =>
+        CreateHealthyDoctorRuntimeOptions(
+            pythonFixture,
+            healthProbeResult,
+            out healthProbeRunner,
+            out _
+        );
+
+    private static CliRuntimeOptions CreateHealthyDoctorRuntimeOptions(
+        PythonDoctorFixture pythonFixture,
+        ProcessResult healthProbeResult,
+        out PromptingResultProcessRunner healthProbeRunner,
+        out HealthyDoctorGitDiscoveryProcessRunner gitDiscoveryRunner
     )
     {
         var promptWriter = new StringWriter();
@@ -6832,10 +7181,11 @@ public sealed class CliApplicationTests
                 productionRoot.ProductionOptions,
             ])
         );
-        var gitDiscoveryRunner = new HealthyDoctorGitDiscoveryProcessRunner();
+        gitDiscoveryRunner = new HealthyDoctorGitDiscoveryProcessRunner();
         var gitOptions = new GitPhase8VerticalSliceOptions
         {
             StateDirectoryPath = pythonFixture.RootPath,
+            GitConfigurationProbeWorkingDirectoryPath = pythonFixture.RootPath,
             ProcessRunner = gitDiscoveryRunner,
             GitExecutablePath = "fake-git",
             LocalShellGitDiscoverySupported = true,

--- a/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Cli.Tests/CliApplicationTests.cs
+++ b/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Cli.Tests/CliApplicationTests.cs
@@ -977,25 +977,43 @@ public sealed class CliApplicationTests
     [Fact]
     public async Task GitCredentialHelperAppHostFailsClosedWithoutProvider()
     {
+        string configRoot = CreateTestDirectory();
         var runner = new SystemProcessRunner();
 
-        ProcessResult result = await runner.RunAsync(
-            new ProcessStartSpec(
-                CliAppHostPath(),
-                ["git", "credential-helper", "get"],
-                standardInput: """
-                protocol=https
-                host=dev.azure.com
-                path=org/project/_git/repository
+        try
+        {
+            ProcessResult result = await runner.RunAsync(
+                new ProcessStartSpec(
+                    CliAppHostPath(),
+                    ["git", "credential-helper", "get"],
+                    environment: new Dictionary<string, string?>
+                    {
+                        [SystemAzureAuthSecureRecordStoreOptions.ConfigRootEnvironmentVariable] =
+                            configRoot,
+                        ["GIT_TERMINAL_PROMPT"] = "0",
+                    },
+                    standardInput: """
+                    protocol=https
+                    host=dev.azure.com
+                    path=org/project/_git/repository
 
-                """
-            ),
-            TestContext.Current.CancellationToken
-        );
+                    """
+                ),
+                TestContext.Current.CancellationToken
+            );
 
-        Assert.Equal(64, result.ExitCode);
-        Assert.Equal(string.Empty, result.StandardOutput);
-        Assert.Contains("ProviderNotConfigured", result.StandardError, StringComparison.Ordinal);
+            Assert.Equal(64, result.ExitCode);
+            Assert.Equal(string.Empty, result.StandardOutput);
+            Assert.Contains(
+                "ProviderNotConfigured",
+                result.StandardError,
+                StringComparison.Ordinal
+            );
+        }
+        finally
+        {
+            DeleteDirectoryIfExists(configRoot);
+        }
     }
 
     [Fact(
@@ -1323,6 +1341,7 @@ public sealed class CliApplicationTests
     public async Task GitCredentialHelperAppHostAcceptsHelperNamedSymlink()
     {
         string tempDirectory = CreateTestDirectory();
+        string configRoot = CreateTestDirectory();
         var runner = new SystemProcessRunner();
         string helperPath = Path.Combine(tempDirectory, "git-credential-azureauth-credprovider");
 
@@ -1335,6 +1354,12 @@ public sealed class CliApplicationTests
                 new ProcessStartSpec(
                     helperPath,
                     ["get"],
+                    environment: new Dictionary<string, string?>
+                    {
+                        [SystemAzureAuthSecureRecordStoreOptions.ConfigRootEnvironmentVariable] =
+                            configRoot,
+                        ["GIT_TERMINAL_PROMPT"] = "0",
+                    },
                     standardInput: """
                     protocol=https
                     host=dev.azure.com
@@ -1356,6 +1381,7 @@ public sealed class CliApplicationTests
         finally
         {
             DeleteDirectoryIfExists(tempDirectory);
+            DeleteDirectoryIfExists(configRoot);
         }
     }
 

--- a/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform.Tests/GitCredentialHelperAdapterTests.cs
+++ b/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform.Tests/GitCredentialHelperAdapterTests.cs
@@ -11,6 +11,10 @@ namespace Hcoona.AzureAuth.CredProvider.Platform.Tests;
 
 public sealed class GitCredentialHelperAdapterTests
 {
+    private const string GitTerminalPromptDisabledGuidance =
+        "Git credential interaction is disabled by GIT_TERMINAL_PROMPT. Retry this Git "
+        + "operation from an interactive session with GIT_TERMINAL_PROMPT unset or enabled.";
+
     [Fact]
     public void GetForDevAzureRepoWritesGitCredentialFieldsOnly()
     {
@@ -645,6 +649,123 @@ public sealed class GitCredentialHelperAdapterTests
         Assert.Equal(AcquisitionMode.SilentOnly, request.AcquisitionMode);
     }
 
+    [Theory]
+    [InlineData(
+        CredentialResultStatus.InteractionRequired,
+        CredentialErrorKind.InteractionRequired,
+        "ProviderInteractionRequired"
+    )]
+    [InlineData(
+        CredentialResultStatus.InteractionBlocked,
+        CredentialErrorKind.InteractionBlocked,
+        "ProviderInteractionBlocked"
+    )]
+    public void GetWithGitTerminalPromptDisabledAddsNarrowGuidanceAndPreservesInteractionFailure(
+        CredentialResultStatus status,
+        CredentialErrorKind errorKind,
+        string errorCode
+    )
+    {
+        const string CorrelationId = "9f2ea1a1-45a4-48d2-9c7f-73a90e6732d2";
+        const string ProviderMessage = "Provider interaction failure.";
+        var credentialAcquisition = new ConfiguredFailureAcquisitionService(
+            status,
+            errorKind,
+            errorCode,
+            ProviderMessage,
+            CorrelationId
+        );
+
+        AdapterRunResult result = Execute(
+            ["git", "credential-helper", "get"],
+            """
+            protocol=https
+            host=dev.azure.com
+            path=org/project/_git/repository
+
+            """,
+            credentialAcquisition: credentialAcquisition,
+            environmentVariableReader: name =>
+                name == "GIT_TERMINAL_PROMPT" ? "0" : null
+        );
+
+        Assert.Equal(AdapterHostExitCode.InteractionRequired, result.Outcome.Result.ExitCode);
+        Assert.False(result.Outcome.Result.WriteProtocolStdout);
+        Assert.Equal(errorCode, result.Outcome.Result.SafeDiagnosticCode);
+        Assert.Equal(string.Empty, result.ProtocolStdout);
+        Assert.Empty(result.HumanStdout);
+        Assert.Single(
+            result.Stderr.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries)
+        );
+        Assert.EndsWith(
+            $" [{CorrelationId}] {GitTerminalPromptDisabledGuidance} code={errorCode}"
+                + Environment.NewLine,
+            result.Stderr,
+            StringComparison.Ordinal
+        );
+        Assert.DoesNotContain(ProviderMessage, result.Stderr, StringComparison.Ordinal);
+        Assert.DoesNotContain("pre-login", result.Stderr, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("prelogin", result.Stderr, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("browser", result.Stderr, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("cache", result.Stderr, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("seed", result.Stderr, StringComparison.OrdinalIgnoreCase);
+
+        CredentialRequestV2 request = Assert.Single(credentialAcquisition.Requests);
+        Assert.Equal(InteractivePolicy.Never, request.InteractivePolicy);
+        Assert.Equal(AcquisitionMode.SilentOnly, request.AcquisitionMode);
+    }
+
+    [Fact]
+    public void GetWithGitTerminalPromptDisabledDoesNotRemapUnrelatedProviderFailure()
+    {
+        const string CorrelationId = "ce2bf81e-5406-4e6c-a327-e1d027494b92";
+        const string ErrorCode = "ProviderUnauthorized";
+        const string ProviderMessage = "Provider rejected the credential request.";
+        var credentialAcquisition = new ConfiguredFailureAcquisitionService(
+            CredentialResultStatus.Unauthorized,
+            CredentialErrorKind.Unauthorized,
+            ErrorCode,
+            ProviderMessage,
+            CorrelationId
+        );
+
+        AdapterRunResult result = Execute(
+            ["git", "credential-helper", "get"],
+            """
+            protocol=https
+            host=dev.azure.com
+            path=org/project/_git/repository
+
+            """,
+            credentialAcquisition: credentialAcquisition,
+            environmentVariableReader: name =>
+                name == "GIT_TERMINAL_PROMPT" ? "0" : null
+        );
+
+        Assert.Equal(AdapterHostExitCode.Unauthorized, result.Outcome.Result.ExitCode);
+        Assert.False(result.Outcome.Result.WriteProtocolStdout);
+        Assert.Equal(ErrorCode, result.Outcome.Result.SafeDiagnosticCode);
+        Assert.Equal(string.Empty, result.ProtocolStdout);
+        Assert.Empty(result.HumanStdout);
+        Assert.Single(
+            result.Stderr.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries)
+        );
+        Assert.EndsWith(
+            $" [{CorrelationId}] {ProviderMessage} code={ErrorCode}" + Environment.NewLine,
+            result.Stderr,
+            StringComparison.Ordinal
+        );
+        Assert.DoesNotContain(
+            GitTerminalPromptDisabledGuidance,
+            result.Stderr,
+            StringComparison.Ordinal
+        );
+
+        CredentialRequestV2 request = Assert.Single(credentialAcquisition.Requests);
+        Assert.Equal(InteractivePolicy.Never, request.InteractivePolicy);
+        Assert.Equal(AcquisitionMode.SilentOnly, request.AcquisitionMode);
+    }
+
     [Fact]
     public void CompositionRootPassesEnvironmentReaderToGitCredentialHelper()
     {
@@ -713,6 +834,38 @@ public sealed class GitCredentialHelperAdapterTests
                         Kind = CredentialErrorKind.InteractionRequired,
                         Code = "SilentAcquisitionUnavailable",
                         SafeMessage = "Silent acquisition is unavailable.",
+                    },
+                }
+            );
+        }
+    }
+
+    private sealed class ConfiguredFailureAcquisitionService(
+        CredentialResultStatus status,
+        CredentialErrorKind errorKind,
+        string errorCode,
+        string safeMessage,
+        string correlationId
+    ) : ICredentialAcquisitionService
+    {
+        public List<CredentialRequestV2> Requests { get; } = [];
+
+        public ValueTask<CredentialResult> AcquireAsync(
+            CredentialRequestV2 request,
+            CancellationToken cancellationToken = default
+        )
+        {
+            Requests.Add(request);
+            return ValueTask.FromResult(
+                new CredentialResult
+                {
+                    Status = status,
+                    DiagnosticsCorrelationId = correlationId,
+                    Error = new CredentialError
+                    {
+                        Kind = errorKind,
+                        Code = errorCode,
+                        SafeMessage = safeMessage,
                     },
                 }
             );

--- a/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform.Tests/GitCredentialHelperAdapterTests.cs
+++ b/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform.Tests/GitCredentialHelperAdapterTests.cs
@@ -189,8 +189,8 @@ public sealed class GitCredentialHelperAdapterTests
         CredentialRequestV2 request = Assert.Single(credentialAcquisition.Requests);
         Assert.Null(request.AccountHint);
         Assert.Equal(IdentityFlow.InteractiveBrowser, request.IdentityFlow);
-        Assert.Equal(InteractivePolicy.Never, request.InteractivePolicy);
-        Assert.Equal(AcquisitionMode.SilentOnly, request.AcquisitionMode);
+        Assert.Equal(InteractivePolicy.HostToolAllows, request.InteractivePolicy);
+        Assert.Equal(AcquisitionMode.InteractionAllowed, request.AcquisitionMode);
         Assert.False(credentialAcquisition.BindingMismatchDetected);
         Assert.DoesNotContain("User@Example.com", result.ProtocolStdout, StringComparison.Ordinal);
         Assert.DoesNotContain(
@@ -359,7 +359,8 @@ public sealed class GitCredentialHelperAdapterTests
         string stdin,
         string executablePath = "/usr/local/bin/azureauth-credprovider",
         CredentialCoreService? credentialCore = null,
-        ICredentialAcquisitionService? credentialAcquisition = null
+        ICredentialAcquisitionService? credentialAcquisition = null,
+        Func<string, string?>? environmentVariableReader = null
     ) =>
         ExecuteCore(
             args,
@@ -367,6 +368,7 @@ public sealed class GitCredentialHelperAdapterTests
             executablePath,
             credentialCore,
             credentialAcquisition,
+            environmentVariableReader,
             TestContext.Current.CancellationToken
         );
 
@@ -382,6 +384,7 @@ public sealed class GitCredentialHelperAdapterTests
             "/usr/local/bin/azureauth-credprovider",
             credentialCore: null,
             credentialAcquisition,
+            environmentVariableReader: null,
             cancellationToken
         );
 
@@ -398,6 +401,7 @@ public sealed class GitCredentialHelperAdapterTests
             "/usr/local/bin/azureauth-credprovider",
             credentialCore: null,
             credentialAcquisition,
+            environmentVariableReader: null,
             cancellationToken,
             protocolStdout
         );
@@ -408,6 +412,7 @@ public sealed class GitCredentialHelperAdapterTests
         string executablePath,
         CredentialCoreService? credentialCore,
         ICredentialAcquisitionService? credentialAcquisition,
+        Func<string, string?>? environmentVariableReader,
         CancellationToken cancellationToken,
         TextWriter? suppliedProtocolStdout = null
     )
@@ -421,7 +426,8 @@ public sealed class GitCredentialHelperAdapterTests
         );
         _ = credentialCore;
         AdapterHostExecutionOutcome outcome = new GitCredentialHelperAdapter(
-            credentialAcquisition ?? new SuccessfulTestAcquisitionService()
+            credentialAcquisition ?? new SuccessfulTestAcquisitionService(),
+            environmentVariableReader ?? (_ => null)
         ).Execute(
             executablePath,
             args,
@@ -531,7 +537,7 @@ public sealed class GitCredentialHelperAdapterTests
     }
 
     [Fact]
-    public void GetKeepsSilentOnlyPolicyAndHumanStdoutEmpty()
+    public void GetWithDefaultEnvironmentAllowsInteractiveBrowserAndKeepsHumanStdoutEmpty()
     {
         var credentialAcquisition = new MismatchSensitiveAcquisitionService();
 
@@ -560,8 +566,8 @@ public sealed class GitCredentialHelperAdapterTests
         Assert.Equal(CredentialKind.BasicPassword, request.CredentialKind);
         Assert.Equal(IdentityFlow.InteractiveBrowser, request.IdentityFlow);
         Assert.NotEqual(IdentityFlow.DeviceCode, request.IdentityFlow);
-        Assert.Equal(InteractivePolicy.Never, request.InteractivePolicy);
-        Assert.Equal(AcquisitionMode.SilentOnly, request.AcquisitionMode);
+        Assert.Equal(InteractivePolicy.HostToolAllows, request.InteractivePolicy);
+        Assert.Equal(AcquisitionMode.InteractionAllowed, request.AcquisitionMode);
         Assert.Equal(CachePolicyMode.ProductPersistentCacheDisabled, request.CachePolicy);
         CiContext ciContext = Assert.IsType<CiContext>(request.CiContext);
         Assert.False(ciContext.ExplicitCiMode);
@@ -569,7 +575,7 @@ public sealed class GitCredentialHelperAdapterTests
     }
 
     [Fact]
-    public void GetSilentRequestPreservesDefaultServiceAndCanonicalResource()
+    public void GetInteractiveRequestPreservesDefaultServiceAndCanonicalResource()
     {
         var credentialAcquisition = new MismatchSensitiveAcquisitionService();
 
@@ -600,7 +606,116 @@ public sealed class GitCredentialHelperAdapterTests
             resource.ServiceEndpoint
         );
         Assert.Equal(IdentityFlow.InteractiveBrowser, request.IdentityFlow);
-        Assert.Equal(AcquisitionMode.SilentOnly, request.AcquisitionMode);
+        Assert.Equal(AcquisitionMode.InteractionAllowed, request.AcquisitionMode);
         Assert.Equal("username=AzureDevOps\npassword=fake-secret-git\n", result.ProtocolStdout);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("0")]
+    [InlineData("false")]
+    [InlineData("no")]
+    [InlineData("off")]
+    public void GetWithGitTerminalPromptDisabledUsesSilentOnlyAndFailsClosed(string value)
+    {
+        var credentialAcquisition = new SilentOnlyFailClosedAcquisitionService();
+
+        AdapterRunResult result = Execute(
+            ["git", "credential-helper", "get"],
+            """
+            protocol=https
+            host=dev.azure.com
+            path=org/project/_git/repository
+
+            """,
+            credentialAcquisition: credentialAcquisition,
+            environmentVariableReader: name =>
+                name == "GIT_TERMINAL_PROMPT" ? value : null
+        );
+
+        Assert.Equal(AdapterHostExitCode.InteractionRequired, result.Outcome.Result.ExitCode);
+        Assert.False(result.Outcome.Result.WriteProtocolStdout);
+        Assert.Equal(string.Empty, result.ProtocolStdout);
+        Assert.Empty(result.HumanStdout);
+        Assert.Contains("code=SilentAcquisitionUnavailable", result.Stderr);
+
+        CredentialRequestV2 request = Assert.Single(credentialAcquisition.Requests);
+        Assert.Equal(IdentityFlow.InteractiveBrowser, request.IdentityFlow);
+        Assert.Equal(InteractivePolicy.Never, request.InteractivePolicy);
+        Assert.Equal(AcquisitionMode.SilentOnly, request.AcquisitionMode);
+    }
+
+    [Fact]
+    public void CompositionRootPassesEnvironmentReaderToGitCredentialHelper()
+    {
+        var credentialAcquisition = new SilentOnlyFailClosedAcquisitionService();
+        CredentialProviderCompositionRoot root =
+            CredentialProviderCompositionRoot.CreateExplicitTestScaffold(
+                credentialAcquisition,
+                new CredentialProviderProductionOptions
+                {
+                    EnvironmentVariableReader = name =>
+                        name == "GIT_TERMINAL_PROMPT" ? "0" : null,
+                }
+            );
+        var protocolStdout = new StringWriter();
+        var humanStdout = new StringWriter();
+        var stderr = new StringWriter();
+
+        AdapterHostExecutionOutcome outcome = root.CreateGitCredentialHelperAdapter()
+            .Execute(
+                "/usr/local/bin/azureauth-credprovider",
+                ["git", "credential-helper", "get"],
+                new StringReader(
+                    """
+                    protocol=https
+                    host=dev.azure.com
+                    path=org/project/_git/repository
+
+                    """
+                ),
+                protocolStdout,
+                humanStdout,
+                new DiagnosticRouter(
+                    [new TextWriterDiagnosticSink(stderr)],
+                    SecretRedactor.Empty
+                ),
+                TestContext.Current.CancellationToken
+            );
+
+        Assert.Equal(AdapterHostExitCode.InteractionRequired, outcome.Result.ExitCode);
+        Assert.Equal(string.Empty, protocolStdout.ToString());
+        Assert.Equal(string.Empty, humanStdout.ToString());
+        Assert.Contains("code=SilentAcquisitionUnavailable", stderr.ToString());
+        Assert.Equal(
+            AcquisitionMode.SilentOnly,
+            Assert.Single(credentialAcquisition.Requests).AcquisitionMode
+        );
+    }
+
+    private sealed class SilentOnlyFailClosedAcquisitionService : ICredentialAcquisitionService
+    {
+        public List<CredentialRequestV2> Requests { get; } = [];
+
+        public ValueTask<CredentialResult> AcquireAsync(
+            CredentialRequestV2 request,
+            CancellationToken cancellationToken = default
+        )
+        {
+            Requests.Add(request);
+            return ValueTask.FromResult(
+                new CredentialResult
+                {
+                    Status = CredentialResultStatus.InteractionRequired,
+                    DiagnosticsCorrelationId = "git-silent-only-test",
+                    Error = new CredentialError
+                    {
+                        Kind = CredentialErrorKind.InteractionRequired,
+                        Code = "SilentAcquisitionUnavailable",
+                        SafeMessage = "Silent acquisition is unavailable.",
+                    },
+                }
+            );
+        }
     }
 }

--- a/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform.Tests/GitPhase8DoctorTests.cs
+++ b/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform.Tests/GitPhase8DoctorTests.cs
@@ -374,11 +374,11 @@ public sealed class GitPhase8DoctorTests
     }
 
     [Fact]
-    public async Task DoctorReportsDiscoveryFailureWhenGitCannotStart()
+    public async Task DoctorReportsDiscoveryFailureForLaunchFailureResult()
     {
         string stateDirectory = CreateTestDirectory();
-        var processRunner = new ThrowingGitDiscoveryProcessRunner(
-            new System.ComponentModel.Win32Exception(2)
+        var processRunner = new RecordingGitDiscoveryProcessRunner(
+            helperResult: ProcessResult.LaunchFailure()
         );
         var service = CreateService(stateDirectory, processRunner);
 
@@ -392,11 +392,102 @@ public sealed class GitPhase8DoctorTests
 
             Assert.False(result.LocalShellHelperShorthandSuccess);
             Assert.False(result.LocalShellHelperShorthandDeferred);
-            Assert.Equal(1, processRunner.InvocationCount);
+            Assert.Contains(
+                processRunner.StartSpecs,
+                startSpec => startSpec.Arguments.Contains("--get-regexp")
+            );
             Assert.Equal(
                 GitEffectiveCredentialHelperState.DiscoveryFailed,
                 result.EffectiveCredentialHelper.State
             );
+            Assert.False(result.EffectiveCredentialHelper.ConfigurationTruncated);
+            Assert.Empty(result.EffectiveCredentialHelper.EffectiveOrder);
+        }
+        finally
+        {
+            DeleteDirectoryIfExists(stateDirectory);
+        }
+    }
+
+    [Fact]
+    public async Task DoctorReportsTruncatedConfigurationWhenUrlMatchOutputIsTooLarge()
+    {
+        string stateDirectory = CreateTestDirectory();
+        var processRunner = new RecordingGitDiscoveryProcessRunner(
+            helperResult: new ProcessResult(
+                0,
+                "global\0credential.https://dev.azure.com/org.helper\nmanager\0",
+                string.Empty
+            ),
+            urlMatchResult: ProcessResult.OutputTooLarge(
+                "credential.partial\ntrue\0",
+                string.Empty,
+                exitCode: 0
+            )
+        );
+        var service = CreateService(stateDirectory, processRunner);
+
+        try
+        {
+            await service.ConfigureAsync(TestContext.Current.CancellationToken);
+
+            GitPhase8DoctorResult result = await service.DoctorAsync(
+                TestContext.Current.CancellationToken
+            );
+
+            Assert.Single(
+                processRunner.StartSpecs,
+                startSpec => startSpec.Arguments.Contains("--get-urlmatch")
+            );
+            Assert.Equal(
+                GitEffectiveCredentialHelperState.DiscoveryFailed,
+                result.EffectiveCredentialHelper.State
+            );
+            Assert.True(result.EffectiveCredentialHelper.ConfigurationTruncated);
+            Assert.Empty(result.EffectiveCredentialHelper.EffectiveOrder);
+        }
+        finally
+        {
+            DeleteDirectoryIfExists(stateDirectory);
+        }
+    }
+
+    [Fact]
+    public async Task DoctorRejectsMalformedNulDelimitedUrlMatchOutput()
+    {
+        string stateDirectory = CreateTestDirectory();
+        var processRunner = new RecordingGitDiscoveryProcessRunner(
+            helperResult: new ProcessResult(
+                0,
+                "global\0credential.https://dev.azure.com/org.helper\nmanager\0",
+                string.Empty
+            ),
+            urlMatchResult: new ProcessResult(
+                0,
+                "credential.unknown\ntrue\0unterminated",
+                string.Empty
+            )
+        );
+        var service = CreateService(stateDirectory, processRunner);
+
+        try
+        {
+            await service.ConfigureAsync(TestContext.Current.CancellationToken);
+
+            GitPhase8DoctorResult result = await service.DoctorAsync(
+                TestContext.Current.CancellationToken
+            );
+
+            Assert.Single(
+                processRunner.StartSpecs,
+                startSpec => startSpec.Arguments.Contains("--get-urlmatch")
+            );
+            Assert.Equal(
+                GitEffectiveCredentialHelperState.DiscoveryFailed,
+                result.EffectiveCredentialHelper.State
+            );
+            Assert.False(result.EffectiveCredentialHelper.ConfigurationTruncated);
+            Assert.Empty(result.EffectiveCredentialHelper.EffectiveOrder);
         }
         finally
         {
@@ -1990,7 +2081,8 @@ public sealed class GitPhase8DoctorTests
 
     private sealed class RecordingGitDiscoveryProcessRunner(
         ProcessResult? helperResult = null,
-        ProcessResult? useHttpPathResult = null
+        ProcessResult? useHttpPathResult = null,
+        ProcessResult? urlMatchResult = null
     )
         : IProcessRunner
     {
@@ -2015,6 +2107,14 @@ public sealed class GitPhase8DoctorTests
             )
             {
                 return Task.FromResult(helperResult);
+            }
+
+            if (
+                urlMatchResult is not null
+                && startSpec.Arguments.Contains("--get-urlmatch")
+            )
+            {
+                return Task.FromResult(urlMatchResult);
             }
 
             if (
@@ -2064,23 +2164,6 @@ public sealed class GitPhase8DoctorTests
                 fallbackStartSpec,
                 cancellationToken
             );
-        }
-    }
-
-    private sealed class ThrowingGitDiscoveryProcessRunner(Exception exception) : IProcessRunner
-    {
-        public int InvocationCount { get; private set; }
-
-        public Task<ProcessResult> RunAsync(
-            ProcessStartSpec startSpec,
-            CancellationToken cancellationToken = default
-        )
-        {
-            ArgumentNullException.ThrowIfNull(startSpec);
-            cancellationToken.ThrowIfCancellationRequested();
-
-            InvocationCount++;
-            throw exception;
         }
     }
 

--- a/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform.Tests/GitPhase8DoctorTests.cs
+++ b/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform.Tests/GitPhase8DoctorTests.cs
@@ -29,13 +29,16 @@ public sealed class GitPhase8DoctorTests
             Assert.Equal(2, processRunner.StartSpecs.Count);
             ProcessStartSpec startSpec = processRunner.StartSpecs[0];
             Assert.True(result.LocalShellHelperShorthandSuccess);
-            Assert.True(result.DevAzureUseHttpPathPresent);
+            Assert.Equal(
+                GitUseHttpPathInspectionState.Present,
+                result.DevAzureUseHttpPath.State
+            );
             Assert.Equal("git-probe", startSpec.FileName);
             Assert.Equal(
                 [
                     "config",
-                    "--global",
                     "--includes",
+                    "--show-scope",
                     "--null",
                     "--get-regexp",
                     @"^credential(\..*)?\.helper$",
@@ -49,6 +52,23 @@ public sealed class GitPhase8DoctorTests
                 startSpec.Environment["HOME"]
             );
             Assert.True(processRunner.HelperAliasWasPresent);
+            Assert.All(
+                processRunner.FallbackStartSpecs,
+                fallback =>
+                {
+                    Assert.Null(fallback.Environment["GIT_CONFIG"]);
+                    Assert.Null(fallback.Environment["GIT_CONFIG_GLOBAL"]);
+                    Assert.Equal("1", fallback.Environment["GIT_CONFIG_NOSYSTEM"]);
+                }
+            );
+            Assert.Equal(
+                GitEffectiveCredentialHelperState.Active,
+                result.EffectiveCredentialHelper.State
+            );
+            Assert.Equal(
+                [GitEffectiveCredentialHelperEntryKind.Product],
+                result.EffectiveCredentialHelper.EffectiveOrder
+            );
         }
         finally
         {
@@ -96,11 +116,15 @@ public sealed class GitPhase8DoctorTests
     }
 
     [Fact]
-    public async Task DoctorFailsDiscoveryWhenGitDoesNotReturnExpectedConfiguredHelper()
+    public async Task DoctorReportsBypassWhenGitDoesNotReturnExpectedConfiguredHelper()
     {
         string stateDirectory = CreateTestDirectory();
         var processRunner = new RecordingGitDiscoveryProcessRunner(
-            new ProcessResult(0, "manager\n", string.Empty)
+            new ProcessResult(
+                0,
+                "global\0credential.helper\nmanager\0",
+                string.Empty
+            )
         );
         var service = CreateService(stateDirectory, processRunner);
 
@@ -114,6 +138,195 @@ public sealed class GitPhase8DoctorTests
 
             Assert.False(result.LocalShellHelperShorthandSuccess);
             Assert.Equal(2, processRunner.StartSpecs.Count);
+            Assert.Equal(
+                GitEffectiveCredentialHelperState.Bypassed,
+                result.EffectiveCredentialHelper.State
+            );
+            Assert.Equal(
+                [GitEffectiveCredentialHelperEntryKind.Other],
+                result.EffectiveCredentialHelper.EffectiveOrder
+            );
+            Assert.Equal(
+                new GitCredentialHelperConflictDescriptor
+                {
+                    Scope = GitConfigurationScope.Unknown,
+                    Selector = GitCredentialHelperSelectorKind.Unknown,
+                    Directive = GitCredentialHelperConflictDirective.ActivationBypassed,
+                },
+                result.EffectiveCredentialHelper.Conflict
+            );
+        }
+        finally
+        {
+            DeleteDirectoryIfExists(stateDirectory);
+        }
+    }
+
+    [Fact]
+    public async Task DoctorReportsEffectiveThirdPartyOrderWithoutProductConfiguration()
+    {
+        string stateDirectory = CreateTestDirectory();
+        var processRunner = new RecordingGitDiscoveryProcessRunner(
+            new ProcessResult(
+                0,
+                "global\0credential.helper\nmanager\0",
+                string.Empty
+            )
+        );
+        var service = CreateService(stateDirectory, processRunner);
+
+        try
+        {
+            GitPhase8DoctorResult result = await service.DoctorAsync(
+                TestContext.Current.CancellationToken
+            );
+
+            Assert.Equal(
+                GitEffectiveCredentialHelperState.NotConfigured,
+                result.EffectiveCredentialHelper.State
+            );
+            Assert.Equal(
+                [GitEffectiveCredentialHelperEntryKind.Other],
+                result.EffectiveCredentialHelper.EffectiveOrder
+            );
+        }
+        finally
+        {
+            DeleteDirectoryIfExists(stateDirectory);
+        }
+    }
+
+    [Fact]
+    public async Task DoctorBoundsOversizedCredentialHelperConfiguration()
+    {
+        string stateDirectory = CreateTestDirectory();
+        string oversizedOutput = string.Concat(
+            Enumerable.Repeat("global\0credential.helper\nmanager\0", 129)
+        );
+        var processRunner = new RecordingGitDiscoveryProcessRunner(
+            new ProcessResult(0, oversizedOutput, string.Empty)
+        );
+        var service = CreateService(stateDirectory, processRunner);
+
+        try
+        {
+            await service.ConfigureAsync(TestContext.Current.CancellationToken);
+
+            GitPhase8DoctorResult result = await service.DoctorAsync(
+                TestContext.Current.CancellationToken
+            );
+
+            Assert.Equal(
+                GitEffectiveCredentialHelperState.DiscoveryFailed,
+                result.EffectiveCredentialHelper.State
+            );
+            Assert.True(result.EffectiveCredentialHelper.ConfigurationTruncated);
+            Assert.Empty(result.EffectiveCredentialHelper.EffectiveOrder);
+        }
+        finally
+        {
+            DeleteDirectoryIfExists(stateDirectory);
+        }
+    }
+
+    public static IEnumerable<object[]> AbnormalHelperDiscoveryResults()
+    {
+        const string Partial = "global\0credential.helper\nmanager\0";
+        yield return
+        [
+            ProcessResult.OutputTooLarge(Partial, string.Empty, exitCode: 0),
+            true,
+        ];
+        yield return
+        [
+            ProcessResult.InvalidOutput(Partial, string.Empty, exitCode: 0),
+            false,
+        ];
+        yield return
+        [
+            ProcessResult.TimedOut(Partial, string.Empty, exitCode: 0),
+            false,
+        ];
+    }
+
+    [Theory]
+    [MemberData(nameof(AbnormalHelperDiscoveryResults))]
+    public async Task DoctorRejectsPartialHelperOutputFromAbnormalProcessResult(
+        ProcessResult processResult,
+        bool expectedTruncated
+    )
+    {
+        string stateDirectory = CreateTestDirectory();
+        var processRunner = new RecordingGitDiscoveryProcessRunner(processResult);
+        var service = CreateService(stateDirectory, processRunner);
+
+        try
+        {
+            await service.ConfigureAsync(TestContext.Current.CancellationToken);
+
+            GitPhase8DoctorResult result = await service.DoctorAsync(
+                TestContext.Current.CancellationToken
+            );
+
+            Assert.Equal(
+                GitEffectiveCredentialHelperState.DiscoveryFailed,
+                result.EffectiveCredentialHelper.State
+            );
+            Assert.Equal(
+                expectedTruncated,
+                result.EffectiveCredentialHelper.ConfigurationTruncated
+            );
+            Assert.Empty(result.EffectiveCredentialHelper.EffectiveOrder);
+        }
+        finally
+        {
+            DeleteDirectoryIfExists(stateDirectory);
+        }
+    }
+
+    public static IEnumerable<object[]> AbnormalUseHttpPathResults()
+    {
+        const string Partial =
+            "protocol=https\nhost=dev.azure.com\npath=org/project/_git/repository\n"
+            + "username=azureauth-use-http-path-present\n"
+            + "password=azureauth-use-http-path-probe\n";
+        yield return [ProcessResult.OutputTooLarge(Partial, string.Empty, exitCode: 0)];
+        yield return [ProcessResult.InvalidOutput(Partial, string.Empty, exitCode: 0)];
+        yield return [new ProcessResult(0, "protocol=https\nmalformed\n", string.Empty)];
+    }
+
+    [Theory]
+    [MemberData(nameof(AbnormalUseHttpPathResults))]
+    public async Task DoctorDoesNotReportUseHttpPathFromAbnormalProcessResult(
+        ProcessResult processResult
+    )
+    {
+        string stateDirectory = CreateTestDirectory();
+        var processRunner = new RecordingGitDiscoveryProcessRunner(
+            useHttpPathResult: processResult
+        );
+        var service = CreateService(stateDirectory, processRunner);
+
+        try
+        {
+            await service.ConfigureAsync(TestContext.Current.CancellationToken);
+
+            GitPhase8DoctorResult result = await service.DoctorAsync(
+                TestContext.Current.CancellationToken
+            );
+
+            Assert.Equal(
+                GitEffectiveCredentialHelperState.Active,
+                result.EffectiveCredentialHelper.State
+            );
+            Assert.Equal(
+                GitUseHttpPathInspectionState.InspectionIncomplete,
+                result.DevAzureUseHttpPath.State
+            );
+            Assert.Equal(
+                processResult.Status == ProcessExecutionStatus.OutputTooLarge,
+                result.DevAzureUseHttpPath.OutputTruncated
+            );
         }
         finally
         {
@@ -149,6 +362,10 @@ public sealed class GitPhase8DoctorTests
             Assert.False(result.LocalShellHelperShorthandSuccess);
             Assert.True(result.LocalShellHelperShorthandDeferred);
             Assert.Empty(processRunner.StartSpecs);
+            Assert.Equal(
+                GitEffectiveCredentialHelperState.DiscoveryDeferred,
+                result.EffectiveCredentialHelper.State
+            );
         }
         finally
         {
@@ -176,6 +393,10 @@ public sealed class GitPhase8DoctorTests
             Assert.False(result.LocalShellHelperShorthandSuccess);
             Assert.False(result.LocalShellHelperShorthandDeferred);
             Assert.Equal(1, processRunner.InvocationCount);
+            Assert.Equal(
+                GitEffectiveCredentialHelperState.DiscoveryFailed,
+                result.EffectiveCredentialHelper.State
+            );
         }
         finally
         {
@@ -184,7 +405,7 @@ public sealed class GitPhase8DoctorTests
     }
 
     [Fact]
-    public async Task DoctorDoesNotDiscoverNonExecutableHelperArtifact()
+    public async Task DoctorSeparatesSelectedConfigurationFromNonExecutableHelperArtifact()
     {
         if (OperatingSystem.IsWindows())
         {
@@ -208,7 +429,11 @@ public sealed class GitPhase8DoctorTests
             );
 
             Assert.False(result.LocalShellHelperShorthandSuccess);
-            Assert.Empty(processRunner.StartSpecs);
+            Assert.Equal(2, processRunner.StartSpecs.Count);
+            Assert.Equal(
+                GitEffectiveCredentialHelperState.Active,
+                result.EffectiveCredentialHelper.State
+            );
         }
         finally
         {
@@ -361,7 +586,10 @@ public sealed class GitPhase8DoctorTests
             );
             Assert.True(doctor.OwnedGitEntriesPresent);
             Assert.True(doctor.LocalShellHelperShorthandSuccess);
-            Assert.True(doctor.DevAzureUseHttpPathPresent);
+            Assert.Equal(
+                GitUseHttpPathInspectionState.Present,
+                doctor.DevAzureUseHttpPath.State
+            );
 
             await service.UnconfigureAsync(TestContext.Current.CancellationToken);
 
@@ -782,7 +1010,10 @@ public sealed class GitPhase8DoctorTests
 
             Assert.Equal(xdgGitConfig, service.Paths.UserGitConfigPath);
             Assert.True(doctor.LocalShellHelperShorthandSuccess);
-            Assert.True(doctor.DevAzureUseHttpPathPresent);
+            Assert.Equal(
+                GitUseHttpPathInspectionState.Present,
+                doctor.DevAzureUseHttpPath.State
+            );
             Assert.Contains(
                 "# existing XDG config\n",
                 File.ReadAllText(xdgGitConfig),
@@ -889,7 +1120,27 @@ public sealed class GitPhase8DoctorTests
             );
 
             Assert.False(doctor.LocalShellHelperShorthandSuccess);
-            Assert.True(doctor.DevAzureUseHttpPathPresent);
+            Assert.Equal(
+                GitUseHttpPathInspectionState.Present,
+                doctor.DevAzureUseHttpPath.State
+            );
+            Assert.Equal(
+                GitEffectiveCredentialHelperState.Shadowed,
+                doctor.EffectiveCredentialHelper.State
+            );
+            Assert.Equal(
+                [GitEffectiveCredentialHelperEntryKind.Other],
+                doctor.EffectiveCredentialHelper.EffectiveOrder
+            );
+            Assert.Equal(
+                new GitCredentialHelperConflictDescriptor
+                {
+                    Scope = GitConfigurationScope.Global,
+                    Selector = GitCredentialHelperSelectorKind.UrlSpecific,
+                    Directive = GitCredentialHelperConflictDirective.Reset,
+                },
+                doctor.EffectiveCredentialHelper.Conflict
+            );
         }
         finally
         {
@@ -921,7 +1172,18 @@ public sealed class GitPhase8DoctorTests
             );
 
             Assert.True(doctor.LocalShellHelperShorthandSuccess);
-            Assert.True(doctor.DevAzureUseHttpPathPresent);
+            Assert.Equal(
+                GitUseHttpPathInspectionState.Present,
+                doctor.DevAzureUseHttpPath.State
+            );
+            Assert.Equal(
+                GitEffectiveCredentialHelperState.Active,
+                doctor.EffectiveCredentialHelper.State
+            );
+            Assert.Equal(
+                [GitEffectiveCredentialHelperEntryKind.Product],
+                doctor.EffectiveCredentialHelper.EffectiveOrder
+            );
         }
         finally
         {
@@ -952,7 +1214,519 @@ public sealed class GitPhase8DoctorTests
             );
 
             Assert.True(doctor.LocalShellHelperShorthandSuccess);
-            Assert.False(doctor.DevAzureUseHttpPathPresent);
+            Assert.Equal(
+                GitUseHttpPathInspectionState.Absent,
+                doctor.DevAzureUseHttpPath.State
+            );
+        }
+        finally
+        {
+            DeleteDirectoryIfExists(stateDirectory);
+        }
+    }
+
+    [Fact]
+    public async Task DoctorReportsHelperResetWhenNoLaterHelperIsConfigured()
+    {
+        string stateDirectory = CreateTestDirectory();
+        GitPhase8VerticalSliceService service = CreateRealGitService(stateDirectory);
+
+        try
+        {
+            await service.ConfigureAsync(TestContext.Current.CancellationToken);
+            File.AppendAllText(
+                service.Paths.UserGitConfigPath,
+                """
+                [credential "https://dev.azure.com/org"]
+                    helper =
+
+                """
+            );
+
+            GitPhase8DoctorResult doctor = await service.DoctorAsync(
+                TestContext.Current.CancellationToken
+            );
+
+            Assert.Equal(
+                GitEffectiveCredentialHelperState.Reset,
+                doctor.EffectiveCredentialHelper.State
+            );
+            Assert.Empty(doctor.EffectiveCredentialHelper.EffectiveOrder);
+            Assert.Equal(
+                new GitCredentialHelperConflictDescriptor
+                {
+                    Scope = GitConfigurationScope.Global,
+                    Selector = GitCredentialHelperSelectorKind.UrlSpecific,
+                    Directive = GitCredentialHelperConflictDirective.Reset,
+                },
+                doctor.EffectiveCredentialHelper.Conflict
+            );
+        }
+        finally
+        {
+            DeleteDirectoryIfExists(stateDirectory);
+        }
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task DoctorTreatsOrdinaryHelperChainingAsActive(bool otherHelperAfterProduct)
+    {
+        string stateDirectory = CreateTestDirectory();
+        GitPhase8VerticalSliceService service = CreateRealGitService(stateDirectory);
+
+        try
+        {
+            await service.ConfigureAsync(TestContext.Current.CancellationToken);
+            const string OtherHelper = "[credential]\n\thelper = manager\n";
+            string userConfig = File.ReadAllText(service.Paths.UserGitConfigPath);
+            File.WriteAllText(
+                service.Paths.UserGitConfigPath,
+                otherHelperAfterProduct
+                    ? userConfig + OtherHelper
+                    : OtherHelper + userConfig
+            );
+
+            GitPhase8DoctorResult doctor = await service.DoctorAsync(
+                TestContext.Current.CancellationToken
+            );
+
+            Assert.Equal(
+                GitEffectiveCredentialHelperState.Active,
+                doctor.EffectiveCredentialHelper.State
+            );
+            Assert.Equal(
+                otherHelperAfterProduct
+                    ?
+                    [
+                        GitEffectiveCredentialHelperEntryKind.Product,
+                        GitEffectiveCredentialHelperEntryKind.Other,
+                    ]
+                    :
+                    [
+                        GitEffectiveCredentialHelperEntryKind.Other,
+                        GitEffectiveCredentialHelperEntryKind.Product,
+                    ],
+                doctor.EffectiveCredentialHelper.EffectiveOrder
+            );
+        }
+        finally
+        {
+            DeleteDirectoryIfExists(stateDirectory);
+        }
+    }
+
+    [Fact]
+    public async Task DoctorReportsBypassWhenGitGlobalConfigurationOverrideSkipsActivation()
+    {
+        string stateDirectory = CreateTestDirectory();
+        string repositoryDirectory = Path.Combine(stateDirectory, "repository");
+        string gitDirectory = Path.Combine(repositoryDirectory, ".git");
+        Directory.CreateDirectory(Path.Combine(gitDirectory, "objects"));
+        Directory.CreateDirectory(Path.Combine(gitDirectory, "refs"));
+        File.WriteAllText(Path.Combine(gitDirectory, "HEAD"), "ref: refs/heads/main\n");
+        File.WriteAllText(
+            Path.Combine(gitDirectory, "config"),
+            """
+            [core]
+                repositoryFormatVersion = 0
+                bare = false
+            [credential]
+                helper = manager
+
+            """
+        );
+        string overrideConfigPath = Path.Combine(stateDirectory, "override.gitconfig");
+        File.WriteAllText(overrideConfigPath, string.Empty);
+        var processRunner = new EnvironmentOverlayProcessRunner(
+            new Dictionary<string, string?>
+            {
+                ["GIT_CONFIG_GLOBAL"] = overrideConfigPath,
+                ["GIT_CONFIG_NOSYSTEM"] = "1",
+            }
+        );
+        GitPhase8VerticalSliceService service = CreateRealGitService(
+            stateDirectory,
+            processRunner: processRunner,
+            gitConfigurationProbeWorkingDirectory: repositoryDirectory
+        );
+
+        try
+        {
+            await service.ConfigureAsync(TestContext.Current.CancellationToken);
+
+            GitPhase8DoctorResult doctor = await service.DoctorAsync(
+                TestContext.Current.CancellationToken
+            );
+
+            Assert.True(doctor.OwnedGitEntriesPresent);
+            Assert.True(doctor.OwnershipManifestPresent);
+            Assert.Equal(
+                GitEffectiveCredentialHelperState.Bypassed,
+                doctor.EffectiveCredentialHelper.State
+            );
+            Assert.Equal(
+                [GitEffectiveCredentialHelperEntryKind.Other],
+                doctor.EffectiveCredentialHelper.EffectiveOrder
+            );
+            Assert.Equal(
+                new GitCredentialHelperConflictDescriptor
+                {
+                    Scope = GitConfigurationScope.Unknown,
+                    Selector = GitCredentialHelperSelectorKind.Unknown,
+                    Directive = GitCredentialHelperConflictDirective.ActivationBypassed,
+                },
+                doctor.EffectiveCredentialHelper.Conflict
+            );
+        }
+        finally
+        {
+            DeleteDirectoryIfExists(stateDirectory);
+        }
+    }
+
+    [Fact]
+    public async Task DoctorHonorsExplicitCommandScopeOverrideAfterIsolation()
+    {
+        string stateDirectory = CreateTestDirectory();
+        var processRunner = new EnvironmentOverlayProcessRunner(
+            new Dictionary<string, string?>
+            {
+                ["GIT_CONFIG_COUNT"] = "2",
+                ["GIT_CONFIG_KEY_0"] = "credential.https://dev.azure.com/org.helper",
+                ["GIT_CONFIG_VALUE_0"] = string.Empty,
+                ["GIT_CONFIG_KEY_1"] = "credential.https://dev.azure.com/org.helper",
+                ["GIT_CONFIG_VALUE_1"] = "manager",
+            }
+        );
+        GitPhase8VerticalSliceService service = CreateRealGitService(
+            stateDirectory,
+            processRunner: processRunner
+        );
+
+        try
+        {
+            await service.ConfigureAsync(TestContext.Current.CancellationToken);
+
+            GitPhase8DoctorResult doctor = await service.DoctorAsync(
+                TestContext.Current.CancellationToken
+            );
+
+            Assert.Equal(
+                GitEffectiveCredentialHelperState.Shadowed,
+                doctor.EffectiveCredentialHelper.State
+            );
+            Assert.Equal(
+                new GitCredentialHelperConflictDescriptor
+                {
+                    Scope = GitConfigurationScope.Command,
+                    Selector = GitCredentialHelperSelectorKind.UrlSpecific,
+                    Directive = GitCredentialHelperConflictDirective.Reset,
+                },
+                doctor.EffectiveCredentialHelper.Conflict
+            );
+        }
+        finally
+        {
+            DeleteDirectoryIfExists(stateDirectory);
+        }
+    }
+
+    [Fact]
+    public async Task DoctorIgnoresCredentialHelpersForUnrelatedHosts()
+    {
+        string stateDirectory = CreateTestDirectory();
+        GitPhase8VerticalSliceService service = CreateRealGitService(stateDirectory);
+
+        try
+        {
+            await service.ConfigureAsync(TestContext.Current.CancellationToken);
+            File.AppendAllText(
+                service.Paths.UserGitConfigPath,
+                """
+                [credential "https://github.com"]
+                    helper = manager
+
+                """
+            );
+
+            GitPhase8DoctorResult doctor = await service.DoctorAsync(
+                TestContext.Current.CancellationToken
+            );
+
+            Assert.Equal(
+                GitEffectiveCredentialHelperState.Active,
+                doctor.EffectiveCredentialHelper.State
+            );
+            Assert.Equal(
+                [GitEffectiveCredentialHelperEntryKind.Product],
+                doctor.EffectiveCredentialHelper.EffectiveOrder
+            );
+        }
+        finally
+        {
+            DeleteDirectoryIfExists(stateDirectory);
+        }
+    }
+
+    [Fact]
+    public async Task DoctorHandlesUnrelatedCredentialUrlPatternContainingEquals()
+    {
+        string stateDirectory = CreateTestDirectory();
+        var processRunner = new RecordingGitDiscoveryProcessRunner();
+        GitPhase8VerticalSliceService service = CreateRealGitService(
+            stateDirectory,
+            processRunner: processRunner
+        );
+
+        try
+        {
+            await service.ConfigureAsync(TestContext.Current.CancellationToken);
+            File.AppendAllText(
+                service.Paths.UserGitConfigPath,
+                """
+                [credential "https://example.com/path=segment"]
+                    helper = manager
+
+                """
+            );
+
+            GitPhase8DoctorResult doctor = await service.DoctorAsync(
+                TestContext.Current.CancellationToken
+            );
+
+            Assert.Equal(
+                GitEffectiveCredentialHelperState.Active,
+                doctor.EffectiveCredentialHelper.State
+            );
+            Assert.Equal(
+                [GitEffectiveCredentialHelperEntryKind.Product],
+                doctor.EffectiveCredentialHelper.EffectiveOrder
+            );
+            ProcessStartSpec applicabilityProbe = Assert.Single(
+                processRunner.StartSpecs,
+                startSpec => startSpec.Arguments.Contains("--get-urlmatch")
+            );
+            Assert.DoesNotContain("-c", applicabilityProbe.Arguments);
+            Assert.Contains(
+                applicabilityProbe.Environment,
+                pair =>
+                    pair.Key.StartsWith("GIT_CONFIG_KEY_", StringComparison.Ordinal)
+                    && pair.Value?.Contains("path=segment", StringComparison.Ordinal) == true
+            );
+        }
+        finally
+        {
+            DeleteDirectoryIfExists(stateDirectory);
+        }
+    }
+
+    [Fact]
+    public async Task DoctorIncludesRepositoryLocalCredentialHelperShadowing()
+    {
+        string stateDirectory = CreateTestDirectory();
+        string repositoryDirectory = Path.Combine(stateDirectory, "repository");
+        string gitDirectory = Path.Combine(repositoryDirectory, ".git");
+        Directory.CreateDirectory(gitDirectory);
+        Directory.CreateDirectory(Path.Combine(gitDirectory, "objects"));
+        Directory.CreateDirectory(Path.Combine(gitDirectory, "refs"));
+        File.WriteAllText(Path.Combine(gitDirectory, "HEAD"), "ref: refs/heads/main\n");
+        File.WriteAllText(
+            Path.Combine(gitDirectory, "config"),
+            """
+            [core]
+                repositoryFormatVersion = 0
+                bare = false
+            [credential "https://dev.azure.com/org"]
+                helper =
+                helper = manager
+
+            """
+        );
+        GitPhase8VerticalSliceService service = CreateRealGitService(
+            stateDirectory,
+            gitConfigurationProbeWorkingDirectory: repositoryDirectory
+        );
+
+        try
+        {
+            await service.ConfigureAsync(TestContext.Current.CancellationToken);
+
+            GitPhase8DoctorResult doctor = await service.DoctorAsync(
+                TestContext.Current.CancellationToken
+            );
+
+            Assert.Equal(
+                GitEffectiveCredentialHelperState.Shadowed,
+                doctor.EffectiveCredentialHelper.State
+            );
+            Assert.Equal(
+                [GitEffectiveCredentialHelperEntryKind.Other],
+                doctor.EffectiveCredentialHelper.EffectiveOrder
+            );
+            Assert.Equal(
+                new GitCredentialHelperConflictDescriptor
+                {
+                    Scope = GitConfigurationScope.Local,
+                    Selector = GitCredentialHelperSelectorKind.UrlSpecific,
+                    Directive = GitCredentialHelperConflictDirective.Reset,
+                },
+                doctor.EffectiveCredentialHelper.Conflict
+            );
+        }
+        finally
+        {
+            DeleteDirectoryIfExists(stateDirectory);
+        }
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task DoctorDelegatesWildcardCredentialScopeMatchingToGit(
+        bool replacementAfterReset
+    )
+    {
+        string stateDirectory = CreateTestDirectory();
+        GitPhase8VerticalSliceService service = CreateRealGitService(stateDirectory);
+
+        try
+        {
+            await service.ConfigureAsync(TestContext.Current.CancellationToken);
+            File.AppendAllText(
+                service.Paths.UserGitConfigPath,
+                "[credential \"https://*.azure.com/org\"]\n"
+                    + "\thelper =\n"
+                    + (replacementAfterReset ? "\thelper = manager\n" : string.Empty)
+            );
+
+            GitPhase8DoctorResult doctor = await service.DoctorAsync(
+                TestContext.Current.CancellationToken
+            );
+
+            Assert.Equal(
+                replacementAfterReset
+                    ? GitEffectiveCredentialHelperState.Shadowed
+                    : GitEffectiveCredentialHelperState.Reset,
+                doctor.EffectiveCredentialHelper.State
+            );
+            Assert.Equal(
+                GitCredentialHelperSelectorKind.UrlSpecific,
+                doctor.EffectiveCredentialHelper.Conflict?.Selector
+            );
+        }
+        finally
+        {
+            DeleteDirectoryIfExists(stateDirectory);
+        }
+    }
+
+    [Fact]
+    public async Task DoctorUsesCredentialConfigOrderForUseHttpPath()
+    {
+        string stateDirectory = CreateTestDirectory();
+        GitPhase8VerticalSliceService service = CreateRealGitService(stateDirectory);
+
+        try
+        {
+            await service.ConfigureAsync(TestContext.Current.CancellationToken);
+            File.AppendAllText(
+                service.Paths.UserGitConfigPath,
+                "[credential]\n\tuseHttpPath = false\n"
+            );
+
+            GitPhase8DoctorResult doctor = await service.DoctorAsync(
+                TestContext.Current.CancellationToken
+            );
+
+            Assert.Equal(
+                GitUseHttpPathInspectionState.Absent,
+                doctor.DevAzureUseHttpPath.State
+            );
+        }
+        finally
+        {
+            DeleteDirectoryIfExists(stateDirectory);
+        }
+    }
+
+    [Theory]
+    [InlineData("future", GitConfigurationScope.Unknown)]
+    [InlineData("GLOBAL", null)]
+    public async Task DoctorSanitizesUnknownScopeAndRejectsMalformedScope(
+        string scopeToken,
+        GitConfigurationScope? expectedScope
+    )
+    {
+        string stateDirectory = CreateTestDirectory();
+        var processRunner = new RecordingGitDiscoveryProcessRunner(
+            new ProcessResult(
+                0,
+                scopeToken + "\0credential.helper\nmanager\0",
+                string.Empty
+            )
+        );
+        var service = CreateService(stateDirectory, processRunner);
+
+        try
+        {
+            await service.ConfigureAsync(TestContext.Current.CancellationToken);
+
+            GitPhase8DoctorResult doctor = await service.DoctorAsync(
+                TestContext.Current.CancellationToken
+            );
+
+            if (expectedScope is null)
+            {
+                Assert.Equal(
+                    GitEffectiveCredentialHelperState.DiscoveryFailed,
+                    doctor.EffectiveCredentialHelper.State
+                );
+                Assert.Null(doctor.EffectiveCredentialHelper.Conflict);
+            }
+            else
+            {
+                Assert.Equal(
+                    GitEffectiveCredentialHelperState.Bypassed,
+                    doctor.EffectiveCredentialHelper.State
+                );
+                Assert.Equal(
+                    expectedScope,
+                    doctor.EffectiveCredentialHelper.Conflict?.Scope
+                );
+            }
+        }
+        finally
+        {
+            DeleteDirectoryIfExists(stateDirectory);
+        }
+    }
+
+    [Fact]
+    public async Task CreateRealGitServiceRemovesAmbientGitConfigurationVariables()
+    {
+        string stateDirectory = CreateTestDirectory();
+        var processRunner = new RecordingGitDiscoveryProcessRunner();
+        GitPhase8VerticalSliceService service = CreateRealGitService(
+            stateDirectory,
+            processRunner: processRunner
+        );
+
+        try
+        {
+            await service.ConfigureAsync(TestContext.Current.CancellationToken);
+            _ = await service.DoctorAsync(TestContext.Current.CancellationToken);
+
+            Assert.All(
+                processRunner.StartSpecs,
+                startSpec =>
+                {
+                    Assert.Null(startSpec.Environment["GIT_CONFIG_GLOBAL"]);
+                    Assert.Null(startSpec.Environment["GIT_CONFIG_COUNT"]);
+                    Assert.Equal("1", startSpec.Environment["GIT_CONFIG_NOSYSTEM"]);
+                }
+            );
         }
         finally
         {
@@ -969,6 +1743,7 @@ public sealed class GitPhase8DoctorTests
             new GitPhase8VerticalSliceOptions
             {
                 StateDirectoryPath = stateDirectory,
+                GitConfigurationProbeWorkingDirectoryPath = stateDirectory,
                 ProcessRunner = processRunner,
                 GitExecutablePath = gitExecutablePath,
                 LocalShellGitDiscoverySupported = true,
@@ -980,14 +1755,20 @@ public sealed class GitPhase8DoctorTests
         string stateDirectory,
         string? homeDirectory = null,
         Action? afterOwnedGitActivationRemoved = null,
-        IFileSystem? fileSystem = null
+        IFileSystem? fileSystem = null,
+        IProcessRunner? processRunner = null,
+        string? gitConfigurationProbeWorkingDirectory = null
     ) =>
         new(
             new GitPhase8VerticalSliceOptions
             {
                 StateDirectoryPath = stateDirectory,
                 UserHomeDirectoryPath = homeDirectory ?? Path.Combine(stateDirectory, "user-home"),
-                ProcessRunner = new SystemProcessRunner(),
+                GitConfigurationProbeWorkingDirectoryPath =
+                    gitConfigurationProbeWorkingDirectory ?? stateDirectory,
+                ProcessRunner = new IsolatedRealGitProcessRunner(
+                    processRunner ?? new SystemProcessRunner()
+                ),
                 GitExecutablePath = "git",
                 LocalShellGitDiscoverySupported = true,
                 ProductExecutablePath = CreateFakeProductExecutable(stateDirectory),
@@ -1100,10 +1881,122 @@ public sealed class GitPhase8DoctorTests
         }
     }
 
-    private sealed class RecordingGitDiscoveryProcessRunner(ProcessResult? result = null)
+    private static Dictionary<string, string?> CreateIsolatedGitEnvironment(
+        IReadOnlyDictionary<string, string?> explicitEnvironment
+    )
+    {
+        var environment = new Dictionary<string, string?>(StringComparer.Ordinal);
+        environment["GIT_CONFIG"] = null;
+        environment["GIT_CONFIG_COUNT"] = null;
+        environment["GIT_CONFIG_GLOBAL"] = null;
+        environment["GIT_CONFIG_PARAMETERS"] = null;
+        environment["GIT_CONFIG_SYSTEM"] = null;
+        foreach (
+            System.Collections.DictionaryEntry entry in Environment.GetEnvironmentVariables()
+        )
+        {
+            string? variable = entry.Key as string;
+            if (
+                variable is not null
+                && variable.StartsWith("GIT_CONFIG_", StringComparison.Ordinal)
+            )
+            {
+                environment[variable] = null;
+            }
+        }
+        environment["GIT_CONFIG_NOSYSTEM"] = "1";
+        ApplyExplicitEnvironment(environment, explicitEnvironment);
+        return environment;
+    }
+
+    private static void ApplyExplicitEnvironment(
+        Dictionary<string, string?> target,
+        IReadOnlyDictionary<string, string?> explicitEnvironment
+    )
+    {
+        foreach ((string key, string? value) in explicitEnvironment)
+        {
+            if (
+                !string.Equals(key, "GIT_CONFIG_COUNT", StringComparison.Ordinal)
+                && !key.StartsWith("GIT_CONFIG_KEY_", StringComparison.Ordinal)
+                && !key.StartsWith("GIT_CONFIG_VALUE_", StringComparison.Ordinal)
+            )
+            {
+                target[key] = value;
+            }
+        }
+
+        List<(string Key, string Value)> entries =
+            ReadExplicitGitConfigEntries(explicitEnvironment);
+        if (
+            entries.Count != 0
+            || explicitEnvironment.ContainsKey("GIT_CONFIG_COUNT")
+        )
+        {
+            target["GIT_CONFIG_COUNT"] = entries.Count.ToString(
+                System.Globalization.CultureInfo.InvariantCulture
+            );
+            for (var index = 0; index < entries.Count; index++)
+            {
+                target["GIT_CONFIG_KEY_" + index] = entries[index].Key;
+                target["GIT_CONFIG_VALUE_" + index] = entries[index].Value;
+            }
+        }
+    }
+
+    private static List<(string Key, string Value)> ReadExplicitGitConfigEntries(
+        IReadOnlyDictionary<string, string?> environment
+    )
+    {
+        if (
+            !environment.TryGetValue("GIT_CONFIG_COUNT", out string? countValue)
+            || countValue is null
+        )
+        {
+            return new List<(string Key, string Value)>();
+        }
+        if (
+            !int.TryParse(
+                countValue,
+                System.Globalization.NumberStyles.None,
+                System.Globalization.CultureInfo.InvariantCulture,
+                out int count
+            )
+            || count < 0
+        )
+        {
+            throw new InvalidOperationException("Invalid explicit Git configuration count.");
+        }
+
+        var entries = new List<(string Key, string Value)>(count);
+        for (var index = 0; index < count; index++)
+        {
+            if (
+                !environment.TryGetValue("GIT_CONFIG_KEY_" + index, out string? key)
+                || key is null
+                || !environment.TryGetValue(
+                    "GIT_CONFIG_VALUE_" + index,
+                    out string? value
+                )
+                || value is null
+            )
+            {
+                continue;
+            }
+            entries.Add((key, value));
+        }
+        return entries;
+    }
+
+    private sealed class RecordingGitDiscoveryProcessRunner(
+        ProcessResult? helperResult = null,
+        ProcessResult? useHttpPathResult = null
+    )
         : IProcessRunner
     {
         public List<ProcessStartSpec> StartSpecs { get; } = [];
+
+        public List<ProcessStartSpec> FallbackStartSpecs { get; } = [];
 
         public bool HelperAliasWasPresent { get; private set; }
 
@@ -1116,9 +2009,20 @@ public sealed class GitPhase8DoctorTests
             cancellationToken.ThrowIfCancellationRequested();
 
             StartSpecs.Add(startSpec);
-            if (result is not null && startSpec.Arguments.Contains("--get-regexp"))
+            if (
+                helperResult is not null
+                && startSpec.Arguments.Contains("--get-regexp")
+            )
             {
-                return Task.FromResult(result);
+                return Task.FromResult(helperResult);
+            }
+
+            if (
+                useHttpPathResult is not null
+                && startSpec.Arguments.Contains("fill")
+            )
+            {
+                return Task.FromResult(useHttpPathResult);
             }
 
             if (
@@ -1146,16 +2050,18 @@ public sealed class GitPhase8DoctorTests
                 }
             }
 
-            return new SystemProcessRunner().RunAsync(
-                new ProcessStartSpec(
+            var fallbackStartSpec = new ProcessStartSpec(
                     "git",
                     startSpec.Arguments,
                     startSpec.WorkingDirectory,
-                    startSpec.Environment,
+                    CreateIsolatedGitEnvironment(startSpec.Environment),
                     startSpec.StandardInput,
                     startSpec.Timeout,
                     startSpec.OutputCaptureOptions
-                ),
+            );
+            FallbackStartSpecs.Add(fallbackStartSpec);
+            return new SystemProcessRunner().RunAsync(
+                fallbackStartSpec,
                 cancellationToken
             );
         }
@@ -1175,6 +2081,92 @@ public sealed class GitPhase8DoctorTests
 
             InvocationCount++;
             throw exception;
+        }
+    }
+
+    private sealed class EnvironmentOverlayProcessRunner(
+        IReadOnlyDictionary<string, string?> environment
+    ) : IProcessRunner
+    {
+        public Task<ProcessResult> RunAsync(
+            ProcessStartSpec startSpec,
+            CancellationToken cancellationToken = default
+        )
+        {
+            var combinedEnvironment = new Dictionary<string, string?>(
+                StringComparer.Ordinal
+            );
+            ApplyExplicitEnvironment(combinedEnvironment, startSpec.Environment);
+            foreach ((string key, string? value) in environment)
+            {
+                if (
+                    !string.Equals(key, "GIT_CONFIG_COUNT", StringComparison.Ordinal)
+                    && !key.StartsWith("GIT_CONFIG_KEY_", StringComparison.Ordinal)
+                    && !key.StartsWith("GIT_CONFIG_VALUE_", StringComparison.Ordinal)
+                )
+                {
+                    combinedEnvironment[key] = value;
+                }
+            }
+            List<(string Key, string Value)> overlayEntries =
+                ReadExplicitGitConfigEntries(environment);
+            List<(string Key, string Value)> startEntries =
+                ReadExplicitGitConfigEntries(startSpec.Environment);
+            var combinedEntries = overlayEntries.Concat(startEntries).ToArray();
+            if (combinedEntries.Length != 0)
+            {
+                combinedEnvironment["GIT_CONFIG_COUNT"] =
+                    combinedEntries.Length.ToString(
+                        System.Globalization.CultureInfo.InvariantCulture
+                    );
+                for (var index = 0; index < combinedEntries.Length; index++)
+                {
+                    combinedEnvironment["GIT_CONFIG_KEY_" + index] =
+                        combinedEntries[index].Key;
+                    combinedEnvironment["GIT_CONFIG_VALUE_" + index] =
+                        combinedEntries[index].Value;
+                }
+            }
+
+            return new SystemProcessRunner().RunAsync(
+                new ProcessStartSpec(
+                    startSpec.FileName,
+                    startSpec.Arguments,
+                    startSpec.WorkingDirectory,
+                    combinedEnvironment,
+                    startSpec.StandardInput,
+                    startSpec.Timeout,
+                    startSpec.OutputCaptureOptions,
+                    startSpec.StandardErrorTee
+                ),
+                cancellationToken
+            );
+        }
+    }
+
+    private sealed class IsolatedRealGitProcessRunner(IProcessRunner inner) : IProcessRunner
+    {
+        public Task<ProcessResult> RunAsync(
+            ProcessStartSpec startSpec,
+            CancellationToken cancellationToken = default
+        )
+        {
+            Dictionary<string, string?> environment =
+                CreateIsolatedGitEnvironment(startSpec.Environment);
+
+            return inner.RunAsync(
+                new ProcessStartSpec(
+                    startSpec.FileName,
+                    startSpec.Arguments,
+                    startSpec.WorkingDirectory,
+                    environment,
+                    startSpec.StandardInput,
+                    startSpec.Timeout,
+                    startSpec.OutputCaptureOptions,
+                    startSpec.StandardErrorTee
+                ),
+                cancellationToken
+            );
         }
     }
 

--- a/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform.Tests/GitPhase8DoctorTests.cs
+++ b/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform.Tests/GitPhase8DoctorTests.cs
@@ -1254,6 +1254,20 @@ public sealed class GitPhase8DoctorTests
                 Assert.IsType<Hcoona.AzureAuth.CredProvider.Contracts.CiContext>(request.CiContext);
             Assert.False(ciContext.ExplicitCiMode);
             Assert.False(ciContext.AllowsPersistentWrites);
+            Hcoona.AzureAuth.CredProvider.Contracts.CredentialRequestV2 helperRequest =
+                credentialAcquisition.Requests[1];
+            Assert.Equal(
+                Hcoona.AzureAuth.CredProvider.Contracts.IdentityFlow.InteractiveBrowser,
+                helperRequest.IdentityFlow
+            );
+            Assert.Equal(
+                Hcoona.AzureAuth.CredProvider.Contracts.InteractivePolicy.Never,
+                helperRequest.InteractivePolicy
+            );
+            Assert.Equal(
+                Hcoona.AzureAuth.CredProvider.Contracts.AcquisitionMode.SilentOnly,
+                helperRequest.AcquisitionMode
+            );
             Assert.DoesNotContain(
                 credentialAcquisition.Requests,
                 candidate =>

--- a/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform.Tests/TestDoubles/InMemoryFileSystem.cs
+++ b/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform.Tests/TestDoubles/InMemoryFileSystem.cs
@@ -140,10 +140,12 @@ public sealed class InMemoryFileSystem
         bool result =
             pathSemantics == InMemoryPathSemantics.Posix ? path.StartsWith('/')
             : pathSemantics == InMemoryPathSemantics.Windows
-                ? path.Length >= 3
+                ? (
+                    path.Length >= 3
                     && char.IsAsciiLetter(path[0])
                     && path[1] == ':'
                     && IsSeparator(path[2])
+                ) || HasWindowsUncShareRoot(path)
             : Path.IsPathFullyQualified(path);
         Record(nameof(IsPathFullyQualified), path, result.ToString());
         return result;
@@ -521,18 +523,31 @@ public sealed class InMemoryFileSystem
         }
 
         char separator = pathSemantics == InMemoryPathSemantics.Windows ? '\\' : '/';
-        string replaced = path.Replace('\\', separator).Replace('/', separator);
+        string replaced =
+            pathSemantics == InMemoryPathSemantics.Windows
+                ? path.Replace('/', separator)
+                : path;
         string prefix;
         string remainder;
         if (pathSemantics == InMemoryPathSemantics.Windows)
         {
+            string[] uncComponents = replaced.StartsWith(@"\\", StringComparison.Ordinal)
+                ? replaced[2..].Split('\\', StringSplitOptions.RemoveEmptyEntries)
+                : [];
+            bool uncRooted = uncComponents.Length >= 2;
             bool rooted =
                 replaced.Length >= 3
                 && char.IsAsciiLetter(replaced[0])
                 && replaced[1] == ':'
                 && replaced[2] == separator;
-            prefix = rooted ? char.ToUpperInvariant(replaced[0]) + @":\" : rootPath;
-            remainder = rooted ? replaced[3..] : replaced;
+            prefix =
+                uncRooted ? @"\\" + uncComponents[0] + @"\" + uncComponents[1]
+                : rooted ? char.ToUpperInvariant(replaced[0]) + @":\"
+                : rootPath;
+            remainder =
+                uncRooted ? string.Join('\\', uncComponents.Skip(2))
+                : rooted ? replaced[3..]
+                : replaced;
         }
         else
         {
@@ -562,12 +577,29 @@ public sealed class InMemoryFileSystem
             components.Add(component);
         }
 
-        return components.Count == 0 ? prefix : prefix + string.Join(separator, components);
+        return components.Count == 0
+            ? prefix
+            : prefix
+                + (
+                    prefix.EndsWith(separator)
+                        ? string.Empty
+                        : separator.ToString()
+                )
+                + string.Join(separator, components);
     }
 
     private string GetParentPath(string path)
     {
-        int separatorIndex = path.LastIndexOfAny(['/', '\\']);
+        if (
+            pathSemantics == InMemoryPathSemantics.Windows
+            && HasWindowsUncShareRoot(path)
+            && path.Count(character => character == '\\') == 3
+        )
+        {
+            return path;
+        }
+
+        int separatorIndex = LastSeparatorIndex(path);
         if (separatorIndex <= 0)
         {
             return rootPath;
@@ -581,13 +613,37 @@ public sealed class InMemoryFileSystem
         return path[..separatorIndex];
     }
 
-    private static string GetFileName(string path)
+    private string GetFileName(string path)
     {
-        int separatorIndex = path.LastIndexOfAny(['/', '\\']);
+        int separatorIndex = LastSeparatorIndex(path);
         return separatorIndex < 0 ? path : path[(separatorIndex + 1)..];
     }
 
-    private static bool IsSeparator(char character) => character is '/' or '\\';
+    private int LastSeparatorIndex(string path) =>
+        UsesWindowsSeparatorSemantics()
+            ? path.LastIndexOfAny(['/', '\\'])
+            : path.LastIndexOf('/');
+
+    private bool IsSeparator(char character) =>
+        character == '/' || (UsesWindowsSeparatorSemantics() && character == '\\');
+
+    private bool UsesWindowsSeparatorSemantics() =>
+        pathSemantics == InMemoryPathSemantics.Windows
+        || (pathSemantics == InMemoryPathSemantics.Host && OperatingSystem.IsWindows());
+
+    private static bool HasWindowsUncShareRoot(string path)
+    {
+        if (!path.StartsWith(@"\\", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        string[] components = path[2..].Split(
+            ['\\', '/'],
+            StringSplitOptions.RemoveEmptyEntries
+        );
+        return components.Length >= 2;
+    }
 
     private string AppendSeparator(string path)
     {

--- a/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform.Tests/TestDoubles/InMemoryFileSystem.cs
+++ b/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform.Tests/TestDoubles/InMemoryFileSystem.cs
@@ -140,12 +140,10 @@ public sealed class InMemoryFileSystem
         bool result =
             pathSemantics == InMemoryPathSemantics.Posix ? path.StartsWith('/')
             : pathSemantics == InMemoryPathSemantics.Windows
-                ? (
-                    path.Length >= 3
+                ? path.Length >= 3
                     && char.IsAsciiLetter(path[0])
                     && path[1] == ':'
                     && IsSeparator(path[2])
-                ) || HasWindowsUncShareRoot(path)
             : Path.IsPathFullyQualified(path);
         Record(nameof(IsPathFullyQualified), path, result.ToString());
         return result;
@@ -523,31 +521,18 @@ public sealed class InMemoryFileSystem
         }
 
         char separator = pathSemantics == InMemoryPathSemantics.Windows ? '\\' : '/';
-        string replaced =
-            pathSemantics == InMemoryPathSemantics.Windows
-                ? path.Replace('/', separator)
-                : path;
+        string replaced = path.Replace('\\', separator).Replace('/', separator);
         string prefix;
         string remainder;
         if (pathSemantics == InMemoryPathSemantics.Windows)
         {
-            string[] uncComponents = replaced.StartsWith(@"\\", StringComparison.Ordinal)
-                ? replaced[2..].Split('\\', StringSplitOptions.RemoveEmptyEntries)
-                : [];
-            bool uncRooted = uncComponents.Length >= 2;
             bool rooted =
                 replaced.Length >= 3
                 && char.IsAsciiLetter(replaced[0])
                 && replaced[1] == ':'
                 && replaced[2] == separator;
-            prefix =
-                uncRooted ? @"\\" + uncComponents[0] + @"\" + uncComponents[1]
-                : rooted ? char.ToUpperInvariant(replaced[0]) + @":\"
-                : rootPath;
-            remainder =
-                uncRooted ? string.Join('\\', uncComponents.Skip(2))
-                : rooted ? replaced[3..]
-                : replaced;
+            prefix = rooted ? char.ToUpperInvariant(replaced[0]) + @":\" : rootPath;
+            remainder = rooted ? replaced[3..] : replaced;
         }
         else
         {
@@ -577,29 +562,12 @@ public sealed class InMemoryFileSystem
             components.Add(component);
         }
 
-        return components.Count == 0
-            ? prefix
-            : prefix
-                + (
-                    prefix.EndsWith(separator)
-                        ? string.Empty
-                        : separator.ToString()
-                )
-                + string.Join(separator, components);
+        return components.Count == 0 ? prefix : prefix + string.Join(separator, components);
     }
 
     private string GetParentPath(string path)
     {
-        if (
-            pathSemantics == InMemoryPathSemantics.Windows
-            && HasWindowsUncShareRoot(path)
-            && path.Count(character => character == '\\') == 3
-        )
-        {
-            return path;
-        }
-
-        int separatorIndex = LastSeparatorIndex(path);
+        int separatorIndex = path.LastIndexOfAny(['/', '\\']);
         if (separatorIndex <= 0)
         {
             return rootPath;
@@ -613,37 +581,13 @@ public sealed class InMemoryFileSystem
         return path[..separatorIndex];
     }
 
-    private string GetFileName(string path)
+    private static string GetFileName(string path)
     {
-        int separatorIndex = LastSeparatorIndex(path);
+        int separatorIndex = path.LastIndexOfAny(['/', '\\']);
         return separatorIndex < 0 ? path : path[(separatorIndex + 1)..];
     }
 
-    private int LastSeparatorIndex(string path) =>
-        UsesWindowsSeparatorSemantics()
-            ? path.LastIndexOfAny(['/', '\\'])
-            : path.LastIndexOf('/');
-
-    private bool IsSeparator(char character) =>
-        character == '/' || (UsesWindowsSeparatorSemantics() && character == '\\');
-
-    private bool UsesWindowsSeparatorSemantics() =>
-        pathSemantics == InMemoryPathSemantics.Windows
-        || (pathSemantics == InMemoryPathSemantics.Host && OperatingSystem.IsWindows());
-
-    private static bool HasWindowsUncShareRoot(string path)
-    {
-        if (!path.StartsWith(@"\\", StringComparison.Ordinal))
-        {
-            return false;
-        }
-
-        string[] components = path[2..].Split(
-            ['\\', '/'],
-            StringSplitOptions.RemoveEmptyEntries
-        );
-        return components.Length >= 2;
-    }
+    private static bool IsSeparator(char character) => character is '/' or '\\';
 
     private string AppendSeparator(string path)
     {


### PR DESCRIPTION
## Summary
- allow normal local Git credential requests to use interactive AzureAuth flows while explicit noninteractive contexts fail closed
- report effective Git helper ordering, resets, bypasses, shadowing, and sanitized provenance
- delegate URL matching and useHttpPath semantics to Git plumbing
- provide bounded guidance when GIT_TERMINAL_PROMPT disables interaction

## Validation
- targeted Git adapter and doctor scenarios
- full AzureAuth platform and isolated CLI suites
- HK PR gate
- multi-angle OCR review, independent TP/FP adjudication, and clean terminal rereview