### PR TITLE
fix(azureauth): Separate NuGet Installation From Activation

### DIFF
--- a/eng/scripts/azureauth-credprovider/DeploymentValidationLegacyNuGet.ps1
+++ b/eng/scripts/azureauth-credprovider/DeploymentValidationLegacyNuGet.ps1
@@ -35,14 +35,9 @@ function Get-LegacyNuGetCleanupPlan {
     if (-not (Test-Path -LiteralPath $ApplicationRoot -PathType Container)) {
         throw 'The legacy deployment application payload is unavailable.'
     }
-    if (-not (Test-Path -LiteralPath $NuGetPluginRoot)) {
-        return [pscustomobject]@{
-            Files       = @()
-            Directories = @()
-            Root        = $NuGetPluginRoot
-        }
-    }
-    if (-not (Test-Path -LiteralPath $NuGetPluginRoot -PathType Container)) {
+    $rootExists = Test-Path -LiteralPath $NuGetPluginRoot
+    if ($rootExists -and
+        -not (Test-Path -LiteralPath $NuGetPluginRoot -PathType Container)) {
         throw 'The legacy NuGet plugin root is not a directory.'
     }
 
@@ -50,9 +45,15 @@ function Get-LegacyNuGetCleanupPlan {
         [System.IO.Path]::DirectorySeparatorChar,
         [System.IO.Path]::AltDirectorySeparatorChar
     ) + [System.IO.Path]::DirectorySeparatorChar
-    $files = [System.Collections.Generic.List[string]]::new()
+    $files = [System.Collections.Generic.List[object]]::new()
     $directories = [System.Collections.Generic.HashSet[string]]::new($PathComparer)
-    foreach ($sourceFile in Get-ChildItem -LiteralPath $ApplicationRoot -File -Recurse -Force) {
+    $sourceFiles = if ($rootExists) {
+        @(Get-ChildItem -LiteralPath $ApplicationRoot -File -Recurse -Force)
+    }
+    else {
+        @()
+    }
+    foreach ($sourceFile in $sourceFiles) {
         $relativePath = [System.IO.Path]::GetRelativePath(
             $ApplicationRoot,
             $sourceFile.FullName
@@ -80,7 +81,18 @@ function Get-LegacyNuGetCleanupPlan {
         if ($sourceFile.Length -ne $targetFile.Length -or $sourceHash -cne $targetHash) {
             throw "The legacy NuGet plugin payload path '$targetPath' has drifted."
         }
-        $files.Add($targetPath)
+        $files.Add(
+            [pscustomobject]@{
+                Path         = $targetPath
+                Content      = [System.IO.File]::ReadAllBytes($targetPath)
+                UnixFileMode = if ($IsWindows) {
+                    $null
+                }
+                else {
+                    [int][System.IO.File]::GetUnixFileMode($targetPath)
+                }
+            }
+        )
 
         $directory = [System.IO.Path]::GetDirectoryName($targetPath)
         while (-not [string]::IsNullOrWhiteSpace($directory) -and
@@ -155,8 +167,20 @@ function Get-LegacyNuGetCleanupPlan {
             throw 'The legacy NuGet ownership manifest is not recognized.'
         }
 
-        $files.Add($markerPath)
-        $files.Add($OwnershipManifestPath)
+        foreach ($metadataPath in @($markerPath, $OwnershipManifestPath)) {
+            $files.Add(
+                [pscustomobject]@{
+                    Path         = $metadataPath
+                    Content      = [System.IO.File]::ReadAllBytes($metadataPath)
+                    UnixFileMode = if ($IsWindows) {
+                        $null
+                    }
+                    else {
+                        [int][System.IO.File]::GetUnixFileMode($metadataPath)
+                    }
+                }
+            )
+        }
     }
 
     return [pscustomobject]@{
@@ -173,22 +197,64 @@ function Remove-LegacyNuGetPayload {
         [object]$Plan
     )
 
-    foreach ($path in $Plan.Files) {
-        if ((Test-Path -LiteralPath $path -PathType Leaf) -and
-            $PSCmdlet.ShouldProcess($path, 'Remove legacy NuGet payload file')) {
-            Remove-Item -LiteralPath $path -Force
+    try {
+        foreach ($file in $Plan.Files) {
+            if ((Test-Path -LiteralPath $file.Path -PathType Leaf) -and
+                $PSCmdlet.ShouldProcess($file.Path, 'Remove legacy NuGet payload file')) {
+                Remove-Item -LiteralPath $file.Path -Force
+            }
+        }
+        foreach ($directory in @($Plan.Directories | Sort-Object Length -Descending)) {
+            if ((Test-Path -LiteralPath $directory -PathType Container) -and
+                @(Get-ChildItem -LiteralPath $directory -Force).Count -eq 0 -and
+                $PSCmdlet.ShouldProcess($directory, 'Remove empty legacy NuGet directory')) {
+                Remove-Item -LiteralPath $directory -Force
+            }
+        }
+        if ((Test-Path -LiteralPath $Plan.Root -PathType Container) -and
+            @(Get-ChildItem -LiteralPath $Plan.Root -Force).Count -eq 0 -and
+            $PSCmdlet.ShouldProcess($Plan.Root, 'Remove empty legacy NuGet root')) {
+            Remove-Item -LiteralPath $Plan.Root -Force
         }
     }
-    foreach ($directory in @($Plan.Directories | Sort-Object Length -Descending)) {
-        if ((Test-Path -LiteralPath $directory -PathType Container) -and
-            @(Get-ChildItem -LiteralPath $directory -Force).Count -eq 0 -and
-            $PSCmdlet.ShouldProcess($directory, 'Remove empty legacy NuGet directory')) {
-            Remove-Item -LiteralPath $directory -Force
+    catch {
+        $cleanupFailure = $_
+        $rollbackFailures = [System.Collections.Generic.List[System.Exception]]::new()
+        try {
+            New-Item -ItemType Directory -Path $Plan.Root -Force | Out-Null
+            foreach ($directory in @($Plan.Directories | Sort-Object Length)) {
+                New-Item -ItemType Directory -Path $directory -Force | Out-Null
+            }
+            foreach ($file in $Plan.Files) {
+                $parentPath = Split-Path -Parent $file.Path
+                if (-not [string]::IsNullOrWhiteSpace($parentPath)) {
+                    New-Item -ItemType Directory -Path $parentPath -Force | Out-Null
+                }
+                [System.IO.File]::WriteAllBytes($file.Path, $file.Content)
+                if ($null -ne $file.UnixFileMode) {
+                    [System.IO.File]::SetUnixFileMode(
+                        $file.Path,
+                        [System.IO.UnixFileMode][int]$file.UnixFileMode
+                    )
+                }
+            }
         }
-    }
-    if ((Test-Path -LiteralPath $Plan.Root -PathType Container) -and
-        @(Get-ChildItem -LiteralPath $Plan.Root -Force).Count -eq 0 -and
-        $PSCmdlet.ShouldProcess($Plan.Root, 'Remove empty legacy NuGet root')) {
-        Remove-Item -LiteralPath $Plan.Root -Force
+        catch {
+            $rollbackFailures.Add($_.Exception)
+        }
+
+        if ($rollbackFailures.Count -gt 0) {
+            $failures = [System.Collections.Generic.List[System.Exception]]::new()
+            $failures.Add($cleanupFailure.Exception)
+            foreach ($failure in $rollbackFailures) {
+                $failures.Add($failure)
+            }
+            throw [System.AggregateException]::new(
+                'Legacy NuGet cleanup failed and its validated state could not be restored.',
+                $failures
+            )
+        }
+
+        throw $cleanupFailure
     }
 }

--- a/eng/scripts/azureauth-credprovider/DeploymentValidationLegacyNuGet.ps1
+++ b/eng/scripts/azureauth-credprovider/DeploymentValidationLegacyNuGet.ps1
@@ -1,0 +1,194 @@
+#Requires -Version 7.0
+
+function Test-ExactObjectPropertySet {
+    param(
+        [Parameter(Mandatory = $true)]
+        [object]$Value,
+
+        [Parameter(Mandatory = $true)]
+        [string[]]$ExpectedNames
+    )
+
+    $actualNames = @($Value.PSObject.Properties.Name)
+    return $actualNames.Count -eq $ExpectedNames.Count -and
+    @($actualNames | Where-Object { $_ -cnotin $ExpectedNames }).Count -eq 0
+}
+
+function Get-LegacyNuGetCleanupPlan {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ApplicationRoot,
+
+        [Parameter(Mandatory = $true)]
+        [string]$NuGetPluginRoot,
+
+        [Parameter(Mandatory = $true)]
+        [string]$OwnershipManifestPath,
+
+        [Parameter(Mandatory = $true)]
+        [System.StringComparer]$PathComparer,
+
+        [Parameter(Mandatory = $true)]
+        [System.StringComparison]$PathComparison
+    )
+
+    if (-not (Test-Path -LiteralPath $ApplicationRoot -PathType Container)) {
+        throw 'The legacy deployment application payload is unavailable.'
+    }
+    if (-not (Test-Path -LiteralPath $NuGetPluginRoot)) {
+        return [pscustomobject]@{
+            Files       = @()
+            Directories = @()
+            Root        = $NuGetPluginRoot
+        }
+    }
+    if (-not (Test-Path -LiteralPath $NuGetPluginRoot -PathType Container)) {
+        throw 'The legacy NuGet plugin root is not a directory.'
+    }
+
+    $rootPrefix = $NuGetPluginRoot.TrimEnd(
+        [System.IO.Path]::DirectorySeparatorChar,
+        [System.IO.Path]::AltDirectorySeparatorChar
+    ) + [System.IO.Path]::DirectorySeparatorChar
+    $files = [System.Collections.Generic.List[string]]::new()
+    $directories = [System.Collections.Generic.HashSet[string]]::new($PathComparer)
+    foreach ($sourceFile in Get-ChildItem -LiteralPath $ApplicationRoot -File -Recurse -Force) {
+        $relativePath = [System.IO.Path]::GetRelativePath(
+            $ApplicationRoot,
+            $sourceFile.FullName
+        )
+        $targetPath = [System.IO.Path]::GetFullPath(
+            (Join-Path $NuGetPluginRoot $relativePath)
+        )
+        if (-not $targetPath.StartsWith($rootPrefix, $PathComparison)) {
+            throw 'The legacy NuGet plugin payload inventory escaped its recorded root.'
+        }
+        if (Test-Path -LiteralPath $targetPath -PathType Container) {
+            throw "The legacy NuGet plugin payload path '$targetPath' drifted to a directory."
+        }
+        if (-not (Test-Path -LiteralPath $targetPath -PathType Leaf)) {
+            continue
+        }
+
+        $targetFile = Get-Item -LiteralPath $targetPath -Force
+        $sourceHash = (
+            Get-FileHash -Algorithm SHA256 -LiteralPath $sourceFile.FullName
+        ).Hash
+        $targetHash = (
+            Get-FileHash -Algorithm SHA256 -LiteralPath $targetPath
+        ).Hash
+        if ($sourceFile.Length -ne $targetFile.Length -or $sourceHash -cne $targetHash) {
+            throw "The legacy NuGet plugin payload path '$targetPath' has drifted."
+        }
+        $files.Add($targetPath)
+
+        $directory = [System.IO.Path]::GetDirectoryName($targetPath)
+        while (-not [string]::IsNullOrWhiteSpace($directory) -and
+            -not $directory.Equals($NuGetPluginRoot, $PathComparison)) {
+            $directories.Add($directory) | Out-Null
+            $directory = [System.IO.Path]::GetDirectoryName($directory)
+        }
+    }
+
+    $markerPath = Join-Path $NuGetPluginRoot '.azureauth-credprovider.nuget-plugin-layout'
+    if (Test-Path -LiteralPath $markerPath -PathType Container) {
+        throw 'The legacy NuGet plugin marker drifted to a directory.'
+    }
+    if (Test-Path -LiteralPath $OwnershipManifestPath -PathType Container) {
+        throw 'The legacy NuGet ownership manifest drifted to a directory.'
+    }
+    $markerExists = Test-Path -LiteralPath $markerPath -PathType Leaf
+    $manifestExists = Test-Path -LiteralPath $OwnershipManifestPath -PathType Leaf
+    if ($markerExists -ne $manifestExists) {
+        throw 'The legacy NuGet marker and ownership manifest are inconsistent.'
+    }
+    if ($markerExists) {
+        $legacyMarker = (
+            "azureauth-credprovider nuget-plugin-layout`n" +
+            "phase=10`n" +
+            "runtime=netcore`n" +
+            "entrypoint=azureauth-credprovider.dll`n"
+        )
+        if ((Get-Content -LiteralPath $markerPath -Raw) -cne $legacyMarker) {
+            throw 'The legacy NuGet plugin marker is not recognized.'
+        }
+
+        $manifestJson = Get-Content -LiteralPath $OwnershipManifestPath -Raw
+        $manifest = $manifestJson | ConvertFrom-Json
+        if (-not (Test-ExactObjectPropertySet `
+                    -Value $manifest `
+                    -ExpectedNames @(
+                    'schemaVersion',
+                    'manifestId',
+                    'ownerProductId',
+                    'scope',
+                    'entrySelector',
+                    'productVersion',
+                    'safeMetadata',
+                    'entries'
+                ))) {
+            throw 'The legacy NuGet ownership manifest is not recognized.'
+        }
+        $entries = @($manifest.entries)
+        if ($manifest.schemaVersion -ne 1 -or
+            $manifest.manifestId -cne 'phase10-nuget-plugin-layout' -or
+            $manifest.ownerProductId -cne 'azureauth-credprovider' -or
+            $manifest.scope -cne 'user' -or
+            $manifest.entrySelector -cne 'nuget.plugin-layout' -or
+            $manifest.productVersion -cne 'phase10' -or
+            @($manifest.safeMetadata.PSObject.Properties).Count -ne 0 -or
+            $entries.Count -ne 1 -or
+            -not (Test-ExactObjectPropertySet `
+                    -Value $entries[0] `
+                    -ExpectedNames @(
+                    'sequence',
+                    'targetKind',
+                    'targetPathOrName',
+                    'key'
+                )) -or
+            $entries[0].sequence -ne 1 -or
+            $entries[0].targetKind -cne 'nuGetPluginLayout' -or
+            -not ([System.IO.Path]::GetFullPath(
+                    [string]$entries[0].targetPathOrName
+                )).Equals($NuGetPluginRoot, $PathComparison) -or
+            $entries[0].key -cne 'physical-target') {
+            throw 'The legacy NuGet ownership manifest is not recognized.'
+        }
+
+        $files.Add($markerPath)
+        $files.Add($OwnershipManifestPath)
+    }
+
+    return [pscustomobject]@{
+        Files       = @($files)
+        Directories = @($directories)
+        Root        = $NuGetPluginRoot
+    }
+}
+
+function Remove-LegacyNuGetPayload {
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(Mandatory = $true)]
+        [object]$Plan
+    )
+
+    foreach ($path in $Plan.Files) {
+        if ((Test-Path -LiteralPath $path -PathType Leaf) -and
+            $PSCmdlet.ShouldProcess($path, 'Remove legacy NuGet payload file')) {
+            Remove-Item -LiteralPath $path -Force
+        }
+    }
+    foreach ($directory in @($Plan.Directories | Sort-Object Length -Descending)) {
+        if ((Test-Path -LiteralPath $directory -PathType Container) -and
+            @(Get-ChildItem -LiteralPath $directory -Force).Count -eq 0 -and
+            $PSCmdlet.ShouldProcess($directory, 'Remove empty legacy NuGet directory')) {
+            Remove-Item -LiteralPath $directory -Force
+        }
+    }
+    if ((Test-Path -LiteralPath $Plan.Root -PathType Container) -and
+        @(Get-ChildItem -LiteralPath $Plan.Root -Force).Count -eq 0 -and
+        $PSCmdlet.ShouldProcess($Plan.Root, 'Remove empty legacy NuGet root')) {
+        Remove-Item -LiteralPath $Plan.Root -Force
+    }
+}

--- a/eng/scripts/azureauth-credprovider/Install-DeploymentValidationBundle.ps1
+++ b/eng/scripts/azureauth-credprovider/Install-DeploymentValidationBundle.ps1
@@ -43,6 +43,7 @@ if ($hostArchitecture -ne [System.Runtime.InteropServices.Architecture]::X64) {
     throw "Deployment validation bundles do not support host architecture '$hostArchitecture'."
 }
 $expectedTargetRid = if ($runningOnWindows) { 'win-x64' } else { 'linux-x64' }
+$legacySourceRevision = 'f1bf00d412732739713a18e9a07e8738ff80c6f8'
 if ($manifest.targetRid -ne $expectedTargetRid) {
     throw "This $($manifest.targetRid) bundle cannot be installed on $expectedTargetRid."
 }
@@ -244,7 +245,9 @@ if (Test-Path -LiteralPath $InstallRoot) {
 
         if ($receiptSchemaVersion -eq
             'azureauth-credprovider-deployment-validation-install-v1') {
-            if ([string]::IsNullOrWhiteSpace([string]$existingReceipt.nugetPluginRoot)) {
+            if ($existingReceipt.sourceRevision -cne $legacySourceRevision -or
+                $existingReceipt.targetRid -cne $expectedTargetRid -or
+                [string]::IsNullOrWhiteSpace([string]$existingReceipt.nugetPluginRoot)) {
                 throw 'The legacy deployment validation installation receipt is invalid.'
             }
             $legacyNuGetPluginRoot = [System.IO.Path]::GetFullPath(
@@ -380,6 +383,9 @@ try {
     }
     Move-Item -LiteralPath $stagedInstallRoot -Destination $InstallRoot
     $installRootActivated = $true
+    if ($null -ne $legacyNuGetCleanupPlan) {
+        Remove-LegacyNuGetPayload -Plan $legacyNuGetCleanupPlan
+    }
 }
 catch {
     $switchFailure = $_
@@ -427,10 +433,6 @@ catch {
     }
 
     throw $switchFailure
-}
-
-if ($null -ne $legacyNuGetCleanupPlan) {
-    Remove-LegacyNuGetPayload -Plan $legacyNuGetCleanupPlan
 }
 
 $undeletedBackupPaths = [System.Collections.Generic.List[string]]::new()

--- a/eng/scripts/azureauth-credprovider/Install-DeploymentValidationBundle.ps1
+++ b/eng/scripts/azureauth-credprovider/Install-DeploymentValidationBundle.ps1
@@ -4,8 +4,6 @@
 param(
     [string]$InstallRoot,
 
-    [string]$NuGetPluginRoot,
-
     [switch]$Force
 )
 
@@ -25,7 +23,6 @@ if ($manifest.schemaVersion -ne 'azureauth-credprovider-deployment-validation-v1
     $manifest.isRelease) {
     throw 'The bundle is not an internal deployment validation artifact.'
 }
-
 $runningOnWindows = $IsWindows
 $expectedBuildOs = if ($runningOnWindows) {
     'Windows'
@@ -131,34 +128,12 @@ if ([string]::IsNullOrWhiteSpace($InstallRoot)) {
     }
 }
 
-if ([string]::IsNullOrWhiteSpace($NuGetPluginRoot)) {
-    $NuGetPluginRoot = Join-Path $homeDirectory '.nuget/plugins/netcore/azureauth-credprovider'
-}
-
 $InstallRoot = [System.IO.Path]::GetFullPath($InstallRoot)
-$NuGetPluginRoot = [System.IO.Path]::GetFullPath($NuGetPluginRoot)
-foreach ($path in @($InstallRoot, $NuGetPluginRoot)) {
-    $pathRoot = [System.IO.Path]::GetPathRoot($path)
-    if ($path -eq $pathRoot -or
-        $path.TrimEnd([System.IO.Path]::DirectorySeparatorChar) -eq
-        $homeDirectory.TrimEnd([System.IO.Path]::DirectorySeparatorChar)) {
-        throw "The deployment target '$path' is too broad."
-    }
-}
-if ($InstallRoot.Equals($NuGetPluginRoot, $pathComparison)) {
-    throw 'The product and NuGet plugin roots must be distinct.'
-}
-$installRootPrefix = $InstallRoot.TrimEnd(
-    [System.IO.Path]::DirectorySeparatorChar,
-    [System.IO.Path]::AltDirectorySeparatorChar
-) + [System.IO.Path]::DirectorySeparatorChar
-$nugetPluginRootPrefix = $NuGetPluginRoot.TrimEnd(
-    [System.IO.Path]::DirectorySeparatorChar,
-    [System.IO.Path]::AltDirectorySeparatorChar
-) + [System.IO.Path]::DirectorySeparatorChar
-if ($InstallRoot.StartsWith($nugetPluginRootPrefix, $pathComparison) -or
-    $NuGetPluginRoot.StartsWith($installRootPrefix, $pathComparison)) {
-    throw 'The product and NuGet plugin roots must not contain one another.'
+$installPathRoot = [System.IO.Path]::GetPathRoot($InstallRoot)
+if ($InstallRoot -eq $installPathRoot -or
+    $InstallRoot.TrimEnd([System.IO.Path]::DirectorySeparatorChar) -eq
+    $homeDirectory.TrimEnd([System.IO.Path]::DirectorySeparatorChar)) {
+    throw "The deployment target '$InstallRoot' is too broad."
 }
 
 $applicationRoot = Join-Path $InstallRoot 'app'
@@ -226,7 +201,7 @@ if (Test-Path -LiteralPath $InstallRoot) {
         $existingReceipt = Get-Content -LiteralPath $existingReceiptPath -Raw |
             ConvertFrom-Json
         if ($existingReceipt.schemaVersion -ne
-            'azureauth-credprovider-deployment-validation-install-v1') {
+            'azureauth-credprovider-deployment-validation-install-v2') {
             throw 'The existing deployment validation installation receipt is invalid.'
         }
 
@@ -236,12 +211,8 @@ if (Test-Path -LiteralPath $InstallRoot) {
         $receiptApplicationRoot = [System.IO.Path]::GetFullPath(
             [string]$existingReceipt.applicationRoot
         )
-        $receiptNuGetPluginRoot = [System.IO.Path]::GetFullPath(
-            [string]$existingReceipt.nugetPluginRoot
-        )
         if (-not $InstallRoot.Equals($receiptInstallRoot, $pathComparison) -or
-            -not $applicationRoot.Equals($receiptApplicationRoot, $pathComparison) -or
-            -not $NuGetPluginRoot.Equals($receiptNuGetPluginRoot, $pathComparison)) {
+            -not $applicationRoot.Equals($receiptApplicationRoot, $pathComparison)) {
             throw 'The replacement roots do not match the existing installation receipt.'
         }
     }
@@ -253,30 +224,8 @@ if (Test-Path -LiteralPath $InstallRoot) {
     }
 }
 
-if (Test-Path -LiteralPath $NuGetPluginRoot) {
-    if (-not $Force) {
-        throw "The deployment target '$NuGetPluginRoot' already exists. Use -Force to replace it."
-    }
-    if (-not (Test-Path -LiteralPath $NuGetPluginRoot -PathType Container)) {
-        throw "The deployment target '$NuGetPluginRoot' is not a directory."
-    }
-    if ($null -eq $existingReceipt -and
-        -not (Test-EmptyDirectory -LiteralPath $NuGetPluginRoot)) {
-        throw (
-            "The deployment target '$NuGetPluginRoot' is non-empty and is not bound " +
-            'to a recognized installation receipt.'
-        )
-    }
-}
-
 $stagedInstallRoot = Get-SiblingDeploymentPath -LiteralPath $InstallRoot -Purpose 'installing'
-$stagedNuGetPluginRoot = Get-SiblingDeploymentPath `
-    -LiteralPath $NuGetPluginRoot `
-    -Purpose 'installing'
 $backupInstallRoot = Get-SiblingDeploymentPath -LiteralPath $InstallRoot -Purpose 'backup'
-$backupNuGetPluginRoot = Get-SiblingDeploymentPath `
-    -LiteralPath $NuGetPluginRoot `
-    -Purpose 'backup'
 $stagedApplicationRoot = Join-Path $stagedInstallRoot 'app'
 $stagedBinRoot = Join-Path $stagedInstallRoot 'bin'
 $stagedPythonRoot = Join-Path $stagedInstallRoot 'python'
@@ -285,14 +234,10 @@ try {
     New-Item -ItemType Directory -Path $stagedApplicationRoot -Force | Out-Null
     New-Item -ItemType Directory -Path $stagedBinRoot -Force | Out-Null
     New-Item -ItemType Directory -Path $stagedPythonRoot -Force | Out-Null
-    New-Item -ItemType Directory -Path $stagedNuGetPluginRoot -Force | Out-Null
 
     Copy-DirectoryContent `
         -Source (Join-Path $bundleRoot 'app') `
         -Destination $stagedApplicationRoot
-    Copy-DirectoryContent `
-        -Source (Join-Path $bundleRoot 'app') `
-        -Destination $stagedNuGetPluginRoot
     Copy-DirectoryContent `
         -Source (Join-Path $bundleRoot 'launchers') `
         -Destination $stagedBinRoot
@@ -311,7 +256,7 @@ try {
         throw 'The installed application payload is incomplete.'
     }
 
-    $nugetEntrypointPath = Join-Path $stagedNuGetPluginRoot 'azureauth-credprovider.dll'
+    $nugetEntrypointPath = Join-Path $stagedApplicationRoot 'azureauth-credprovider.dll'
     if (-not (Test-Path -LiteralPath $nugetEntrypointPath -PathType Leaf)) {
         throw 'The installed NuGet plugin payload is incomplete.'
     }
@@ -332,13 +277,12 @@ try {
     }
 
     $receipt = [ordered]@{
-        schemaVersion   = 'azureauth-credprovider-deployment-validation-install-v1'
+        schemaVersion   = 'azureauth-credprovider-deployment-validation-install-v2'
         productVersion  = $manifest.productVersion
         sourceRevision  = $manifest.sourceRevision
         targetRid       = $manifest.targetRid
         installRoot     = $InstallRoot
         applicationRoot = $applicationRoot
-        nugetPluginRoot = $NuGetPluginRoot
     }
     $receipt | ConvertTo-Json -Depth 5 |
         Set-Content `
@@ -346,89 +290,52 @@ try {
             -Encoding utf8
 }
 catch {
-    foreach ($path in @($stagedNuGetPluginRoot, $stagedInstallRoot)) {
-        if (Test-Path -LiteralPath $path) {
-            Remove-Item -LiteralPath $path -Recurse -Force
-        }
+    if (Test-Path -LiteralPath $stagedInstallRoot) {
+        Remove-Item -LiteralPath $stagedInstallRoot -Recurse -Force
     }
     throw
 }
 
 $installBackupCreated = $false
-$nugetPluginBackupCreated = $false
 $installRootActivated = $false
-$nugetPluginRootActivated = $false
 try {
     if (Test-Path -LiteralPath $InstallRoot) {
         Move-Item -LiteralPath $InstallRoot -Destination $backupInstallRoot
         $installBackupCreated = $true
     }
-    if (Test-Path -LiteralPath $NuGetPluginRoot) {
-        Move-Item -LiteralPath $NuGetPluginRoot -Destination $backupNuGetPluginRoot
-        $nugetPluginBackupCreated = $true
-    }
-
     Move-Item -LiteralPath $stagedInstallRoot -Destination $InstallRoot
     $installRootActivated = $true
-    Move-Item -LiteralPath $stagedNuGetPluginRoot -Destination $NuGetPluginRoot
-    $nugetPluginRootActivated = $true
 }
 catch {
     $switchFailure = $_
     $rollbackFailures = [System.Collections.Generic.List[System.Exception]]::new()
 
-    foreach ($replacement in @(
-            @{
-                Activated = $nugetPluginRootActivated
-                Path      = $NuGetPluginRoot
-            },
-            @{
-                Activated = $installRootActivated
-                Path      = $InstallRoot
-            }
-        )) {
-        if ($replacement.Activated -and (Test-Path -LiteralPath $replacement.Path)) {
-            try {
-                Remove-Item -LiteralPath $replacement.Path -Recurse -Force
-            }
-            catch {
-                $rollbackFailures.Add($_.Exception)
-            }
+    if ($installRootActivated -and (Test-Path -LiteralPath $InstallRoot)) {
+        try {
+            Remove-Item -LiteralPath $InstallRoot -Recurse -Force
+        }
+        catch {
+            $rollbackFailures.Add($_.Exception)
         }
     }
 
-    foreach ($backup in @(
-            @{
-                Created     = $nugetPluginBackupCreated
-                BackupPath  = $backupNuGetPluginRoot
-                RestorePath = $NuGetPluginRoot
-            },
-            @{
-                Created     = $installBackupCreated
-                BackupPath  = $backupInstallRoot
-                RestorePath = $InstallRoot
-            }
-        )) {
-        if ($backup.Created -and (Test-Path -LiteralPath $backup.BackupPath)) {
-            try {
-                Move-Item `
-                    -LiteralPath $backup.BackupPath `
-                    -Destination $backup.RestorePath
-            }
-            catch {
-                $rollbackFailures.Add($_.Exception)
-            }
+    if ($installBackupCreated -and (Test-Path -LiteralPath $backupInstallRoot)) {
+        try {
+            Move-Item `
+                -LiteralPath $backupInstallRoot `
+                -Destination $InstallRoot
+        }
+        catch {
+            $rollbackFailures.Add($_.Exception)
         }
     }
 
-    foreach ($path in @($stagedNuGetPluginRoot, $stagedInstallRoot)) {
-        if (Test-Path -LiteralPath $path) {
-            try {
-                Remove-Item -LiteralPath $path -Recurse -Force
-            }
-            catch {
-                $rollbackFailures.Add($_.Exception)
-            }
+    if (Test-Path -LiteralPath $stagedInstallRoot) {
+        try {
+            Remove-Item -LiteralPath $stagedInstallRoot -Recurse -Force
+        }
+        catch {
+            $rollbackFailures.Add($_.Exception)
         }
     }
 
@@ -448,27 +355,26 @@ catch {
 }
 
 $undeletedBackupPaths = [System.Collections.Generic.List[string]]::new()
-foreach ($path in @($backupNuGetPluginRoot, $backupInstallRoot)) {
-    if (Test-Path -LiteralPath $path) {
-        try {
-            Remove-Item -LiteralPath $path -Recurse -Force
+if (Test-Path -LiteralPath $backupInstallRoot) {
+    try {
+        Remove-Item -LiteralPath $backupInstallRoot -Recurse -Force
+    }
+    catch {
+        if (Test-Path -LiteralPath $backupInstallRoot) {
+            $undeletedBackupPaths.Add($backupInstallRoot)
+            Write-Warning (
+                "Post-commit cleanup could not completely remove deployment backup data at " +
+                "'$backupInstallRoot': $($_.Exception.Message) The active installation remains " +
+                'committed; data left at this path may be incomplete and must not be treated as ' +
+                'a fully recoverable backup.'
+            ) -WarningAction Continue
         }
-        catch {
-            if (Test-Path -LiteralPath $path) {
-                $undeletedBackupPaths.Add($path)
-                Write-Warning (
-                    "Post-commit cleanup could not completely remove deployment backup data at " +
-                    "'$path': $($_.Exception.Message) The active installation remains committed; " +
-                    'data left at this path may be incomplete and must not be treated as a fully ' +
-                    'recoverable backup.'
-                ) -WarningAction Continue
-            }
-            else {
-                Write-Warning (
-                    "Post-commit cleanup reported a failure after removing deployment backup " +
-                    "data at '$path': $($_.Exception.Message) The active installation remains committed."
-                ) -WarningAction Continue
-            }
+        else {
+            Write-Warning (
+                "Post-commit cleanup reported a failure after removing deployment backup " +
+                "data at '$backupInstallRoot': $($_.Exception.Message) The active installation " +
+                'remains committed.'
+            ) -WarningAction Continue
         }
     }
 }
@@ -482,6 +388,5 @@ if ($undeletedBackupPaths.Count -gt 0) {
 
 Write-Output "Installed internal deployment validation payload: $InstallRoot"
 Write-Output "CLI activation directory: $binRoot"
-Write-Output "NuGet plugin directory: $NuGetPluginRoot"
 Write-Output "Python wheel directory: $pythonRoot"
 Write-Output 'No global PATH, shell profile, registry, Git, NuGet, or Python environment was modified.'

--- a/eng/scripts/azureauth-credprovider/Install-DeploymentValidationBundle.ps1
+++ b/eng/scripts/azureauth-credprovider/Install-DeploymentValidationBundle.ps1
@@ -4,6 +4,8 @@
 param(
     [string]$InstallRoot,
 
+    [string]$LegacyNuGetOwnershipManifestPath,
+
     [switch]$Force
 )
 
@@ -67,6 +69,11 @@ $pathComparer = if ($runningOnWindows) {
 else {
     [System.StringComparer]::Ordinal
 }
+$legacyNuGetSupportPath = Join-Path $bundleRoot 'legacy-nuget.ps1'
+if (-not (Test-Path -LiteralPath $legacyNuGetSupportPath -PathType Leaf)) {
+    throw 'The deployment validation legacy NuGet support script is missing.'
+}
+. $legacyNuGetSupportPath
 $listedPaths = [System.Collections.Generic.HashSet[string]]::new($pathComparer)
 foreach ($entry in $manifestFiles) {
     $relativePath = [string]$entry.path
@@ -188,6 +195,7 @@ function Get-SiblingDeploymentPath {
 }
 
 $existingReceipt = $null
+$legacyNuGetCleanupPlan = $null
 if (Test-Path -LiteralPath $InstallRoot) {
     if (-not $Force) {
         throw "The deployment target '$InstallRoot' already exists. Use -Force to replace it."
@@ -200,9 +208,27 @@ if (Test-Path -LiteralPath $InstallRoot) {
     if (Test-Path -LiteralPath $existingReceiptPath -PathType Leaf) {
         $existingReceipt = Get-Content -LiteralPath $existingReceiptPath -Raw |
             ConvertFrom-Json
-        if ($existingReceipt.schemaVersion -ne
-            'azureauth-credprovider-deployment-validation-install-v2') {
+        $receiptSchemaVersion = [string]$existingReceipt.schemaVersion
+        if ($receiptSchemaVersion -notin @(
+                'azureauth-credprovider-deployment-validation-install-v1',
+                'azureauth-credprovider-deployment-validation-install-v2'
+            )) {
             throw 'The existing deployment validation installation receipt is invalid.'
+        }
+        if ($receiptSchemaVersion -eq
+            'azureauth-credprovider-deployment-validation-install-v1' -and
+            -not (Test-ExactObjectPropertySet `
+                    -Value $existingReceipt `
+                    -ExpectedNames @(
+                    'schemaVersion',
+                    'productVersion',
+                    'sourceRevision',
+                    'targetRid',
+                    'installRoot',
+                    'applicationRoot',
+                    'nugetPluginRoot'
+                ))) {
+            throw 'The legacy deployment validation installation receipt is invalid.'
         }
 
         $receiptInstallRoot = [System.IO.Path]::GetFullPath(
@@ -214,6 +240,55 @@ if (Test-Path -LiteralPath $InstallRoot) {
         if (-not $InstallRoot.Equals($receiptInstallRoot, $pathComparison) -or
             -not $applicationRoot.Equals($receiptApplicationRoot, $pathComparison)) {
             throw 'The replacement roots do not match the existing installation receipt.'
+        }
+
+        if ($receiptSchemaVersion -eq
+            'azureauth-credprovider-deployment-validation-install-v1') {
+            if ([string]::IsNullOrWhiteSpace([string]$existingReceipt.nugetPluginRoot)) {
+                throw 'The legacy deployment validation installation receipt is invalid.'
+            }
+            $legacyNuGetPluginRoot = [System.IO.Path]::GetFullPath(
+                [string]$existingReceipt.nugetPluginRoot
+            )
+            $legacyPathRoot = [System.IO.Path]::GetPathRoot($legacyNuGetPluginRoot)
+            if ($legacyNuGetPluginRoot -eq $legacyPathRoot -or
+                $legacyNuGetPluginRoot.TrimEnd(
+                    [System.IO.Path]::DirectorySeparatorChar,
+                    [System.IO.Path]::AltDirectorySeparatorChar
+                ) -eq $homeDirectory.TrimEnd(
+                    [System.IO.Path]::DirectorySeparatorChar,
+                    [System.IO.Path]::AltDirectorySeparatorChar
+                )) {
+                throw "The legacy NuGet deployment target '$legacyNuGetPluginRoot' is too broad."
+            }
+            $legacyNuGetPluginRootPrefix = $legacyNuGetPluginRoot.TrimEnd(
+                [System.IO.Path]::DirectorySeparatorChar,
+                [System.IO.Path]::AltDirectorySeparatorChar
+            ) + [System.IO.Path]::DirectorySeparatorChar
+            $currentInstallRootPrefix = $InstallRoot.TrimEnd(
+                [System.IO.Path]::DirectorySeparatorChar,
+                [System.IO.Path]::AltDirectorySeparatorChar
+            ) + [System.IO.Path]::DirectorySeparatorChar
+            if ($InstallRoot.Equals($legacyNuGetPluginRoot, $pathComparison) -or
+                $InstallRoot.StartsWith($legacyNuGetPluginRootPrefix, $pathComparison) -or
+                $legacyNuGetPluginRoot.StartsWith($currentInstallRootPrefix, $pathComparison)) {
+                throw 'The product and legacy NuGet plugin roots must not overlap.'
+            }
+            if ([string]::IsNullOrWhiteSpace($LegacyNuGetOwnershipManifestPath)) {
+                $LegacyNuGetOwnershipManifestPath = Join-Path $homeDirectory (
+                    '.azureauth-credprovider/phase10/manifests/' +
+                    'nuget-plugin-layout-ownership-manifest.json'
+                )
+            }
+            $LegacyNuGetOwnershipManifestPath = [System.IO.Path]::GetFullPath(
+                $LegacyNuGetOwnershipManifestPath
+            )
+            $legacyNuGetCleanupPlan = Get-LegacyNuGetCleanupPlan `
+                -ApplicationRoot $receiptApplicationRoot `
+                -NuGetPluginRoot $legacyNuGetPluginRoot `
+                -OwnershipManifestPath $LegacyNuGetOwnershipManifestPath `
+                -PathComparer $pathComparer `
+                -PathComparison $pathComparison
         }
     }
     elseif (-not (Test-EmptyDirectory -LiteralPath $InstallRoot)) {
@@ -352,6 +427,10 @@ catch {
     }
 
     throw $switchFailure
+}
+
+if ($null -ne $legacyNuGetCleanupPlan) {
+    Remove-LegacyNuGetPayload -Plan $legacyNuGetCleanupPlan
 }
 
 $undeletedBackupPaths = [System.Collections.Generic.List[string]]::new()

--- a/eng/scripts/azureauth-credprovider/New-DeploymentValidationBundle.ps1
+++ b/eng/scripts/azureauth-credprovider/New-DeploymentValidationBundle.ps1
@@ -174,6 +174,9 @@ exec "$script_dir/../app/azureauth-credprovider" git credential-helper "$@"
     Copy-Item -LiteralPath (
         Join-Path $scriptRoot 'Uninstall-DeploymentValidationBundle.ps1'
     ) -Destination (Join-Path $stagingRoot 'uninstall.ps1')
+    Copy-Item -LiteralPath (
+        Join-Path $scriptRoot 'DeploymentValidationLegacyNuGet.ps1'
+    ) -Destination (Join-Path $stagingRoot 'legacy-nuget.ps1')
 
     $manifestPath = Join-Path $stagingRoot 'manifest.json'
     if (Test-Path -LiteralPath $manifestPath) {

--- a/eng/scripts/azureauth-credprovider/Uninstall-DeploymentValidationBundle.ps1
+++ b/eng/scripts/azureauth-credprovider/Uninstall-DeploymentValidationBundle.ps1
@@ -12,6 +12,18 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 $runningOnWindows = $IsWindows
+$hostArchitecture = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
+$expectedTargetRid = if (
+    $hostArchitecture -eq [System.Runtime.InteropServices.Architecture]::X64
+) {
+    if ($runningOnWindows) {
+        'win-x64'
+    }
+    elseif ($IsLinux) {
+        'linux-x64'
+    }
+}
+$legacySourceRevision = 'f1bf00d412732739713a18e9a07e8738ff80c6f8'
 $pathComparison = if ($runningOnWindows) {
     [System.StringComparison]::OrdinalIgnoreCase
 }
@@ -100,7 +112,10 @@ if ($InstallRoot -eq $installPathRoot -or
 $legacyNuGetCleanupPlan = $null
 if ($receiptSchemaVersion -eq
     'azureauth-credprovider-deployment-validation-install-v1') {
-    if ([string]::IsNullOrWhiteSpace([string]$receipt.nugetPluginRoot)) {
+    if ($receipt.sourceRevision -cne $legacySourceRevision -or
+        [string]::IsNullOrWhiteSpace($expectedTargetRid) -or
+        $receipt.targetRid -cne $expectedTargetRid -or
+        [string]::IsNullOrWhiteSpace([string]$receipt.nugetPluginRoot)) {
         throw 'The legacy deployment validation installation receipt is invalid.'
     }
     $legacyNuGetPluginRoot = [System.IO.Path]::GetFullPath(

--- a/eng/scripts/azureauth-credprovider/Uninstall-DeploymentValidationBundle.ps1
+++ b/eng/scripts/azureauth-credprovider/Uninstall-DeploymentValidationBundle.ps1
@@ -3,6 +3,8 @@
 param(
     [string]$InstallRoot,
 
+    [string]$LegacyNuGetOwnershipManifestPath,
+
     [switch]$SkipConfigurationCleanup
 )
 
@@ -16,6 +18,18 @@ $pathComparison = if ($runningOnWindows) {
 else {
     [System.StringComparison]::Ordinal
 }
+$pathComparer = if ($runningOnWindows) {
+    [System.StringComparer]::OrdinalIgnoreCase
+}
+else {
+    [System.StringComparer]::Ordinal
+}
+$bundleRoot = Split-Path -Parent $PSCommandPath
+$legacyNuGetSupportPath = Join-Path $bundleRoot 'legacy-nuget.ps1'
+if (-not (Test-Path -LiteralPath $legacyNuGetSupportPath -PathType Leaf)) {
+    throw 'The deployment validation legacy NuGet support script is missing.'
+}
+. $legacyNuGetSupportPath
 $homeDirectory = [Environment]::GetFolderPath([Environment+SpecialFolder]::UserProfile)
 if ([string]::IsNullOrWhiteSpace($homeDirectory)) {
     throw 'The current user profile directory is unavailable.'
@@ -34,15 +48,34 @@ if ([string]::IsNullOrWhiteSpace($InstallRoot)) {
 }
 
 $InstallRoot = [System.IO.Path]::GetFullPath($InstallRoot)
+
 $receiptPath = Join-Path $InstallRoot 'installation.json'
 if (-not (Test-Path -LiteralPath $receiptPath -PathType Leaf)) {
     throw "The deployment validation installation receipt is missing from '$InstallRoot'."
 }
 
 $receipt = Get-Content -LiteralPath $receiptPath -Raw | ConvertFrom-Json
-if ($receipt.schemaVersion -ne
-    'azureauth-credprovider-deployment-validation-install-v2') {
+$receiptSchemaVersion = [string]$receipt.schemaVersion
+if ($receiptSchemaVersion -notin @(
+        'azureauth-credprovider-deployment-validation-install-v1',
+        'azureauth-credprovider-deployment-validation-install-v2'
+    )) {
     throw 'The deployment validation installation receipt is invalid.'
+}
+if ($receiptSchemaVersion -eq
+    'azureauth-credprovider-deployment-validation-install-v1' -and
+    -not (Test-ExactObjectPropertySet `
+            -Value $receipt `
+            -ExpectedNames @(
+            'schemaVersion',
+            'productVersion',
+            'sourceRevision',
+            'targetRid',
+            'installRoot',
+            'applicationRoot',
+            'nugetPluginRoot'
+        ))) {
+    throw 'The legacy deployment validation installation receipt is invalid.'
 }
 
 $applicationRoot = Join-Path $InstallRoot 'app'
@@ -62,6 +95,56 @@ if ($InstallRoot -eq $installPathRoot -or
     $InstallRoot.TrimEnd([System.IO.Path]::DirectorySeparatorChar) -eq
     $homeDirectory.TrimEnd([System.IO.Path]::DirectorySeparatorChar)) {
     throw "The deployment target '$InstallRoot' is too broad."
+}
+
+$legacyNuGetCleanupPlan = $null
+if ($receiptSchemaVersion -eq
+    'azureauth-credprovider-deployment-validation-install-v1') {
+    if ([string]::IsNullOrWhiteSpace([string]$receipt.nugetPluginRoot)) {
+        throw 'The legacy deployment validation installation receipt is invalid.'
+    }
+    $legacyNuGetPluginRoot = [System.IO.Path]::GetFullPath(
+        [string]$receipt.nugetPluginRoot
+    )
+    $legacyPathRoot = [System.IO.Path]::GetPathRoot($legacyNuGetPluginRoot)
+    if ($legacyNuGetPluginRoot -eq $legacyPathRoot -or
+        $legacyNuGetPluginRoot.TrimEnd(
+            [System.IO.Path]::DirectorySeparatorChar,
+            [System.IO.Path]::AltDirectorySeparatorChar
+        ) -eq $homeDirectory.TrimEnd(
+            [System.IO.Path]::DirectorySeparatorChar,
+            [System.IO.Path]::AltDirectorySeparatorChar
+        )) {
+        throw "The legacy NuGet deployment target '$legacyNuGetPluginRoot' is too broad."
+    }
+    $installRootPrefix = $InstallRoot.TrimEnd(
+        [System.IO.Path]::DirectorySeparatorChar,
+        [System.IO.Path]::AltDirectorySeparatorChar
+    ) + [System.IO.Path]::DirectorySeparatorChar
+    $legacyNuGetPluginRootPrefix = $legacyNuGetPluginRoot.TrimEnd(
+        [System.IO.Path]::DirectorySeparatorChar,
+        [System.IO.Path]::AltDirectorySeparatorChar
+    ) + [System.IO.Path]::DirectorySeparatorChar
+    if ($InstallRoot.Equals($legacyNuGetPluginRoot, $pathComparison) -or
+        $InstallRoot.StartsWith($legacyNuGetPluginRootPrefix, $pathComparison) -or
+        $legacyNuGetPluginRoot.StartsWith($installRootPrefix, $pathComparison)) {
+        throw 'The product and legacy NuGet plugin roots must not overlap.'
+    }
+    if ([string]::IsNullOrWhiteSpace($LegacyNuGetOwnershipManifestPath)) {
+        $LegacyNuGetOwnershipManifestPath = Join-Path $homeDirectory (
+            '.azureauth-credprovider/phase10/manifests/' +
+            'nuget-plugin-layout-ownership-manifest.json'
+        )
+    }
+    $LegacyNuGetOwnershipManifestPath = [System.IO.Path]::GetFullPath(
+        $LegacyNuGetOwnershipManifestPath
+    )
+    $legacyNuGetCleanupPlan = Get-LegacyNuGetCleanupPlan `
+        -ApplicationRoot $applicationRoot `
+        -NuGetPluginRoot $legacyNuGetPluginRoot `
+        -OwnershipManifestPath $LegacyNuGetOwnershipManifestPath `
+        -PathComparer $pathComparer `
+        -PathComparison $pathComparison
 }
 
 $productExecutableName = if ($runningOnWindows) {
@@ -103,6 +186,10 @@ if (-not $SkipConfigurationCleanup) {
             )
         }
     }
+}
+
+if ($null -ne $legacyNuGetCleanupPlan) {
+    Remove-LegacyNuGetPayload -Plan $legacyNuGetCleanupPlan
 }
 
 if (Test-Path -LiteralPath $InstallRoot) {

--- a/eng/scripts/azureauth-credprovider/Uninstall-DeploymentValidationBundle.ps1
+++ b/eng/scripts/azureauth-credprovider/Uninstall-DeploymentValidationBundle.ps1
@@ -3,8 +3,6 @@
 param(
     [string]$InstallRoot,
 
-    [string]$NuGetPluginRoot,
-
     [switch]$SkipConfigurationCleanup
 )
 
@@ -43,14 +41,10 @@ if (-not (Test-Path -LiteralPath $receiptPath -PathType Leaf)) {
 
 $receipt = Get-Content -LiteralPath $receiptPath -Raw | ConvertFrom-Json
 if ($receipt.schemaVersion -ne
-    'azureauth-credprovider-deployment-validation-install-v1') {
+    'azureauth-credprovider-deployment-validation-install-v2') {
     throw 'The deployment validation installation receipt is invalid.'
 }
 
-if ([string]::IsNullOrWhiteSpace($NuGetPluginRoot)) {
-    $NuGetPluginRoot = [string]$receipt.nugetPluginRoot
-}
-$NuGetPluginRoot = [System.IO.Path]::GetFullPath($NuGetPluginRoot)
 $applicationRoot = Join-Path $InstallRoot 'app'
 if (-not $InstallRoot.Equals(
         [System.IO.Path]::GetFullPath([string]$receipt.installRoot),
@@ -59,36 +53,15 @@ if (-not $InstallRoot.Equals(
     -not $applicationRoot.Equals(
         [System.IO.Path]::GetFullPath([string]$receipt.applicationRoot),
         $pathComparison
-    ) -or
-    -not $NuGetPluginRoot.Equals(
-        [System.IO.Path]::GetFullPath([string]$receipt.nugetPluginRoot),
-        $pathComparison
     )) {
     throw 'The requested removal roots do not match the installation receipt.'
 }
 
-foreach ($path in @($InstallRoot, $NuGetPluginRoot)) {
-    $pathRoot = [System.IO.Path]::GetPathRoot($path)
-    if ($path -eq $pathRoot -or
-        $path.TrimEnd([System.IO.Path]::DirectorySeparatorChar) -eq
-        $homeDirectory.TrimEnd([System.IO.Path]::DirectorySeparatorChar)) {
-        throw "The deployment target '$path' is too broad."
-    }
-}
-if ($InstallRoot.Equals($NuGetPluginRoot, $pathComparison)) {
-    throw 'The product and NuGet plugin roots must be distinct.'
-}
-$installRootPrefix = $InstallRoot.TrimEnd(
-    [System.IO.Path]::DirectorySeparatorChar,
-    [System.IO.Path]::AltDirectorySeparatorChar
-) + [System.IO.Path]::DirectorySeparatorChar
-$nugetPluginRootPrefix = $NuGetPluginRoot.TrimEnd(
-    [System.IO.Path]::DirectorySeparatorChar,
-    [System.IO.Path]::AltDirectorySeparatorChar
-) + [System.IO.Path]::DirectorySeparatorChar
-if ($InstallRoot.StartsWith($nugetPluginRootPrefix, $pathComparison) -or
-    $NuGetPluginRoot.StartsWith($installRootPrefix, $pathComparison)) {
-    throw 'The product and NuGet plugin roots must not contain one another.'
+$installPathRoot = [System.IO.Path]::GetPathRoot($InstallRoot)
+if ($InstallRoot -eq $installPathRoot -or
+    $InstallRoot.TrimEnd([System.IO.Path]::DirectorySeparatorChar) -eq
+    $homeDirectory.TrimEnd([System.IO.Path]::DirectorySeparatorChar)) {
+    throw "The deployment target '$InstallRoot' is too broad."
 }
 
 $productExecutableName = if ($runningOnWindows) {
@@ -132,12 +105,8 @@ if (-not $SkipConfigurationCleanup) {
     }
 }
 
-if (Test-Path -LiteralPath $NuGetPluginRoot) {
-    Remove-Item -LiteralPath $NuGetPluginRoot -Recurse -Force
-}
 if (Test-Path -LiteralPath $InstallRoot) {
     Remove-Item -LiteralPath $InstallRoot -Recurse -Force
 }
 
 Write-Output "Removed internal deployment validation payload: $InstallRoot"
-Write-Output "Removed NuGet plugin payload: $NuGetPluginRoot"

--- a/src/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Cli/CliApplication.cs
+++ b/src/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Cli/CliApplication.cs
@@ -3085,6 +3085,7 @@ internal static class CliApplication
     )
     {
         ArgumentNullException.ThrowIfNull(configureResult);
+        bool mutatesState = configureResult.PlanResult.Changes.Count > 0;
 
         return JoinLines(
             $"command: {invocation.CommandName}",
@@ -3092,7 +3093,7 @@ internal static class CliApplication
             $"phase: {PhaseName}",
             $"ci-mode: {GetCiModeText(invocation.CiMode)}",
             $"scope: {GetScopeText(invocation.CiMode)}",
-            "mutates-state: yes",
+            "mutates-state: " + (mutatesState ? "yes" : "no"),
             $"plan-operation: {GetPlanOperationText(configureResult.PlanResult.Operation)}",
             $"applied-change-count: {configureResult.PlanResult.Changes.Count}",
             "nuget-plugin-layout-marker: "
@@ -3241,12 +3242,14 @@ internal static class CliApplication
         && root.Installation.HostPlatform == AzureAuthHostPlatform.NativeLinux
         && root.ProductionOptions.DeviceCodePromptWriter is not null;
 
-    private static IEnumerable<string> BuildNuGetDoctorLines(NuGetPhase10DoctorResult doctorResult)
+    private static List<string> BuildNuGetDoctorLines(NuGetPhase10DoctorResult doctorResult)
     {
         ArgumentNullException.ThrowIfNull(doctorResult);
-        return
+        List<string> lines =
         [
             "nuget-configuration-plan: " + GetCheckStatusText(doctorResult.ConfigurationPlanValid),
+            "nuget-configuration-state: "
+                + GetNuGetConfigurationStateText(doctorResult.ConfigurationState),
             "nuget-plugin-layout-marker: "
                 + GetPresenceText(doctorResult.PluginLayoutMarkerPresent),
             "nuget-ownership-manifest: " + GetPresenceText(doctorResult.OwnershipManifestPresent),
@@ -3261,7 +3264,39 @@ internal static class CliApplication
             "nuget-environment-overrides: "
                 + (doctorResult.OptionalEnvironmentOverridesAbsent ? "absent" : "present"),
         ];
+        if (doctorResult.ConfigurationState == NuGetConfigurationState.Refreshable)
+        {
+            lines.Insert(
+                2,
+                "nuget-configuration-plan-remediation: run "
+                    + "azureauth-credprovider configure nuget"
+            );
+        }
+        else if (doctorResult.ConfigurationState == NuGetConfigurationState.Unrecognized)
+        {
+            lines.Insert(
+                2,
+                "nuget-configuration-plan-remediation: manually inspect and restore "
+                    + "the product-owned NuGet plugin layout"
+            );
+        }
+        return lines;
     }
+
+    private static string GetNuGetConfigurationStateText(
+        NuGetConfigurationState configurationState
+    ) =>
+        configurationState switch
+        {
+            NuGetConfigurationState.Valid => "valid",
+            NuGetConfigurationState.Refreshable => "refreshable",
+            NuGetConfigurationState.Unrecognized => "unrecognized",
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(configurationState),
+                configurationState,
+                null
+            ),
+        };
 
     private static List<string> BuildPythonDoctorLines(
         PythonPhase11DoctorResult doctorResult

--- a/src/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Cli/CliApplication.cs
+++ b/src/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Cli/CliApplication.cs
@@ -3903,12 +3903,12 @@ internal static class CliApplication
                 ConfigurationChangeOperation.Set,
                 ConfigurationTargetKind.NuGetPluginLayout,
                 NuGetPluginLayoutConfigurationKey
-            ) => "register product-owned NuGet netcore plugin layout marker",
+            ) => "create product-owned NuGet netcore plugin activation",
             (
                 ConfigurationChangeOperation.Remove,
                 ConfigurationTargetKind.NuGetPluginLayout,
                 NuGetPluginLayoutConfigurationKey
-            ) => "remove product-owned NuGet netcore plugin layout marker",
+            ) => "remove product-owned NuGet netcore plugin activation",
             _ => throw new InvalidOperationException("Unsupported planned change."),
         };
     }

--- a/src/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform/Configuration/ConfigurationManager.cs
+++ b/src/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform/Configuration/ConfigurationManager.cs
@@ -172,18 +172,6 @@ public sealed class ConfigurationManager : IConfigurationManager
             resultManifests.Add(previewManifest);
         }
 
-        foreach ((ConfigurationChangePlan plan, ConfigurationPlanOperation operation) in normalized)
-        {
-            if (operation != ConfigurationPlanOperation.Remove)
-            {
-                continue;
-            }
-
-            cancellationToken.ThrowIfCancellationRequested();
-            await ApplyChanges(plan, originalManifest, operation, cancellationToken);
-            DeleteTemporaryContainer(plan);
-        }
-
         ConfigurationOwnershipManifest? ownershipIntent = CreateOwnershipIntent(
             originalManifest,
             previewManifest
@@ -191,23 +179,48 @@ public sealed class ConfigurationManager : IConfigurationManager
         bool hasApply = normalized.Any(operation =>
             operation.Operation == ConfigurationPlanOperation.Apply
         );
-        if (hasApply)
+        bool hasRemove = normalized.Any(operation =>
+            operation.Operation == ConfigurationPlanOperation.Remove
+        );
+        ConfigurationOwnershipManifest? persistedManifest = originalManifest;
+        if (hasRemove || hasApply)
         {
-            PersistManifest(ownershipIntent);
+            persistedManifest = hasApply ? ownershipIntent : previewManifest;
+            PersistManifest(persistedManifest);
+        }
+
+        try
+        {
+            foreach (
+                (ConfigurationChangePlan plan, ConfigurationPlanOperation operation) in normalized
+            )
+            {
+                if (operation != ConfigurationPlanOperation.Remove)
+                {
+                    continue;
+                }
+
+                cancellationToken.ThrowIfCancellationRequested();
+                await ApplyChanges(plan, originalManifest, operation, cancellationToken);
+                DeleteTemporaryContainer(plan);
+            }
+        }
+        catch
+        {
+            PersistManifest(originalManifest);
+            throw;
         }
 
         foreach ((ConfigurationChangePlan plan, ConfigurationPlanOperation operation) in normalized)
         {
-            if (operation != ConfigurationPlanOperation.Apply)
+            if (operation == ConfigurationPlanOperation.Apply)
             {
-                continue;
+                cancellationToken.ThrowIfCancellationRequested();
+                await ApplyChanges(plan, ownershipIntent, operation, cancellationToken);
             }
-
-            cancellationToken.ThrowIfCancellationRequested();
-            await ApplyChanges(plan, ownershipIntent, operation, cancellationToken);
         }
 
-        if (!ManifestsEquivalent(ownershipIntent, previewManifest))
+        if (!ManifestsEquivalent(persistedManifest, previewManifest))
         {
             PersistManifest(previewManifest);
         }

--- a/src/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform/Configuration/ConfigurationManager.cs
+++ b/src/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform/Configuration/ConfigurationManager.cs
@@ -211,13 +211,33 @@ public sealed class ConfigurationManager : IConfigurationManager
             throw;
         }
 
-        foreach ((ConfigurationChangePlan plan, ConfigurationPlanOperation operation) in normalized)
+        try
         {
-            if (operation == ConfigurationPlanOperation.Apply)
+            foreach (
+                (ConfigurationChangePlan plan, ConfigurationPlanOperation operation) in normalized
+            )
             {
-                cancellationToken.ThrowIfCancellationRequested();
-                await ApplyChanges(plan, ownershipIntent, operation, cancellationToken);
+                if (operation == ConfigurationPlanOperation.Apply)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    await ApplyChanges(plan, ownershipIntent, operation, cancellationToken);
+                }
             }
+        }
+        catch
+        {
+            if (
+                originalManifest is null
+                && normalized.Length == 1
+                && normalized[0].Operation == ConfigurationPlanOperation.Apply
+                && normalized[0].Plan.Changes.Count == 1
+                && normalized[0].Plan.Changes[0].TargetKind
+                    == ConfigurationTargetKind.NuGetPluginLayout
+            )
+            {
+                PersistManifest(originalManifest);
+            }
+            throw;
         }
 
         if (!ManifestsEquivalent(persistedManifest, previewManifest))

--- a/src/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform/Configuration/NuGetPluginLayoutPhysicalTargetWriter.cs
+++ b/src/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform/Configuration/NuGetPluginLayoutPhysicalTargetWriter.cs
@@ -1,4 +1,7 @@
+using System.Security.Cryptography;
 using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using Hcoona.AzureAuth.CredProvider.Contracts;
 using Hcoona.AzureAuth.CredProvider.Platform.FileSystem;
 
@@ -7,9 +10,19 @@ namespace Hcoona.AzureAuth.CredProvider.Platform.Configuration;
 internal sealed class NuGetPluginLayoutPhysicalTargetWriter(IFileSystem fileSystem)
     : IConfigurationPhysicalTargetWriter
 {
-    private const string MarkerFileName = ".azureauth-credprovider.nuget-plugin-layout";
+    internal const string MarkerFileName = ".azureauth-credprovider.nuget-plugin-layout";
+    private const string MarkerSchemaVersion =
+        "azureauth-credprovider-nuget-plugin-activation-v1";
+    private const string PluginEntrypointFileName = "azureauth-credprovider.dll";
     private const string SupportedKey = "physical-target";
     private static readonly Encoding Utf8NoBom = new UTF8Encoding(false, true);
+    private static readonly JsonSerializerOptions MarkerJsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        TypeInfoResolver = NuGetPluginActivationJsonContext.Default,
+        UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow,
+        WriteIndented = true,
+    };
 
     public void Validate(
         ConfigurationPhysicalTargetWriterRequest request,
@@ -28,33 +41,19 @@ internal sealed class NuGetPluginLayoutPhysicalTargetWriter(IFileSystem fileSyst
     {
         cancellationToken.ThrowIfCancellationRequested();
         ValidateRequest(request);
-        ValidateCurrentState(request);
-        string markerPath = GetMarkerPath(request.Change.TargetPathOrName);
+        NuGetPluginActivationManifest? existingManifest = ValidateCurrentState(request);
         bool remove =
             request.PlanOperation == ConfigurationPlanOperation.Remove
             || request.Change.Operation == ConfigurationChangeOperation.Remove;
         if (remove)
         {
-            if (fileSystem.FileExists(markerPath))
-            {
-                fileSystem.DeleteFile(markerPath);
-            }
+            RemoveActivation(request.Change.TargetPathOrName, existingManifest);
             return;
         }
 
-        if (
-            fileSystem.FileExists(markerPath)
-            && string.Equals(
-                fileSystem.ReadAllText(markerPath, Utf8NoBom),
-                request.Change.Value,
-                StringComparison.Ordinal
-            )
-        )
-        {
-            return;
-        }
-
-        fileSystem.AtomicWriteAllText(markerPath, request.Change.Value!, Utf8NoBom);
+        SourcePayload payload = ReadSourcePayload(request.Change.Value!);
+        ValidateNewTargets(request.Change.TargetPathOrName, existingManifest, payload);
+        ReplaceActivation(request.Change.TargetPathOrName, existingManifest, payload);
     }
 
     public bool IsSatisfied(
@@ -64,13 +63,37 @@ internal sealed class NuGetPluginLayoutPhysicalTargetWriter(IFileSystem fileSyst
     {
         cancellationToken.ThrowIfCancellationRequested();
         ValidateRequest(request);
-        string markerPath = GetMarkerPath(request.Change.TargetPathOrName);
-        return fileSystem.FileExists(markerPath)
-            && string.Equals(
-                fileSystem.ReadAllText(markerPath, Utf8NoBom),
-                request.Change.Value,
-                StringComparison.Ordinal
+        if (
+            request.PlanOperation == ConfigurationPlanOperation.Remove
+            || request.Change.Operation == ConfigurationChangeOperation.Remove
+        )
+        {
+            return !fileSystem.DirectoryExists(request.Change.TargetPathOrName)
+                && !fileSystem.FileExists(GetMarkerPath(request.Change.TargetPathOrName));
+        }
+
+        try
+        {
+            SourcePayload payload = ReadSourcePayload(request.Change.Value!);
+            NuGetPluginActivationManifest? existing = ReadAndValidateActivation(
+                request.Change.TargetPathOrName,
+                request.Change.Value
             );
+            return existing is not null && ManifestsEquivalent(existing, payload.Manifest);
+        }
+        catch (
+            Exception exception
+        ) when (
+            exception
+                is ArgumentException
+                    or IOException
+                    or InvalidOperationException
+                    or JsonException
+                    or UnauthorizedAccessException
+        )
+        {
+            return false;
+        }
     }
 
     internal static string? GetPlanningValidationViolation(ConfigurationChange change)
@@ -101,18 +124,12 @@ internal sealed class NuGetPluginLayoutPhysicalTargetWriter(IFileSystem fileSyst
             && string.IsNullOrWhiteSpace(change.Value)
         )
         {
-            return "The NuGet plugin layout marker value is required.";
+            return "The NuGet plugin source application root is required.";
         }
         return change.IsSecretValue
-            ? "The NuGet plugin layout marker must not contain secrets."
+            ? "The NuGet plugin layout value must not contain secrets."
             : null;
     }
-
-    private string? GetTargetRootPathValidationViolation(string targetRootPath) =>
-        string.IsNullOrWhiteSpace(targetRootPath)
-        || !fileSystem.IsPathFullyQualified(targetRootPath)
-            ? "The NuGet plugin layout target must be fully qualified."
-            : null;
 
     private void ValidateRequest(ConfigurationPhysicalTargetWriterRequest request)
     {
@@ -134,27 +151,654 @@ internal sealed class NuGetPluginLayoutPhysicalTargetWriter(IFileSystem fileSyst
         }
     }
 
-    private void ValidateCurrentState(ConfigurationPhysicalTargetWriterRequest request)
+    private string? GetTargetRootPathValidationViolation(string targetRootPath) =>
+        string.IsNullOrWhiteSpace(targetRootPath)
+        || !fileSystem.IsPathFullyQualified(targetRootPath)
+            ? "The NuGet plugin layout target must be fully qualified."
+            : null;
+
+    private NuGetPluginActivationManifest? ValidateCurrentState(
+        ConfigurationPhysicalTargetWriterRequest request
+    )
     {
-        string markerPath = GetMarkerPath(request.Change.TargetPathOrName);
-        bool exists = fileSystem.FileExists(markerPath);
+        string targetRootPath = request.Change.TargetPathOrName;
+        string markerPath = GetMarkerPath(targetRootPath);
+        bool targetDirectoryExists = fileSystem.DirectoryExists(targetRootPath);
+        bool targetFileExists = fileSystem.FileExists(targetRootPath);
+        bool markerExists = fileSystem.FileExists(markerPath);
+        bool markerDirectoryExists = fileSystem.DirectoryExists(markerPath);
         bool remove =
             request.PlanOperation == ConfigurationPlanOperation.Remove
             || request.Change.Operation == ConfigurationChangeOperation.Remove;
+
+        if (targetFileExists || markerDirectoryExists)
+        {
+            throw new InvalidOperationException(
+                "The NuGet plugin activation target is not a recognized directory layout."
+            );
+        }
         if (remove && !request.IsOwned(request.Change, fileSystem))
         {
             throw new InvalidOperationException(
-                "NuGet plugin layout removal requires recognized ownership."
+                "NuGet plugin activation removal requires recognized ownership."
             );
         }
-        if (!remove && exists && !request.IsOwned(request.Change, fileSystem))
+        if (!targetDirectoryExists && !markerExists)
+        {
+            return null;
+        }
+        if (!markerExists)
         {
             throw new InvalidOperationException(
-                "The NuGet plugin layout marker exists without recognized ownership."
+                "The NuGet plugin activation directory exists without its ownership marker."
             );
         }
+        if (!request.IsOwned(request.Change, fileSystem))
+        {
+            throw new InvalidOperationException(
+                "The NuGet plugin activation marker exists without recognized ownership."
+            );
+        }
+
+        return ReadAndValidateActivation(
+            targetRootPath,
+            remove ? null : request.Change.Value
+        );
+    }
+
+    private SourcePayload ReadSourcePayload(string sourceRootPath)
+    {
+        if (
+            !fileSystem.IsPathFullyQualified(sourceRootPath)
+            || !fileSystem.DirectoryExists(sourceRootPath)
+        )
+        {
+            throw new InvalidOperationException(
+                "The NuGet plugin source application root is unavailable."
+            );
+        }
+
+        string fullSourceRoot = fileSystem.GetFullPath(sourceRootPath);
+        StringComparer pathComparer = FileSystemPathSemantics.GetComparer(fileSystem);
+        var files = new List<SourcePayloadFile>();
+        foreach (
+            string sourcePath in fileSystem
+                .EnumerateFiles(fullSourceRoot, "*", SearchOption.AllDirectories)
+                .OrderBy(static path => path, pathComparer)
+        )
+        {
+            string relativePath = GetSafeRelativePath(fullSourceRoot, sourcePath);
+            if (pathComparer.Equals(relativePath, MarkerFileName))
+            {
+                throw new InvalidOperationException(
+                    "The source application payload contains the reserved NuGet activation marker."
+                );
+            }
+
+            byte[] content = fileSystem.ReadAllBytes(sourcePath);
+            UnixFileMode? unixFileMode = FileSystemPathSemantics.UsesWindowsPaths(fileSystem)
+                ? null
+                : fileSystem.GetUnixFileMode(sourcePath);
+            files.Add(
+                new SourcePayloadFile(
+                    relativePath,
+                    content,
+                    Convert.ToHexString(SHA256.HashData(content)).ToLowerInvariant(),
+                    unixFileMode
+                )
+            );
+        }
+
+        if (
+            files.Count == 0
+            || !files.Any(file =>
+                string.Equals(
+                    file.RelativePath,
+                    PluginEntrypointFileName,
+                    StringComparison.Ordinal
+                )
+            )
+        )
+        {
+            throw new InvalidOperationException(
+                "The NuGet plugin source application payload is incomplete."
+            );
+        }
+
+        return new SourcePayload(
+            new NuGetPluginActivationManifest
+            {
+                SchemaVersion = MarkerSchemaVersion,
+                SourceApplicationRoot = fullSourceRoot,
+                Files = files
+                    .Select(file => new NuGetPluginActivationFile
+                    {
+                        Path = file.RelativePath,
+                        Length = file.Content.LongLength,
+                        Sha256 = file.Sha256,
+                        UnixFileMode = file.UnixFileMode is null
+                            ? null
+                            : (int)file.UnixFileMode.Value,
+                    })
+                    .ToArray(),
+            },
+            files
+        );
+    }
+
+    private NuGetPluginActivationManifest? ReadAndValidateActivation(
+        string targetRootPath,
+        string? expectedSourceRoot
+    )
+    {
+        string markerPath = GetMarkerPath(targetRootPath);
+        if (!fileSystem.FileExists(markerPath))
+        {
+            return null;
+        }
+
+        NuGetPluginActivationManifest manifest =
+            JsonSerializer.Deserialize<NuGetPluginActivationManifest>(
+                fileSystem.ReadAllText(markerPath, Utf8NoBom),
+                MarkerJsonOptions
+            )
+            ?? throw new InvalidOperationException(
+                "The NuGet plugin activation marker is invalid."
+            );
+        if (
+            !string.Equals(manifest.SchemaVersion, MarkerSchemaVersion, StringComparison.Ordinal)
+            || string.IsNullOrWhiteSpace(manifest.SourceApplicationRoot)
+            || !fileSystem.IsPathFullyQualified(manifest.SourceApplicationRoot)
+            || manifest.Files.Length == 0
+            || (
+                expectedSourceRoot is not null
+                && !string.Equals(
+                    fileSystem.GetFullPath(manifest.SourceApplicationRoot),
+                    fileSystem.GetFullPath(expectedSourceRoot),
+                    FileSystemPathSemantics.GetComparison(fileSystem)
+                )
+            )
+        )
+        {
+            throw new InvalidOperationException(
+                "The NuGet plugin activation marker is not recognized."
+            );
+        }
+
+        var listedPaths = new HashSet<string>(FileSystemPathSemantics.GetComparer(fileSystem));
+        bool entrypointListed = false;
+        foreach (NuGetPluginActivationFile entry in manifest.Files)
+        {
+            string targetPath = GetOwnedTargetPath(targetRootPath, entry.Path);
+            if (
+                !listedPaths.Add(entry.Path)
+                || entry.Length < 0
+                || string.IsNullOrWhiteSpace(entry.Sha256)
+                || !fileSystem.FileExists(targetPath)
+                || fileSystem.DirectoryExists(targetPath)
+            )
+            {
+                throw new InvalidOperationException(
+                    "The NuGet plugin activation payload is damaged."
+                );
+            }
+
+            byte[] content = fileSystem.ReadAllBytes(targetPath);
+            string actualHash = Convert.ToHexString(SHA256.HashData(content)).ToLowerInvariant();
+            if (
+                content.LongLength != entry.Length
+                || !string.Equals(actualHash, entry.Sha256, StringComparison.OrdinalIgnoreCase)
+            )
+            {
+                throw new InvalidOperationException(
+                    "The NuGet plugin activation payload is damaged."
+                );
+            }
+
+            entrypointListed |= string.Equals(
+                entry.Path,
+                PluginEntrypointFileName,
+                StringComparison.Ordinal
+            );
+        }
+
+        return entrypointListed
+            ? manifest
+            : throw new InvalidOperationException(
+                "The NuGet plugin activation payload is incomplete."
+            );
+    }
+
+    private void ValidateNewTargets(
+        string targetRootPath,
+        NuGetPluginActivationManifest? existingManifest,
+        SourcePayload payload
+    )
+    {
+        if (
+            FileSystemPathSemantics.IsSameOrDescendant(
+                fileSystem,
+                payload.Manifest.SourceApplicationRoot,
+                targetRootPath
+            )
+            || FileSystemPathSemantics.IsSameOrDescendant(
+                fileSystem,
+                targetRootPath,
+                payload.Manifest.SourceApplicationRoot
+            )
+        )
+        {
+            throw new InvalidOperationException(
+                "The NuGet plugin source and activation roots must be disjoint."
+            );
+        }
+
+        var existingOwnedPaths = new HashSet<string>(
+            existingManifest?.Files.Select(file => file.Path) ?? [],
+            FileSystemPathSemantics.GetComparer(fileSystem)
+        );
+        HashSet<string> existingOwnedDirectories = GetOwnedAncestorDirectories(
+            existingOwnedPaths
+        );
+        foreach (SourcePayloadFile file in payload.Files)
+        {
+            string targetPath = GetOwnedTargetPath(targetRootPath, file.RelativePath);
+            if (
+                fileSystem.DirectoryExists(targetPath)
+                || (
+                    fileSystem.FileExists(targetPath)
+                    && !existingOwnedPaths.Contains(file.RelativePath)
+                )
+            )
+            {
+                throw new InvalidOperationException(
+                    "The NuGet plugin activation would overwrite an unowned path."
+                );
+            }
+            if (!existingOwnedPaths.Contains(file.RelativePath))
+            {
+                ValidateNewPathAncestors(
+                    targetRootPath,
+                    file.RelativePath,
+                    existingOwnedDirectories
+                );
+            }
+        }
+    }
+
+    private HashSet<string> GetOwnedAncestorDirectories(IEnumerable<string> ownedPaths)
+    {
+        var result = new HashSet<string>(FileSystemPathSemantics.GetComparer(fileSystem));
+        foreach (string ownedPath in ownedPaths)
+        {
+            string[] segments = GetRelativePathSegments(ownedPath);
+            for (int segmentCount = 1; segmentCount < segments.Length; segmentCount++)
+            {
+                result.Add(string.Join('/', segments.Take(segmentCount)));
+            }
+        }
+        return result;
+    }
+
+    private void ValidateNewPathAncestors(
+        string targetRootPath,
+        string relativePath,
+        HashSet<string> existingOwnedDirectories
+    )
+    {
+        string[] segments = GetRelativePathSegments(relativePath);
+        for (int segmentCount = 1; segmentCount < segments.Length; segmentCount++)
+        {
+            string ancestorPath = string.Join('/', segments.Take(segmentCount));
+            if (
+                fileSystem.DirectoryExists(GetOwnedTargetPath(targetRootPath, ancestorPath))
+                && !existingOwnedDirectories.Contains(ancestorPath)
+            )
+            {
+                throw new InvalidOperationException(
+                    "The NuGet plugin activation would use an unowned existing directory."
+                );
+            }
+        }
+    }
+
+    private void ReplaceActivation(
+        string targetRootPath,
+        NuGetPluginActivationManifest? existingManifest,
+        SourcePayload payload
+    )
+    {
+        string markerPath = GetMarkerPath(targetRootPath);
+        string? oldMarker = existingManifest is null
+            ? null
+            : fileSystem.ReadAllText(markerPath, Utf8NoBom);
+        Dictionary<string, RestorableFile> oldFiles = SnapshotOwnedFiles(
+            targetRootPath,
+            existingManifest
+        );
+        var affectedPaths = new HashSet<string>(
+            oldFiles.Keys,
+            FileSystemPathSemantics.GetComparer(fileSystem)
+        );
+        foreach (SourcePayloadFile file in payload.Files)
+        {
+            affectedPaths.Add(file.RelativePath);
+        }
+
+        try
+        {
+            foreach (SourcePayloadFile file in payload.Files)
+            {
+                string targetPath = GetOwnedTargetPath(targetRootPath, file.RelativePath);
+                fileSystem.AtomicWriteAllBytes(targetPath, file.Content);
+                if (file.UnixFileMode is { } mode)
+                {
+                    fileSystem.SetUnixFileMode(targetPath, mode);
+                }
+            }
+
+            var newPaths = new HashSet<string>(
+                payload.Files.Select(file => file.RelativePath),
+                FileSystemPathSemantics.GetComparer(fileSystem)
+            );
+            foreach (string obsoletePath in oldFiles.Keys.Where(path => !newPaths.Contains(path)))
+            {
+                fileSystem.DeleteFile(GetOwnedTargetPath(targetRootPath, obsoletePath));
+            }
+
+            fileSystem.AtomicWriteAllText(
+                markerPath,
+                JsonSerializer.Serialize(payload.Manifest, MarkerJsonOptions) + "\n",
+                Utf8NoBom
+            );
+            PruneEmptyDirectories(
+                targetRootPath,
+                oldFiles.Keys.Where(path => !newPaths.Contains(path)),
+                preserveTargetRoot: true
+            );
+        }
+        catch
+        {
+            RestoreActivation(targetRootPath, markerPath, oldMarker, oldFiles, affectedPaths);
+            throw;
+        }
+    }
+
+    private void RemoveActivation(
+        string targetRootPath,
+        NuGetPluginActivationManifest? existingManifest
+    )
+    {
+        if (existingManifest is null)
+        {
+            return;
+        }
+
+        string markerPath = GetMarkerPath(targetRootPath);
+        string oldMarker = fileSystem.ReadAllText(markerPath, Utf8NoBom);
+        Dictionary<string, RestorableFile> oldFiles = SnapshotOwnedFiles(
+            targetRootPath,
+            existingManifest
+        );
+        try
+        {
+            foreach (string relativePath in oldFiles.Keys)
+            {
+                fileSystem.DeleteFile(GetOwnedTargetPath(targetRootPath, relativePath));
+            }
+            fileSystem.DeleteFile(markerPath);
+            PruneEmptyDirectories(
+                targetRootPath,
+                oldFiles.Keys,
+                preserveTargetRoot: false
+            );
+        }
+        catch
+        {
+            RestoreActivation(
+                targetRootPath,
+                markerPath,
+                oldMarker,
+                oldFiles,
+                oldFiles.Keys
+            );
+            throw;
+        }
+    }
+
+    private Dictionary<string, RestorableFile> SnapshotOwnedFiles(
+        string targetRootPath,
+        NuGetPluginActivationManifest? manifest
+    )
+    {
+        var result = new Dictionary<string, RestorableFile>(
+            FileSystemPathSemantics.GetComparer(fileSystem)
+        );
+        if (manifest is null)
+        {
+            return result;
+        }
+
+        foreach (NuGetPluginActivationFile entry in manifest.Files)
+        {
+            string targetPath = GetOwnedTargetPath(targetRootPath, entry.Path);
+            result.Add(
+                entry.Path,
+                new RestorableFile(
+                    fileSystem.ReadAllBytes(targetPath),
+                    FileSystemPathSemantics.UsesWindowsPaths(fileSystem)
+                        ? null
+                        : fileSystem.GetUnixFileMode(targetPath)
+                )
+            );
+        }
+        return result;
+    }
+
+    private void RestoreActivation(
+        string targetRootPath,
+        string markerPath,
+        string? oldMarker,
+        IReadOnlyDictionary<string, RestorableFile> oldFiles,
+        IEnumerable<string> affectedPaths
+    )
+    {
+        foreach (string relativePath in affectedPaths.Distinct(
+            FileSystemPathSemantics.GetComparer(fileSystem)
+        ))
+        {
+            string targetPath = GetOwnedTargetPath(targetRootPath, relativePath);
+            if (oldFiles.TryGetValue(relativePath, out RestorableFile? oldFile))
+            {
+                fileSystem.AtomicWriteAllBytes(targetPath, oldFile.Content);
+                if (oldFile.UnixFileMode is { } mode)
+                {
+                    fileSystem.SetUnixFileMode(targetPath, mode);
+                }
+            }
+            else if (fileSystem.FileExists(targetPath))
+            {
+                fileSystem.DeleteFile(targetPath);
+            }
+        }
+
+        if (oldMarker is null)
+        {
+            if (fileSystem.FileExists(markerPath))
+            {
+                fileSystem.DeleteFile(markerPath);
+            }
+        }
+        else
+        {
+            fileSystem.AtomicWriteAllText(markerPath, oldMarker, Utf8NoBom);
+        }
+        PruneEmptyDirectories(
+            targetRootPath,
+            affectedPaths,
+            preserveTargetRoot: oldMarker is not null
+        );
+    }
+
+    private void PruneEmptyDirectories(
+        string targetRootPath,
+        IEnumerable<string> affectedPaths,
+        bool preserveTargetRoot
+    )
+    {
+        if (!fileSystem.DirectoryExists(targetRootPath))
+        {
+            return;
+        }
+
+        var candidateDirectories = new HashSet<string>(
+            FileSystemPathSemantics.GetComparer(fileSystem)
+        );
+        foreach (string affectedPath in affectedPaths)
+        {
+            string[] segments = GetRelativePathSegments(affectedPath);
+            for (int segmentCount = segments.Length - 1; segmentCount > 0; segmentCount--)
+            {
+                candidateDirectories.Add(
+                    GetOwnedTargetPath(
+                        targetRootPath,
+                        string.Join('/', segments.Take(segmentCount))
+                    )
+                );
+            }
+        }
+
+        foreach (string directory in candidateDirectories.OrderByDescending(
+            static path => path.Length
+        ))
+        {
+            if (
+                fileSystem.DirectoryExists(directory)
+                && !fileSystem.EnumerateFiles(directory).Any()
+                && !fileSystem.EnumerateDirectories(directory).Any()
+            )
+            {
+                fileSystem.DeleteDirectory(directory);
+            }
+        }
+
+        if (
+            !preserveTargetRoot
+            && !fileSystem.EnumerateFiles(targetRootPath).Any()
+            && !fileSystem.EnumerateDirectories(targetRootPath).Any()
+        )
+        {
+            fileSystem.DeleteDirectory(targetRootPath);
+        }
+    }
+
+    private static string[] GetRelativePathSegments(string relativePath) =>
+        relativePath.Split(['/', '\\'], StringSplitOptions.RemoveEmptyEntries);
+
+    private string GetSafeRelativePath(string rootPath, string filePath)
+    {
+        string fullRoot = fileSystem.GetFullPath(rootPath).TrimEnd('/', '\\');
+        string fullPath = fileSystem.GetFullPath(filePath);
+        char separator = FileSystemPathSemantics.UsesWindowsPaths(fileSystem) ? '\\' : '/';
+        string prefix = fullRoot + separator;
+        if (!fullPath.StartsWith(prefix, FileSystemPathSemantics.GetComparison(fileSystem)))
+        {
+            throw new InvalidOperationException(
+                "The NuGet plugin source inventory escaped its application root."
+            );
+        }
+
+        return fullPath[prefix.Length..].Replace('\\', '/');
+    }
+
+    private string GetOwnedTargetPath(string targetRootPath, string relativePath)
+    {
+        if (
+            string.IsNullOrWhiteSpace(relativePath)
+            || relativePath.StartsWith('/')
+            || relativePath.StartsWith('\\')
+            || relativePath
+                .Split(['/', '\\'], StringSplitOptions.RemoveEmptyEntries)
+                .Any(segment => segment is "." or "..")
+        )
+        {
+            throw new InvalidOperationException(
+                "The NuGet plugin activation marker contains an unsafe path."
+            );
+        }
+
+        string targetPath = FileSystemPathSemantics.Combine(
+            fileSystem,
+            targetRootPath,
+            relativePath
+        );
+        if (!FileSystemPathSemantics.IsSameOrDescendant(fileSystem, targetPath, targetRootPath))
+        {
+            throw new InvalidOperationException(
+                "The NuGet plugin activation marker contains an unsafe path."
+            );
+        }
+        return targetPath;
     }
 
     private string GetMarkerPath(string targetRootPath) =>
         FileSystemPathSemantics.Combine(fileSystem, targetRootPath, MarkerFileName);
+
+    private bool ManifestsEquivalent(
+        NuGetPluginActivationManifest left,
+        NuGetPluginActivationManifest right
+    ) =>
+        string.Equals(left.SchemaVersion, right.SchemaVersion, StringComparison.Ordinal)
+        && string.Equals(
+            left.SourceApplicationRoot,
+            right.SourceApplicationRoot,
+            FileSystemPathSemantics.GetComparison(fileSystem)
+        )
+        && left.Files.SequenceEqual(right.Files);
+
+    private sealed record SourcePayload(
+        NuGetPluginActivationManifest Manifest,
+        IReadOnlyList<SourcePayloadFile> Files
+    );
+
+    private sealed record SourcePayloadFile(
+        string RelativePath,
+        byte[] Content,
+        string Sha256,
+        UnixFileMode? UnixFileMode
+    );
+
+    private sealed record RestorableFile(byte[] Content, UnixFileMode? UnixFileMode);
+
 }
+
+internal sealed record NuGetPluginActivationManifest
+{
+    public required string SchemaVersion { get; init; }
+
+    public required string SourceApplicationRoot { get; init; }
+
+    public required NuGetPluginActivationFile[] Files { get; init; }
+}
+
+internal sealed record NuGetPluginActivationFile
+{
+    public required string Path { get; init; }
+
+    public required long Length { get; init; }
+
+    public required string Sha256 { get; init; }
+
+    public int? UnixFileMode { get; init; }
+}
+
+[JsonSerializable(typeof(NuGetPluginActivationManifest))]
+[JsonSerializable(typeof(NuGetPluginActivationFile))]
+[JsonSerializable(typeof(NuGetPluginActivationFile[]))]
+[JsonSourceGenerationOptions(
+    JsonSerializerDefaults.Web,
+    WriteIndented = true,
+    GenerationMode = JsonSourceGenerationMode.Metadata,
+    UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow
+)]
+internal sealed partial class NuGetPluginActivationJsonContext : JsonSerializerContext;

--- a/src/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform/Configuration/NuGetPluginLayoutPhysicalTargetWriter.cs
+++ b/src/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform/Configuration/NuGetPluginLayoutPhysicalTargetWriter.cs
@@ -11,6 +11,11 @@ internal sealed class NuGetPluginLayoutPhysicalTargetWriter(IFileSystem fileSyst
     : IConfigurationPhysicalTargetWriter
 {
     internal const string MarkerFileName = ".azureauth-credprovider.nuget-plugin-layout";
+    internal const string LegacyMarkerValue =
+        "azureauth-credprovider nuget-plugin-layout\n"
+        + "phase=10\n"
+        + "runtime=netcore\n"
+        + "entrypoint=azureauth-credprovider.dll\n";
     private const string MarkerSchemaVersion =
         "azureauth-credprovider-nuget-plugin-activation-v1";
     private const string PluginEntrypointFileName = "azureauth-credprovider.dll";
@@ -42,8 +47,12 @@ internal sealed class NuGetPluginLayoutPhysicalTargetWriter(IFileSystem fileSyst
 
         SourcePayload payload = ReadSourcePayload(request.Change.Value!);
         ValidateDisjointRoots(request.Change.TargetPathOrName, payload);
-        NuGetPluginActivationManifest? existingManifest = ValidateCurrentState(request);
-        ValidateNewTargets(request.Change.TargetPathOrName, existingManifest, payload);
+        ExistingActivation? existingActivation = ValidateCurrentState(
+            request,
+            allowNewOwnershipIntent: false,
+            payload
+        );
+        ValidateNewTargets(request.Change.TargetPathOrName, existingActivation, payload);
     }
 
     public void Write(
@@ -58,24 +67,31 @@ internal sealed class NuGetPluginLayoutPhysicalTargetWriter(IFileSystem fileSyst
             || request.Change.Operation == ConfigurationChangeOperation.Remove;
         if (remove)
         {
-            NuGetPluginActivationManifest? removalManifest = ValidateCurrentState(request);
-            RemoveActivation(request.Change.TargetPathOrName, removalManifest);
+            ExistingActivation? removalActivation = ValidateCurrentState(
+                request,
+                allowNewOwnershipIntent: false
+            );
+            RemoveActivation(request.Change.TargetPathOrName, removalActivation);
             return;
         }
 
         SourcePayload payload = ReadSourcePayload(request.Change.Value!);
         ValidateDisjointRoots(request.Change.TargetPathOrName, payload);
-        NuGetPluginActivationManifest? existingManifest = ValidateCurrentState(request);
-        ValidateNewTargets(request.Change.TargetPathOrName, existingManifest, payload);
+        ExistingActivation? existingActivation = ValidateCurrentState(
+            request,
+            allowNewOwnershipIntent: true,
+            payload
+        );
+        ValidateNewTargets(request.Change.TargetPathOrName, existingActivation, payload);
         if (
-            existingManifest is not null
-            && ManifestsEquivalent(existingManifest, payload.Manifest)
+            existingActivation is { IsLegacy: false }
+            && ManifestsEquivalent(existingActivation.Manifest, payload.Manifest)
             && TargetModesMatch(request.Change.TargetPathOrName, payload)
         )
         {
             return;
         }
-        ReplaceActivation(request.Change.TargetPathOrName, existingManifest, payload);
+        ReplaceActivation(request.Change.TargetPathOrName, existingActivation, payload);
     }
 
     public bool IsSatisfied(
@@ -97,12 +113,13 @@ internal sealed class NuGetPluginLayoutPhysicalTargetWriter(IFileSystem fileSyst
         try
         {
             SourcePayload payload = ReadSourcePayload(request.Change.Value!);
-            NuGetPluginActivationManifest? existing = ReadAndValidateActivation(
+            ExistingActivation? existing = ReadAndValidateActivation(
                 request.Change.TargetPathOrName,
-                request.Change.Value
+                request.Change.Value,
+                payload
             );
-            return existing is not null
-                && ManifestsEquivalent(existing, payload.Manifest)
+            return existing is { IsLegacy: false }
+                && ManifestsEquivalent(existing.Manifest, payload.Manifest)
                 && TargetModesMatch(request.Change.TargetPathOrName, payload);
         }
         catch (
@@ -196,8 +213,10 @@ internal sealed class NuGetPluginLayoutPhysicalTargetWriter(IFileSystem fileSyst
             ? "The NuGet plugin layout target must be fully qualified."
             : null;
 
-    private NuGetPluginActivationManifest? ValidateCurrentState(
-        ConfigurationPhysicalTargetWriterRequest request
+    private ExistingActivation? ValidateCurrentState(
+        ConfigurationPhysicalTargetWriterRequest request,
+        bool allowNewOwnershipIntent = false,
+        SourcePayload? legacyPayload = null
     )
     {
         string targetRootPath = request.Change.TargetPathOrName;
@@ -228,9 +247,20 @@ internal sealed class NuGetPluginLayoutPhysicalTargetWriter(IFileSystem fileSyst
         }
         if (!markerExists)
         {
-            throw new InvalidOperationException(
-                "The NuGet plugin activation directory exists without its ownership marker."
-            );
+            if (
+                remove
+                || (
+                    !allowNewOwnershipIntent
+                    && request.IsOwned(request.Change, fileSystem)
+                )
+            )
+            {
+                throw new InvalidOperationException(
+                    "The NuGet plugin activation directory exists without its ownership marker."
+                );
+            }
+
+            return null;
         }
         if (!request.IsOwned(request.Change, fileSystem))
         {
@@ -241,7 +271,8 @@ internal sealed class NuGetPluginLayoutPhysicalTargetWriter(IFileSystem fileSyst
 
         return ReadAndValidateActivation(
             targetRootPath,
-            remove ? null : request.Change.Value
+            remove ? null : request.Change.Value,
+            legacyPayload
         );
     }
 
@@ -325,9 +356,10 @@ internal sealed class NuGetPluginLayoutPhysicalTargetWriter(IFileSystem fileSyst
         );
     }
 
-    private NuGetPluginActivationManifest? ReadAndValidateActivation(
+    private ExistingActivation? ReadAndValidateActivation(
         string targetRootPath,
-        string? expectedSourceRoot
+        string? expectedSourceRoot,
+        SourcePayload? legacyPayload = null
     )
     {
         string markerPath = GetMarkerPath(targetRootPath);
@@ -336,9 +368,15 @@ internal sealed class NuGetPluginLayoutPhysicalTargetWriter(IFileSystem fileSyst
             return null;
         }
 
+        string marker = fileSystem.ReadAllText(markerPath, Utf8NoBom);
+        if (string.Equals(marker, LegacyMarkerValue, StringComparison.Ordinal))
+        {
+            return ReadLegacyActivation(targetRootPath, legacyPayload);
+        }
+
         NuGetPluginActivationManifest manifest =
             JsonSerializer.Deserialize<NuGetPluginActivationManifest>(
-                fileSystem.ReadAllText(markerPath, Utf8NoBom),
+                marker,
                 MarkerJsonOptions
             )
             ?? throw new InvalidOperationException(
@@ -402,20 +440,83 @@ internal sealed class NuGetPluginLayoutPhysicalTargetWriter(IFileSystem fileSyst
         }
 
         return entrypointListed
-            ? manifest
+            ? new ExistingActivation(manifest, IsLegacy: false)
             : throw new InvalidOperationException(
                 "The NuGet plugin activation payload is incomplete."
             );
     }
 
+    private ExistingActivation ReadLegacyActivation(
+        string targetRootPath,
+        SourcePayload? payload
+    )
+    {
+        string entrypointPath = GetOwnedTargetPath(
+            targetRootPath,
+            PluginEntrypointFileName
+        );
+        if (
+            !fileSystem.FileExists(entrypointPath)
+            || fileSystem.DirectoryExists(entrypointPath)
+        )
+        {
+            throw new InvalidOperationException(
+                "The legacy NuGet plugin activation entrypoint is damaged."
+            );
+        }
+
+        IEnumerable<string> candidatePaths = payload is null
+            ? [PluginEntrypointFileName]
+            : payload.Files.Select(static file => file.RelativePath);
+        var files = new List<NuGetPluginActivationFile>();
+        foreach (string relativePath in candidatePaths)
+        {
+            string targetPath = GetOwnedTargetPath(targetRootPath, relativePath);
+            if (fileSystem.DirectoryExists(targetPath))
+            {
+                throw new InvalidOperationException(
+                    "The legacy NuGet plugin activation payload is damaged."
+                );
+            }
+            if (!fileSystem.FileExists(targetPath))
+            {
+                continue;
+            }
+
+            byte[] content = fileSystem.ReadAllBytes(targetPath);
+            files.Add(
+                new NuGetPluginActivationFile
+                {
+                    Path = relativePath,
+                    Length = content.LongLength,
+                    Sha256 = Convert.ToHexString(SHA256.HashData(content)).ToLowerInvariant(),
+                    UnixFileMode = FileSystemPathSemantics.UsesWindowsPaths(fileSystem)
+                        ? null
+                        : (int)fileSystem.GetUnixFileMode(targetPath),
+                }
+            );
+        }
+
+        return new ExistingActivation(
+            new NuGetPluginActivationManifest
+            {
+                SchemaVersion = MarkerSchemaVersion,
+                SourceApplicationRoot =
+                    payload?.Manifest.SourceApplicationRoot ?? targetRootPath,
+                Files = files.ToArray(),
+            },
+            IsLegacy: true
+        );
+    }
+
     private void ValidateNewTargets(
         string targetRootPath,
-        NuGetPluginActivationManifest? existingManifest,
+        ExistingActivation? existingActivation,
         SourcePayload payload
     )
     {
         var existingOwnedPaths = new HashSet<string>(
-            existingManifest?.Files.Select(file => file.Path) ?? [],
+            existingActivation?.Manifest.Files.Select(file => file.Path) ?? [],
             FileSystemPathSemantics.GetComparer(fileSystem)
         );
         HashSet<string> existingOwnedDirectories = GetOwnedAncestorDirectories(
@@ -436,7 +537,10 @@ internal sealed class NuGetPluginLayoutPhysicalTargetWriter(IFileSystem fileSyst
                     "The NuGet plugin activation would overwrite an unowned path."
                 );
             }
-            if (!existingOwnedPaths.Contains(file.RelativePath))
+            if (
+                !existingOwnedPaths.Contains(file.RelativePath)
+                && existingActivation is not { IsLegacy: true }
+            )
             {
                 ValidateNewPathAncestors(
                     targetRootPath,
@@ -506,17 +610,17 @@ internal sealed class NuGetPluginLayoutPhysicalTargetWriter(IFileSystem fileSyst
 
     private void ReplaceActivation(
         string targetRootPath,
-        NuGetPluginActivationManifest? existingManifest,
+        ExistingActivation? existingActivation,
         SourcePayload payload
     )
     {
         string markerPath = GetMarkerPath(targetRootPath);
-        string? oldMarker = existingManifest is null
+        string? oldMarker = existingActivation is null
             ? null
             : fileSystem.ReadAllText(markerPath, Utf8NoBom);
         Dictionary<string, RestorableFile> oldFiles = SnapshotOwnedFiles(
             targetRootPath,
-            existingManifest
+            existingActivation
         );
         var affectedPaths = new HashSet<string>(
             oldFiles.Keys,
@@ -568,10 +672,10 @@ internal sealed class NuGetPluginLayoutPhysicalTargetWriter(IFileSystem fileSyst
 
     private void RemoveActivation(
         string targetRootPath,
-        NuGetPluginActivationManifest? existingManifest
+        ExistingActivation? existingActivation
     )
     {
-        if (existingManifest is null)
+        if (existingActivation is null)
         {
             return;
         }
@@ -580,7 +684,7 @@ internal sealed class NuGetPluginLayoutPhysicalTargetWriter(IFileSystem fileSyst
         string oldMarker = fileSystem.ReadAllText(markerPath, Utf8NoBom);
         Dictionary<string, RestorableFile> oldFiles = SnapshotOwnedFiles(
             targetRootPath,
-            existingManifest
+            existingActivation
         );
         try
         {
@@ -610,18 +714,18 @@ internal sealed class NuGetPluginLayoutPhysicalTargetWriter(IFileSystem fileSyst
 
     private Dictionary<string, RestorableFile> SnapshotOwnedFiles(
         string targetRootPath,
-        NuGetPluginActivationManifest? manifest
+        ExistingActivation? activation
     )
     {
         var result = new Dictionary<string, RestorableFile>(
             FileSystemPathSemantics.GetComparer(fileSystem)
         );
-        if (manifest is null)
+        if (activation is null)
         {
             return result;
         }
 
-        foreach (NuGetPluginActivationFile entry in manifest.Files)
+        foreach (NuGetPluginActivationFile entry in activation.Manifest.Files)
         {
             string targetPath = GetOwnedTargetPath(targetRootPath, entry.Path);
             result.Add(
@@ -810,8 +914,12 @@ internal sealed class NuGetPluginLayoutPhysicalTargetWriter(IFileSystem fileSyst
         UnixFileMode? UnixFileMode
     );
 
-    private sealed record RestorableFile(byte[] Content, UnixFileMode? UnixFileMode);
+    private sealed record ExistingActivation(
+        NuGetPluginActivationManifest Manifest,
+        bool IsLegacy
+    );
 
+    private sealed record RestorableFile(byte[] Content, UnixFileMode? UnixFileMode);
 }
 
 internal sealed record NuGetPluginActivationManifest

--- a/src/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform/Configuration/NuGetPluginLayoutPhysicalTargetWriter.cs
+++ b/src/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform/Configuration/NuGetPluginLayoutPhysicalTargetWriter.cs
@@ -451,27 +451,38 @@ internal sealed class NuGetPluginLayoutPhysicalTargetWriter(IFileSystem fileSyst
         SourcePayload? payload
     )
     {
-        string entrypointPath = GetOwnedTargetPath(
-            targetRootPath,
-            PluginEntrypointFileName
-        );
+        if (payload is null)
+        {
+            return new ExistingActivation(
+                new NuGetPluginActivationManifest
+                {
+                    SchemaVersion = MarkerSchemaVersion,
+                    SourceApplicationRoot = targetRootPath,
+                    Files = [],
+                },
+                IsLegacy: true
+            );
+        }
+
+        string entrypointPath = GetOwnedTargetPath(targetRootPath, PluginEntrypointFileName);
         if (
             !fileSystem.FileExists(entrypointPath)
             || fileSystem.DirectoryExists(entrypointPath)
         )
         {
             throw new InvalidOperationException(
-                "The legacy NuGet plugin activation entrypoint is damaged."
+                "The legacy NuGet plugin activation entrypoint cannot be matched "
+                    + "to the source payload."
             );
         }
 
-        IEnumerable<string> candidatePaths = payload is null
-            ? [PluginEntrypointFileName]
-            : payload.Files.Select(static file => file.RelativePath);
         var files = new List<NuGetPluginActivationFile>();
-        foreach (string relativePath in candidatePaths)
+        foreach (SourcePayloadFile sourceFile in payload.Files)
         {
-            string targetPath = GetOwnedTargetPath(targetRootPath, relativePath);
+            string targetPath = GetOwnedTargetPath(
+                targetRootPath,
+                sourceFile.RelativePath
+            );
             if (fileSystem.DirectoryExists(targetPath))
             {
                 throw new InvalidOperationException(
@@ -483,16 +494,34 @@ internal sealed class NuGetPluginLayoutPhysicalTargetWriter(IFileSystem fileSyst
                 continue;
             }
 
-            byte[] content = fileSystem.ReadAllBytes(targetPath);
+            byte[] targetContent = fileSystem.ReadAllBytes(targetPath);
+            string targetHash = Convert.ToHexString(SHA256.HashData(targetContent))
+                .ToLowerInvariant();
+            if (
+                !targetContent.AsSpan().SequenceEqual(sourceFile.Content)
+                || !string.Equals(
+                    targetHash,
+                    sourceFile.Sha256,
+                    StringComparison.Ordinal
+                )
+            )
+            {
+                throw new InvalidOperationException(
+                    "The legacy NuGet plugin activation payload does not match "
+                        + "the authoritative source payload."
+                );
+            }
+
             files.Add(
                 new NuGetPluginActivationFile
                 {
-                    Path = relativePath,
-                    Length = content.LongLength,
-                    Sha256 = Convert.ToHexString(SHA256.HashData(content)).ToLowerInvariant(),
-                    UnixFileMode = FileSystemPathSemantics.UsesWindowsPaths(fileSystem)
-                        ? null
-                        : (int)fileSystem.GetUnixFileMode(targetPath),
+                    Path = sourceFile.RelativePath,
+                    Length = sourceFile.Content.LongLength,
+                    Sha256 = sourceFile.Sha256,
+                    UnixFileMode =
+                        sourceFile.UnixFileMode is null
+                            ? null
+                            : (int)sourceFile.UnixFileMode.Value,
                 }
             );
         }
@@ -501,8 +530,7 @@ internal sealed class NuGetPluginLayoutPhysicalTargetWriter(IFileSystem fileSyst
             new NuGetPluginActivationManifest
             {
                 SchemaVersion = MarkerSchemaVersion,
-                SourceApplicationRoot =
-                    payload?.Manifest.SourceApplicationRoot ?? targetRootPath,
+                SourceApplicationRoot = payload.Manifest.SourceApplicationRoot,
                 Files = files.ToArray(),
             },
             IsLegacy: true
@@ -537,10 +565,7 @@ internal sealed class NuGetPluginLayoutPhysicalTargetWriter(IFileSystem fileSyst
                     "The NuGet plugin activation would overwrite an unowned path."
                 );
             }
-            if (
-                !existingOwnedPaths.Contains(file.RelativePath)
-                && existingActivation is not { IsLegacy: true }
-            )
+            if (!existingOwnedPaths.Contains(file.RelativePath))
             {
                 ValidateNewPathAncestors(
                     targetRootPath,
@@ -696,7 +721,7 @@ internal sealed class NuGetPluginLayoutPhysicalTargetWriter(IFileSystem fileSyst
             PruneEmptyDirectories(
                 targetRootPath,
                 oldFiles.Keys,
-                preserveTargetRoot: false
+                preserveTargetRoot: existingActivation.IsLegacy
             );
         }
         catch

--- a/src/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform/Configuration/NuGetPluginLayoutPhysicalTargetWriter.cs
+++ b/src/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform/Configuration/NuGetPluginLayoutPhysicalTargetWriter.cs
@@ -31,7 +31,19 @@ internal sealed class NuGetPluginLayoutPhysicalTargetWriter(IFileSystem fileSyst
     {
         cancellationToken.ThrowIfCancellationRequested();
         ValidateRequest(request);
-        ValidateCurrentState(request);
+        if (
+            request.PlanOperation == ConfigurationPlanOperation.Remove
+            || request.Change.Operation == ConfigurationChangeOperation.Remove
+        )
+        {
+            ValidateCurrentState(request);
+            return;
+        }
+
+        SourcePayload payload = ReadSourcePayload(request.Change.Value!);
+        ValidateDisjointRoots(request.Change.TargetPathOrName, payload);
+        NuGetPluginActivationManifest? existingManifest = ValidateCurrentState(request);
+        ValidateNewTargets(request.Change.TargetPathOrName, existingManifest, payload);
     }
 
     public void Write(
@@ -41,18 +53,28 @@ internal sealed class NuGetPluginLayoutPhysicalTargetWriter(IFileSystem fileSyst
     {
         cancellationToken.ThrowIfCancellationRequested();
         ValidateRequest(request);
-        NuGetPluginActivationManifest? existingManifest = ValidateCurrentState(request);
         bool remove =
             request.PlanOperation == ConfigurationPlanOperation.Remove
             || request.Change.Operation == ConfigurationChangeOperation.Remove;
         if (remove)
         {
-            RemoveActivation(request.Change.TargetPathOrName, existingManifest);
+            NuGetPluginActivationManifest? removalManifest = ValidateCurrentState(request);
+            RemoveActivation(request.Change.TargetPathOrName, removalManifest);
             return;
         }
 
         SourcePayload payload = ReadSourcePayload(request.Change.Value!);
+        ValidateDisjointRoots(request.Change.TargetPathOrName, payload);
+        NuGetPluginActivationManifest? existingManifest = ValidateCurrentState(request);
         ValidateNewTargets(request.Change.TargetPathOrName, existingManifest, payload);
+        if (
+            existingManifest is not null
+            && ManifestsEquivalent(existingManifest, payload.Manifest)
+            && TargetModesMatch(request.Change.TargetPathOrName, payload)
+        )
+        {
+            return;
+        }
         ReplaceActivation(request.Change.TargetPathOrName, existingManifest, payload);
     }
 
@@ -79,7 +101,9 @@ internal sealed class NuGetPluginLayoutPhysicalTargetWriter(IFileSystem fileSyst
                 request.Change.TargetPathOrName,
                 request.Change.Value
             );
-            return existing is not null && ManifestsEquivalent(existing, payload.Manifest);
+            return existing is not null
+                && ManifestsEquivalent(existing, payload.Manifest)
+                && TargetModesMatch(request.Change.TargetPathOrName, payload);
         }
         catch (
             Exception exception
@@ -94,6 +118,21 @@ internal sealed class NuGetPluginLayoutPhysicalTargetWriter(IFileSystem fileSyst
         {
             return false;
         }
+    }
+
+    private bool TargetModesMatch(string targetRootPath, SourcePayload payload)
+    {
+        if (FileSystemPathSemantics.UsesWindowsPaths(fileSystem))
+        {
+            return true;
+        }
+
+        return payload.Files.All(file =>
+            file.UnixFileMode is { } mode
+            && fileSystem.GetUnixFileMode(
+                GetOwnedTargetPath(targetRootPath, file.RelativePath)
+            ) == mode
+        );
     }
 
     internal static string? GetPlanningValidationViolation(ConfigurationChange change)
@@ -375,24 +414,6 @@ internal sealed class NuGetPluginLayoutPhysicalTargetWriter(IFileSystem fileSyst
         SourcePayload payload
     )
     {
-        if (
-            FileSystemPathSemantics.IsSameOrDescendant(
-                fileSystem,
-                payload.Manifest.SourceApplicationRoot,
-                targetRootPath
-            )
-            || FileSystemPathSemantics.IsSameOrDescendant(
-                fileSystem,
-                targetRootPath,
-                payload.Manifest.SourceApplicationRoot
-            )
-        )
-        {
-            throw new InvalidOperationException(
-                "The NuGet plugin source and activation roots must be disjoint."
-            );
-        }
-
         var existingOwnedPaths = new HashSet<string>(
             existingManifest?.Files.Select(file => file.Path) ?? [],
             FileSystemPathSemantics.GetComparer(fileSystem)
@@ -423,6 +444,27 @@ internal sealed class NuGetPluginLayoutPhysicalTargetWriter(IFileSystem fileSyst
                     existingOwnedDirectories
                 );
             }
+        }
+    }
+
+    private void ValidateDisjointRoots(string targetRootPath, SourcePayload payload)
+    {
+        if (
+            FileSystemPathSemantics.IsSameOrDescendant(
+                fileSystem,
+                payload.Manifest.SourceApplicationRoot,
+                targetRootPath
+            )
+            || FileSystemPathSemantics.IsSameOrDescendant(
+                fileSystem,
+                targetRootPath,
+                payload.Manifest.SourceApplicationRoot
+            )
+        )
+        {
+            throw new InvalidOperationException(
+                "The NuGet plugin source and activation roots must be disjoint."
+            );
         }
     }
 

--- a/src/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform/VerticalSlice/NuGetPhase10VerticalSliceService.cs
+++ b/src/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform/VerticalSlice/NuGetPhase10VerticalSliceService.cs
@@ -489,10 +489,15 @@ public sealed class NuGetPhase10VerticalSliceService
                 return false;
             }
 
-            manifest = ConfigurationOwnershipManifestSerializer.Deserialize(
-                fileSystem.ReadAllText(paths.OwnershipManifestPath)
-            );
+            string manifestJson = fileSystem.ReadAllText(paths.OwnershipManifestPath);
+            manifest = ConfigurationOwnershipManifestSerializer.Deserialize(manifestJson);
             if (
+                !string.Equals(
+                    ConfigurationOwnershipManifestSerializer.Serialize(manifest),
+                    manifestJson,
+                    StringComparison.Ordinal
+                )
+                ||
                 !HasExpectedManifestMetadata(manifest)
                 || !HasExpectedManagedManifestEntries(manifest)
             )

--- a/src/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform/VerticalSlice/NuGetPhase10VerticalSliceService.cs
+++ b/src/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform/VerticalSlice/NuGetPhase10VerticalSliceService.cs
@@ -16,6 +16,8 @@ public sealed record NuGetPhase10VerticalSliceOptions
 
     public string? ApplicationPayloadRootPath { get; init; }
 
+    public string? UserHomeDirectoryPath { get; init; }
+
     public IFileSystem? FileSystem { get; init; }
 
     public Func<string, string?>? EnvironmentVariableReader { get; init; }
@@ -806,7 +808,9 @@ public sealed class NuGetPhase10VerticalSliceService
             "manifests",
             "nuget-plugin-layout-ownership-manifest.json"
         );
-        string homeDirectory = GetCurrentUserProfileDirectory(environmentVariableReader);
+        string homeDirectory =
+            NullIfWhiteSpace(options.UserHomeDirectoryPath)
+            ?? GetCurrentUserProfileDirectory(environmentVariableReader);
         if (string.IsNullOrWhiteSpace(homeDirectory))
         {
             throw new InvalidOperationException(
@@ -932,6 +936,9 @@ public sealed class NuGetPhase10VerticalSliceService
 
     private static StringComparison GetPathComparison() =>
         OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+
+    private static string? NullIfWhiteSpace(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value;
 
     private static bool IsExpectedStateCheckFailure(Exception exception) =>
         exception

--- a/src/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform/VerticalSlice/NuGetPhase10VerticalSliceService.cs
+++ b/src/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform/VerticalSlice/NuGetPhase10VerticalSliceService.cs
@@ -71,9 +71,18 @@ public sealed record NuGetPhase10UnconfigureResult
     public required bool OwnershipManifestPresent { get; init; }
 }
 
+public enum NuGetConfigurationState
+{
+    Valid = 1,
+    Refreshable = 2,
+    Unrecognized = 3,
+}
+
 public sealed record NuGetPhase10DoctorResult
 {
     public required NuGetPhase10VerticalSliceResolvedPaths Paths { get; init; }
+
+    public required NuGetConfigurationState ConfigurationState { get; init; }
 
     public required bool ConfigurationPlanValid { get; init; }
 
@@ -180,10 +189,29 @@ public sealed class NuGetPhase10VerticalSliceService
 
         ThrowIfUnrecognizedOwnershipManifestExists();
         ThrowIfMissingManifestLeavesProductOwnedNuGetPluginLayoutState();
+        ConfigurationChangePlan plan = CreateConfigurePlan();
+        ConfigurationManager manager = CreateManager();
         ConfigurationPlanResult planResult;
         try
         {
-            planResult = await CreateManager().ApplyAsync(CreateConfigurePlan(), cancellationToken);
+            if (manager.IsAppliedStateCurrent(plan, cancellationToken))
+            {
+                ConfigurationPlanResult currentResult = await manager.DryRunAsync(
+                    plan,
+                    cancellationToken
+                );
+                planResult = currentResult with
+                {
+                    Operation = ConfigurationPlanOperation.Apply,
+                    Plan = currentResult.Plan with { Changes = [] },
+                    Changes = [],
+                    PlannedOperations = [],
+                };
+            }
+            else
+            {
+                planResult = await manager.ApplyAsync(plan, cancellationToken);
+            }
         }
         catch (Exception exception) when (IsExpectedStateCheckFailure(exception))
         {
@@ -282,7 +310,8 @@ public sealed class NuGetPhase10VerticalSliceService
         cancellationToken.ThrowIfCancellationRequested();
 
         NuGetPhase10OwnedState ownedState = await InspectOwnedStateAsync(cancellationToken);
-        bool configurationPlanValid = await TryValidateConfigurationPlanAsync(cancellationToken);
+        NuGetConfigurationState configurationState =
+            await ClassifyConfigurationStateAsync(cancellationToken);
         bool netCorePluginEntrypointPresent = TryPluginEntrypointExists();
         bool pluginModeEntrypointResolvable =
             netCorePluginEntrypointPresent && TryResolvePluginModeEntrypoint();
@@ -290,7 +319,8 @@ public sealed class NuGetPhase10VerticalSliceService
         return new NuGetPhase10DoctorResult
         {
             Paths = paths,
-            ConfigurationPlanValid = configurationPlanValid,
+            ConfigurationState = configurationState,
+            ConfigurationPlanValid = configurationState == NuGetConfigurationState.Valid,
             PluginLayoutMarkerPresent = ownedState.PluginLayoutMarkerPresent,
             OwnershipManifestPresent = ownedState.OwnershipManifestPresent,
             NetCorePluginEntrypointPresent = netCorePluginEntrypointPresent,
@@ -517,7 +547,7 @@ public sealed class NuGetPhase10VerticalSliceService
         }
     }
 
-    private async ValueTask<bool> TryValidateConfigurationPlanAsync(
+    private async ValueTask<NuGetConfigurationState> ClassifyConfigurationStateAsync(
         CancellationToken cancellationToken
     )
     {
@@ -526,12 +556,29 @@ public sealed class NuGetPhase10VerticalSliceService
             ConfigurationChangePlan plan = CreateConfigurePlan();
             ConfigurationManager manager = CreateManager();
             ConfigurationPlanValidationResult validation = manager.ValidatePlan(plan);
-            ConfigurationPlanResult planResult = await manager.DryRunAsync(plan, cancellationToken);
-            return validation.IsValid && planResult.Operation == ConfigurationPlanOperation.DryRun;
+            if (!validation.IsValid)
+            {
+                return NuGetConfigurationState.Unrecognized;
+            }
+
+            ThrowIfUnrecognizedOwnershipManifestExists();
+            ThrowIfMissingManifestLeavesProductOwnedNuGetPluginLayoutState();
+
+            bool activationPresent =
+                OwnershipManifestPathExists() || PluginLayoutMarkerPathExists();
+            if (!activationPresent)
+            {
+                return NuGetConfigurationState.Valid;
+            }
+
+            await manager.DryRunAsync(plan, cancellationToken);
+            return manager.IsAppliedStateCurrent(plan, cancellationToken)
+                ? NuGetConfigurationState.Valid
+                : NuGetConfigurationState.Refreshable;
         }
         catch (Exception exception) when (IsExpectedStateCheckFailure(exception))
         {
-            return false;
+            return NuGetConfigurationState.Unrecognized;
         }
     }
 

--- a/src/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform/VerticalSlice/NuGetPhase10VerticalSliceService.cs
+++ b/src/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform/VerticalSlice/NuGetPhase10VerticalSliceService.cs
@@ -14,6 +14,8 @@ public sealed record NuGetPhase10VerticalSliceOptions
 {
     public string? StateDirectoryPath { get; init; }
 
+    public string? ApplicationPayloadRootPath { get; init; }
+
     public IFileSystem? FileSystem { get; init; }
 
     public Func<string, string?>? EnvironmentVariableReader { get; init; }
@@ -28,6 +30,8 @@ public sealed record NuGetPhase10VerticalSliceResolvedPaths
     public required string OwnershipManifestPath { get; init; }
 
     public required string PluginTargetRootPath { get; init; }
+
+    public required string ApplicationPayloadRootPath { get; init; }
 
     public required string PluginEntrypointPath { get; init; }
 
@@ -99,13 +103,6 @@ public sealed class NuGetPhase10UnrecognizedStateException : InvalidOperationExc
 
 public sealed class NuGetPhase10VerticalSliceService
 {
-    internal const string MarkerFileName = ".azureauth-credprovider.nuget-plugin-layout";
-    internal const string MarkerValue =
-        "azureauth-credprovider nuget-plugin-layout\n"
-        + "phase=10\n"
-        + "runtime=netcore\n"
-        + "entrypoint=azureauth-credprovider.dll\n";
-
     private const string ProductId = "azureauth-credprovider";
     private const string ProductVersion = "phase10";
     private const string ManifestId = "phase10-nuget-plugin-layout";
@@ -325,7 +322,12 @@ public sealed class NuGetPhase10VerticalSliceService
                 EntrySelector = EntrySelector,
                 ProductVersion = ProductVersion,
             },
-            [CreateNuGetPluginLayoutChange(ConfigurationChangeOperation.Set, MarkerValue)]
+            [
+                CreateNuGetPluginLayoutChange(
+                    ConfigurationChangeOperation.Set,
+                    paths.ApplicationPayloadRootPath
+                ),
+            ]
         );
     }
 
@@ -425,23 +427,11 @@ public sealed class NuGetPhase10VerticalSliceService
     {
         try
         {
-            if (!fileSystem.FileExists(paths.PluginLayoutMarkerPath))
-            {
-                return false;
-            }
-
-            if (fileSystem.DirectoryExists(paths.PluginLayoutMarkerPath))
-            {
-                throw new NuGetPhase10UnrecognizedStateException(
-                    "The Phase 10 NuGet plugin layout state is not recognized."
-                );
-            }
-
-            return string.Equals(
-                fileSystem.ReadAllText(paths.PluginLayoutMarkerPath),
-                MarkerValue,
-                StringComparison.Ordinal
-            );
+            return fileSystem.FileExists(paths.PluginTargetRootPath)
+                || fileSystem.FileExists(paths.PluginLayoutMarkerPath)
+                || fileSystem.DirectoryExists(paths.PluginLayoutMarkerPath)
+                || fileSystem.FileExists(paths.PluginEntrypointPath)
+                || fileSystem.DirectoryExists(paths.PluginEntrypointPath);
         }
         catch (NuGetPhase10UnrecognizedStateException)
         {
@@ -490,50 +480,41 @@ public sealed class NuGetPhase10VerticalSliceService
         }
     }
 
-    private async ValueTask<NuGetPhase10OwnedState> InspectOwnedStateAsync(
+    private ValueTask<NuGetPhase10OwnedState> InspectOwnedStateAsync(
         CancellationToken cancellationToken
     )
     {
+        cancellationToken.ThrowIfCancellationRequested();
         bool ownershipManifestPresent = OwnershipManifestPathExists();
         if (!ownershipManifestPresent)
         {
-            return new NuGetPhase10OwnedState(
-                ProductOwnedNuGetPluginLayoutStateExists(),
-                OwnershipManifestPresent: false
+            return ValueTask.FromResult(
+                new NuGetPhase10OwnedState(
+                    PluginLayoutMarkerPathExists(),
+                    OwnershipManifestPresent: false
+                )
             );
         }
 
-        bool pluginLayoutMarkerPresent = false;
+        return ValueTask.FromResult(
+            new NuGetPhase10OwnedState(
+                PluginLayoutMarkerPathExists(),
+                ownershipManifestPresent
+            )
+        );
+    }
+
+    private bool PluginLayoutMarkerPathExists()
+    {
         try
         {
-            if (TryLoadExpectedOwnershipManifest(out ConfigurationOwnershipManifest? manifest))
-            {
-                pluginLayoutMarkerPresent = await CanDryRunOwnedNuGetRemovalAsync(
-                    manifest,
-                    cancellationToken
-                );
-            }
-            else
-            {
-                pluginLayoutMarkerPresent = ProductOwnedNuGetPluginLayoutStateExists();
-            }
+            return fileSystem.FileExists(paths.PluginLayoutMarkerPath)
+                && !fileSystem.DirectoryExists(paths.PluginLayoutMarkerPath);
         }
         catch (Exception exception) when (IsExpectedStateCheckFailure(exception))
         {
-            pluginLayoutMarkerPresent = false;
+            return false;
         }
-
-        return new NuGetPhase10OwnedState(pluginLayoutMarkerPresent, ownershipManifestPresent);
-    }
-
-    private async ValueTask<bool> CanDryRunOwnedNuGetRemovalAsync(
-        ConfigurationOwnershipManifest manifest,
-        CancellationToken cancellationToken
-    )
-    {
-        ConfigurationPlanResult planResult = await CreateManager()
-            .DryRunAsync(CreateUnconfigurePlan(manifest), cancellationToken);
-        return planResult.Operation == ConfigurationPlanOperation.DryRun;
     }
 
     private async ValueTask<bool> TryValidateConfigurationPlanAsync(
@@ -796,6 +777,9 @@ public sealed class NuGetPhase10VerticalSliceService
                 }
             );
         string pluginTargetRootPath = fileSystem.GetFullPath(projection.TargetPath);
+        string applicationPayloadRootPath = fileSystem.GetFullPath(
+            options.ApplicationPayloadRootPath ?? AppContext.BaseDirectory
+        );
         string pluginEntrypointPath = FileSystemPathSemantics.Combine(
             fileSystem,
             pluginTargetRootPath,
@@ -804,7 +788,7 @@ public sealed class NuGetPhase10VerticalSliceService
         string pluginLayoutMarkerPath = FileSystemPathSemantics.Combine(
             fileSystem,
             pluginTargetRootPath,
-            MarkerFileName
+            NuGetPluginLayoutPhysicalTargetWriter.MarkerFileName
         );
 
         return new NuGetPhase10VerticalSliceResolvedPaths
@@ -812,6 +796,7 @@ public sealed class NuGetPhase10VerticalSliceService
             StateDirectoryPath = stateDirectoryPath,
             OwnershipManifestPath = ownershipManifestPath,
             PluginTargetRootPath = pluginTargetRootPath,
+            ApplicationPayloadRootPath = applicationPayloadRootPath,
             PluginEntrypointPath = pluginEntrypointPath,
             PluginLayoutMarkerPath = pluginLayoutMarkerPath,
         };

--- a/src/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform/VerticalSlice/NuGetPhase10VerticalSliceService.cs
+++ b/src/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform/VerticalSlice/NuGetPhase10VerticalSliceService.cs
@@ -571,13 +571,10 @@ public sealed class NuGetPhase10VerticalSliceService
 
             bool activationPresent =
                 OwnershipManifestPathExists() || PluginLayoutMarkerPathExists();
-            if (!activationPresent)
-            {
-                return NuGetConfigurationState.Valid;
-            }
-
             await manager.DryRunAsync(plan, cancellationToken);
-            return manager.IsAppliedStateCurrent(plan, cancellationToken)
+            return !activationPresent
+                ? NuGetConfigurationState.Valid
+                : manager.IsAppliedStateCurrent(plan, cancellationToken)
                 ? NuGetConfigurationState.Valid
                 : NuGetConfigurationState.Refreshable;
         }

--- a/src/private/app/azureauth-credprovider/docs/high-level-design.md
+++ b/src/private/app/azureauth-credprovider/docs/high-level-design.md
@@ -375,8 +375,13 @@ copies payloads only into per-user, product-owned locations and does not mutate
 global PATH, shell profiles, the registry, Git configuration, NuGet
 configuration, or Python environments. Ecosystem configuration remains an
 explicit CLI operation. Uninstallation first invokes product-owned Git, NuGet,
-and Python unconfiguration, then removes the recorded product and NuGet payload
-roots.
+and Python unconfiguration, then removes the recorded product payload root.
+`configure nuget` exclusively owns creation of the conventional NuGet discovery
+layout, and `unconfigure nuget` removes only the inventory-verified activation
+files it owns. Directory cleanup considers only ancestors of affected inventory
+paths whose ownership is established by prior inventory ancestry or creation for
+the current payload, so unrelated files and pre-existing empty subtrees are
+preserved.
 
 The bundle by itself validates deployment shape and lifecycle behavior. It is
 not a signed release artifact or release installer and does not close Windows,

--- a/src/private/app/azureauth-credprovider/docs/phase-wp16-deployment-validation-bundle.md
+++ b/src/private/app/azureauth-credprovider/docs/phase-wp16-deployment-validation-bundle.md
@@ -43,10 +43,6 @@ Default product roots are:
 | Windows  | `%LOCALAPPDATA%\AzureAuth\CredProvider\installation` |
 | Linux    | `~/.local/lib/azureauth-credprovider`                |
 
-The NuGet netcore plugin payload is installed separately under
-`~/.nuget/plugins/netcore/azureauth-credprovider` on both platforms, using the
-current user's profile directory.
-
 The product root contains:
 
 - `app/` for the complete application payload;
@@ -56,7 +52,13 @@ The product root contains:
 
 Physical installation does not mutate global PATH, shell profiles, the Windows
 registry, Git configuration, NuGet configuration, or Python environments. The
-wheel must be installed into the exact Python environment that imports the
+NuGet conventional discovery directory does not exist until `configure nuget`
+copies the installed application payload to
+`~/.nuget/plugins/netcore/azureauth-credprovider` and records the product-owned
+activation inventory. `unconfigure nuget` removes only inventory-listed files
+whose hashes still match and preserves unrelated files.
+
+The wheel must be installed into the exact Python environment that imports the
 backend. On Linux, `configure python` then writes the backend manifest and
 controlled-PATH `keyring` shim. The shim invokes the installed apphost directly,
 so uv and pip subprocess mode can authenticate before a project environment has
@@ -69,9 +71,9 @@ configuration.
 Installation rejects an artifact whose manifest does not declare the internal
 non-release schema, supported operating system, and host-matching x64 RID. It
 validates the manifest file inventory and hashes, copies the full app payload to
-both the product app root and NuGet's conventional netcore plugin root, installs
-launchers and the wheel, restores Unix executable modes, and records an install
-receipt.
+the product app root, installs launchers and the wheel, restores Unix executable
+modes, and records an install receipt. Physical installation never creates the
+NuGet conventional plugin root.
 
 By default, uninstallation invokes:
 
@@ -88,39 +90,34 @@ In an identified Azure Pipelines job, uninstallation also runs
 `cleanup --ci azure-pipelines` for the current `SYSTEM_JOBID`; it does not scan
 or remove state for other jobs.
 
-It then removes only the product and NuGet plugin roots recorded in the install
-receipt. `-SkipConfigurationCleanup` is an explicit escape hatch for damaged or
+It then removes only the product root recorded in the install receipt. NuGet
+activation removal belongs exclusively to `unconfigure nuget`.
+`-SkipConfigurationCleanup` is an explicit escape hatch for damaged or
 incomplete installations; it does not bypass receipt validation. If the product
 executable is missing, normal uninstall stops rather than silently leaving stale
 ecosystem configuration.
 
 `-Force` replaces only an empty target or an existing installation whose receipt
-matches both requested roots. It rejects non-empty unrelated directories and
-root changes that could orphan the prior NuGet payload. Product and NuGet roots
-must be disjoint; neither may contain the other. Payload copying uses literal
-source paths, including when the extracted bundle path contains PowerShell
-wildcard characters. If installation fails after creating its target roots, it
-removes those partial roots before propagating the failure.
+matches the requested product root. It rejects non-empty unrelated directories.
+Payload copying uses literal source paths, including when the extracted bundle
+path contains PowerShell wildcard characters. If installation fails after
+creating its target root, it removes that partial root before propagating the
+failure.
 
 ## Linux Lifecycle Evidence
 
-On 2026-07-31, an isolated `linux-x64` bundle completed:
+On 2026-08-11, an isolated `linux-x64` working-tree bundle completed:
 
 1. Archive manifest and file-hash validation.
-2. Installation into isolated product and NuGet roots.
-3. CLI and Git launcher invocation.
-4. Git, NuGet, and Python configuration without authentication.
-5. Wheel installation into an isolated virtual environment.
-6. Backend-manifest loading and exact `python-keyring` apphost argv verification.
-7. Configuration-aware uninstallation.
-8. Removal of the product and NuGet payload roots.
-9. Refusal to delete a damaged installation without the explicit cleanup bypass.
-10. Rejection of unsupported generation and host-mismatched RID requests.
-11. Refusal to force-replace unrelated or receipt-mismatched roots.
-12. Cleanup of roots created by a failed installation.
-13. Rejection of nested product and NuGet roots.
-14. Installation from an extraction path containing wildcard characters.
-15. Rejection of hidden files absent from the bundle manifest.
+2. Physical installation without a NuGet conventional discovery directory.
+3. Uninstallation before NuGet configuration.
+4. `configure nuget` creation of the discoverable owned plugin layout.
+5. Configuration-aware uninstallation after NuGet configuration.
+6. Removal of owned NuGet activation files while preserving an unrelated file.
+7. Refusal to force-replace unrelated or receipt-mismatched product roots.
+8. Cleanup of product roots created by a failed installation.
+9. Installation from an extraction path containing wildcard characters.
+10. Rejection of hidden files absent from the bundle manifest.
 
 No token acquisition, AzureAuth launch, browser interaction, WAM interaction,
 device code, or private-feed authorization occurred.

--- a/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Cli.Tests/CliApplicationTests.cs
+++ b/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Cli.Tests/CliApplicationTests.cs
@@ -5280,13 +5280,33 @@ public sealed class CliApplicationTests
         };
     }
 
-    private static NuGetPhase10VerticalSliceOptions CreateIsolatedNuGetPhase10Options() =>
-        new()
+    private static NuGetPhase10VerticalSliceOptions CreateIsolatedNuGetPhase10Options()
+    {
+        string rootPath = Path.Combine(
+            Environment.CurrentDirectory,
+            "artifacts",
+            "azureauth-credprovider",
+            "cli-nuget-fixture"
+        );
+        string applicationRoot = Path.Combine(rootPath, "app");
+        var fileSystem =
+            new EmptyNuGetDryRunFileSystem.RecordingNuGetConfigurationFileSystem();
+        fileSystem.AtomicWriteAllText(
+            Path.Combine(applicationRoot, "azureauth-credprovider.dll"),
+            "fake-assembly"
+        );
+        fileSystem.AtomicWriteAllText(
+            Path.Combine(applicationRoot, "dependency.dll"),
+            "dependency"
+        );
+        return new NuGetPhase10VerticalSliceOptions
         {
-            StateDirectoryPath = "/state/azureauth-credprovider/phase10",
-            FileSystem = new EmptyNuGetDryRunFileSystem(),
+            StateDirectoryPath = Path.Combine(rootPath, "state"),
+            ApplicationPayloadRootPath = applicationRoot,
+            FileSystem = fileSystem,
             EnvironmentVariableReader = _ => null,
         };
+    }
 
     private static NpmPhase12VerticalSliceOptions CreateIsolatedNpmPhase12Options(
         string rootPath

--- a/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Cli.Tests/CliApplicationTests.cs
+++ b/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Cli.Tests/CliApplicationTests.cs
@@ -1260,11 +1260,7 @@ public sealed class CliApplicationTests
     public async Task AppHostConfigureAndDryRunIgnoreMalformedProviderRecord()
     {
         const string SecretMarker = "must-not-leak-malformed-configure-secret";
-        string rootPath = Path.Combine(
-            AppContext.BaseDirectory,
-            "malformed-configure-" + Guid.NewGuid().ToString("N")
-        );
-        CreateOwnerOnlyDirectory(rootPath);
+        string rootPath = CreateTestDirectory();
         string configurationHome = Path.Combine(rootPath, "configuration-home");
         CreateOwnerOnlyDirectory(configurationHome);
         try
@@ -1833,9 +1829,14 @@ public sealed class CliApplicationTests
         var nuGetOptions = new NuGetPhase10VerticalSliceOptions
         {
             StateDirectoryPath = Path.Combine(stateDirectory, "nuget"),
+            ApplicationPayloadRootPath = Path.Combine(stateDirectory, "nuget-app"),
             FileSystem = nuGetFileSystem,
             EnvironmentVariableReader = _ => null,
         };
+        nuGetFileSystem.AtomicWriteAllText(
+            Path.Combine(stateDirectory, "nuget-app", "azureauth-credprovider.dll"),
+            "plugin"
+        );
         CliRuntimeOptions runtimeOptions = CreateGitPhase8RuntimeOptions(stateDirectory) with
         {
             CompositionRoot = null,
@@ -1905,12 +1906,14 @@ public sealed class CliApplicationTests
                 );
                 if (!dryRun)
                 {
+                    Assert.Contains(
+                        "azureauth-credprovider-nuget-plugin-activation-v1",
+                        nuGetFileSystem.ReadAllText(nuGetService.Paths.PluginLayoutMarkerPath),
+                        StringComparison.Ordinal
+                    );
                     Assert.Equal(
-                        "azureauth-credprovider nuget-plugin-layout\n"
-                            + "phase=10\n"
-                            + "runtime=netcore\n"
-                            + "entrypoint=azureauth-credprovider.dll\n",
-                        nuGetFileSystem.ReadAllText(nuGetService.Paths.PluginLayoutMarkerPath)
+                        "plugin",
+                        nuGetFileSystem.ReadAllText(nuGetService.Paths.PluginEntrypointPath)
                     );
                     Assert.Contains(
                         "phase10-nuget-plugin-layout",
@@ -4690,7 +4693,7 @@ public sealed class CliApplicationTests
             configuration-plan: valid
             planned-change-count: 1
             planned-actions:
-              1. register product-owned NuGet netcore plugin layout marker
+              1. create product-owned NuGet netcore plugin activation
             note: dry-run only; no files, credentials, or caches are changed in phase 10
             """
         );

--- a/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Cli.Tests/CliApplicationTests.cs
+++ b/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Cli.Tests/CliApplicationTests.cs
@@ -1742,6 +1742,142 @@ public sealed class CliApplicationTests
     }
 
     [Fact]
+    public void ConfigureNuGetReportsInitialNoOpAndChangedSourceCounts()
+    {
+        const string applicationRoot = "/installation/app";
+        var fileSystem =
+            new EmptyNuGetDryRunFileSystem.RecordingNuGetConfigurationFileSystem();
+        fileSystem.AtomicWriteAllText(
+            applicationRoot + "/azureauth-credprovider.dll",
+            "source-a"
+        );
+        fileSystem.AtomicWriteAllText(applicationRoot + "/dependency.dll", "dependency");
+        var options = new NuGetPhase10VerticalSliceOptions
+        {
+            StateDirectoryPath = "/state/nuget",
+            ApplicationPayloadRootPath = applicationRoot,
+            FileSystem = fileSystem,
+            EnvironmentVariableReader = _ => null,
+        };
+        var runtime = new CliRuntimeOptions { NuGetPhase10Options = options };
+
+        CommandResult initial = InvokeWithRuntime(runtime, "configure", "nuget");
+        CommandResult unchanged = InvokeWithRuntime(runtime, "configure", "nuget");
+        fileSystem.AtomicWriteAllText(
+            applicationRoot + "/azureauth-credprovider.dll",
+            "source-b"
+        );
+        CommandResult changed = InvokeWithRuntime(runtime, "configure", "nuget");
+
+        AssertNuGetConfigureCounts(initial, "yes", 1);
+        AssertNuGetConfigureCounts(unchanged, "no", 0);
+        AssertNuGetConfigureCounts(changed, "yes", 1);
+        var service = new NuGetPhase10VerticalSliceService(options);
+        Assert.Equal("source-b", fileSystem.ReadAllText(service.Paths.PluginEntrypointPath));
+    }
+
+    [Fact]
+    public void DoctorReportsRefreshableNuGetActivationWithConfigureRemediation()
+    {
+        using var pythonFixture = new PythonDoctorFixture(PythonDoctorFixtureMode.Healthy);
+        const string applicationRoot = "/installation/app";
+        var fileSystem =
+            new EmptyNuGetDryRunFileSystem.RecordingNuGetConfigurationFileSystem();
+        fileSystem.AtomicWriteAllText(
+            applicationRoot + "/azureauth-credprovider.dll",
+            "source-a"
+        );
+        fileSystem.AtomicWriteAllText(applicationRoot + "/dependency.dll", "dependency");
+        var options = new NuGetPhase10VerticalSliceOptions
+        {
+            StateDirectoryPath = "/state/nuget",
+            ApplicationPayloadRootPath = applicationRoot,
+            FileSystem = fileSystem,
+            EnvironmentVariableReader = _ => null,
+        };
+        CliRuntimeOptions runtime = CreateHealthyDoctorRuntimeOptions(pythonFixture) with
+        {
+            NuGetPhase10Options = options,
+        };
+
+        Assert.Equal(0, InvokeWithRuntime(runtime, "configure", "git").ExitCode);
+        Assert.Equal(0, InvokeWithRuntime(runtime, "configure", "nuget").ExitCode);
+        fileSystem.AtomicWriteAllText(
+            applicationRoot + "/azureauth-credprovider.dll",
+            "source-b"
+        );
+
+        CommandResult doctor = InvokeWithRuntime(runtime, "doctor");
+
+        Assert.Equal(1, doctor.ExitCode);
+        AssertDoctorCheck(doctor.StdOut, "nuget-configuration-state", "refreshable");
+        Assert.Contains(
+            "nuget-configuration-plan-remediation: run "
+                + "azureauth-credprovider configure nuget",
+            doctor.StdOut,
+            StringComparison.Ordinal
+        );
+        Assert.DoesNotContain(
+            "manually inspect and restore",
+            doctor.StdOut,
+            StringComparison.Ordinal
+        );
+    }
+
+    [Fact]
+    public void DoctorReportsUnrecognizedNuGetActivationWithManualRemediation()
+    {
+        using var pythonFixture = new PythonDoctorFixture(PythonDoctorFixtureMode.Healthy);
+        const string applicationRoot = "/installation/app";
+        var fileSystem =
+            new EmptyNuGetDryRunFileSystem.RecordingNuGetConfigurationFileSystem();
+        fileSystem.AtomicWriteAllText(
+            applicationRoot + "/azureauth-credprovider.dll",
+            "source-a"
+        );
+        var options = new NuGetPhase10VerticalSliceOptions
+        {
+            StateDirectoryPath = "/state/nuget",
+            ApplicationPayloadRootPath = applicationRoot,
+            FileSystem = fileSystem,
+            EnvironmentVariableReader = _ => null,
+        };
+        CliRuntimeOptions runtime = CreateHealthyDoctorRuntimeOptions(pythonFixture) with
+        {
+            NuGetPhase10Options = options,
+        };
+        var service = new NuGetPhase10VerticalSliceService(options);
+
+        Assert.Equal(0, InvokeWithRuntime(runtime, "configure", "git").ExitCode);
+        Assert.Equal(0, InvokeWithRuntime(runtime, "configure", "nuget").ExitCode);
+        fileSystem.AtomicWriteAllText(service.Paths.OwnershipManifestPath, "{");
+
+        CommandResult doctor = InvokeWithRuntime(runtime, "doctor");
+        CommandResult configure = InvokeWithRuntime(runtime, "configure", "nuget");
+
+        Assert.Equal(1, doctor.ExitCode);
+        AssertDoctorCheck(doctor.StdOut, "nuget-configuration-state", "unrecognized");
+        Assert.Contains(
+            "nuget-configuration-plan-remediation: manually inspect and restore "
+                + "the product-owned NuGet plugin layout",
+            doctor.StdOut,
+            StringComparison.Ordinal
+        );
+        Assert.DoesNotContain(
+            "azureauth-credprovider configure nuget",
+            doctor.StdOut,
+            StringComparison.Ordinal
+        );
+        Assert.Equal(1, configure.ExitCode);
+        Assert.Contains(
+            "configure cannot modify unrecognized Phase 10 NuGet state",
+            configure.StdErr,
+            StringComparison.Ordinal
+        );
+        Assert.Equal("{", fileSystem.ReadAllText(service.Paths.OwnershipManifestPath));
+    }
+
+    [Fact]
     public void UnconfigureNuGetDryRunValidatesPhase10StateAndWritesGenericOutput()
     {
         CliRuntimeOptions runtimeOptions = CreateNuGetPhase10DryRunRuntimeOptions();
@@ -4718,6 +4854,26 @@ public sealed class CliApplicationTests
         );
     }
 
+    private static void AssertNuGetConfigureCounts(
+        CommandResult result,
+        string mutatesState,
+        int appliedChangeCount
+    )
+    {
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal(string.Empty, result.StdErr);
+        Assert.Contains(
+            "mutates-state: " + mutatesState,
+            result.StdOut,
+            StringComparison.Ordinal
+        );
+        Assert.Contains(
+            $"applied-change-count: {appliedChangeCount}",
+            result.StdOut,
+            StringComparison.Ordinal
+        );
+    }
+
     // editorconfig-checker-enable
     private static string GetExpectedGitMutationOutput(
         string command,
@@ -4812,6 +4968,7 @@ public sealed class CliApplicationTests
                     "auth-persistent-derived-credentials: disabled",
                     "auth-product-plaintext-fallback: disabled",
                     "nuget-configuration-plan: pass",
+                    "nuget-configuration-state: valid",
                     "nuget-plugin-layout-marker: absent",
                     "nuget-ownership-manifest: absent",
                     "nuget-netcore-plugin-entrypoint: fail",

--- a/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Cli.Tests/CliApplicationTests.cs
+++ b/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Cli.Tests/CliApplicationTests.cs
@@ -5105,7 +5105,22 @@ public sealed class CliApplicationTests
 
     private static CliRuntimeOptions CreateNuGetPhase10DryRunRuntimeOptions()
     {
-        return new CliRuntimeOptions { NuGetPhase10Options = CreateIsolatedNuGetPhase10Options() };
+        const string applicationRoot = "/installation/app";
+        var fileSystem =
+            new EmptyNuGetDryRunFileSystem.RecordingNuGetConfigurationFileSystem();
+        fileSystem.AtomicWriteAllText(
+            applicationRoot + "/azureauth-credprovider.dll",
+            "fake-assembly"
+        );
+        fileSystem.AtomicWriteAllText(applicationRoot + "/dependency.dll", "dependency");
+        return new CliRuntimeOptions
+        {
+            NuGetPhase10Options = CreateIsolatedNuGetPhase10Options() with
+            {
+                ApplicationPayloadRootPath = applicationRoot,
+                FileSystem = fileSystem,
+            },
+        };
     }
 
     private static NuGetPhase10VerticalSliceOptions CreateIsolatedNuGetPhase10Options() =>

--- a/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform.Tests/ConfigurationManagerTests.cs
+++ b/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform.Tests/ConfigurationManagerTests.cs
@@ -349,7 +349,7 @@ public sealed class ConfigurationManagerTests
             )
         );
 
-        Assert.DoesNotContain(
+        Assert.Contains(
             plan.Changes.Single().Key,
             fileSystem.ReadAllText(TargetPath),
             StringComparison.Ordinal
@@ -397,7 +397,7 @@ public sealed class ConfigurationManagerTests
             )
         );
 
-        Assert.DoesNotContain(
+        Assert.Contains(
             removedPlan.Changes.Single().Key,
             fileSystem.ReadAllText(TargetPath),
             StringComparison.Ordinal
@@ -421,6 +421,62 @@ public sealed class ConfigurationManagerTests
             LoadManifest(fileSystem).Entries
         );
         Assert.Equal(retainedSelector, entry.Key);
+    }
+
+    [Fact]
+    public async Task RemoveWithRetainedEntryPersistsPreviewManifestOnlyOnce()
+    {
+        const string retainedSelector =
+            "//pkgs.dev.azure.com/org/_packaging/retained-feed/npm/registry/:_authToken";
+        var fileSystem = new InMemoryFileSystem(InMemoryPathSemantics.Posix);
+        var manager = new ConfigurationManager(fileSystem, ManifestPath);
+        ConfigurationChangePlan removedPlan = CreateNpmPlanForFeed(
+            "removed-npm-plan",
+            "removed-feed",
+            Secret
+        );
+        ConfigurationChangePlan retainedPlan = CreateNpmPlanForFeed(
+            "retained-npm-plan",
+            "retained-feed",
+            "retained-token-value"
+        );
+        await manager.ApplyAsync(removedPlan, TestContext.Current.CancellationToken);
+        await manager.ApplyAsync(retainedPlan, TestContext.Current.CancellationToken);
+        int manifestWritesBefore = fileSystem.Calls.Count(call =>
+            call.Operation == nameof(InMemoryFileSystem.AtomicWriteAllText)
+            && string.Equals(call.Path, ManifestPath, StringComparison.Ordinal)
+        );
+        fileSystem.FailMatchingCall(
+            nameof(InMemoryFileSystem.AtomicWriteAllText),
+            ManifestPath,
+            2,
+            new IOException("Injected redundant manifest write failure.")
+        );
+
+        await manager.RemoveAsync(
+            CreateRemovePlan(removedPlan),
+            TestContext.Current.CancellationToken
+        );
+
+        Assert.Equal(
+            manifestWritesBefore + 1,
+            fileSystem.Calls.Count(call =>
+                call.Operation == nameof(InMemoryFileSystem.AtomicWriteAllText)
+                && string.Equals(call.Path, ManifestPath, StringComparison.Ordinal)
+            )
+        );
+        string targetContents = fileSystem.ReadAllText(TargetPath);
+        Assert.DoesNotContain(
+            removedPlan.Changes.Single().Key,
+            targetContents,
+            StringComparison.Ordinal
+        );
+        Assert.Contains(retainedSelector, targetContents, StringComparison.Ordinal);
+        ConfigurationOwnershipManifestEntry entry = Assert.Single(
+            LoadManifest(fileSystem).Entries
+        );
+        Assert.Equal(retainedSelector, entry.Key);
+        Assert.Equal(1, entry.Sequence);
     }
 
     private static ConfigurationChangePlan CreateNpmPlan(string targetPath, string token)
@@ -750,7 +806,11 @@ public sealed class ConfigurationManagerTests
             StringComparison.Ordinal
         );
 
-        if (failurePoint == ReplacementFailurePoint.RemoveTarget)
+        if (
+            failurePoint
+            is ReplacementFailurePoint.RemoveTarget
+                or ReplacementFailurePoint.OwnershipIntent
+        )
         {
             Assert.Contains(oldSelector, target, StringComparison.Ordinal);
         }

--- a/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform.Tests/ConfigurationNuGetPluginLayoutPhysicalWriterPhase4DTests.cs
+++ b/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform.Tests/ConfigurationNuGetPluginLayoutPhysicalWriterPhase4DTests.cs
@@ -7,17 +7,22 @@ namespace Hcoona.AzureAuth.CredProvider.Platform.Tests;
 
 public sealed class ConfigurationNuGetPluginLayoutPhysicalWriterPhase4DTests
 {
-    private const string Root = "/home/user/.nuget/plugins/netcore";
+    private const string Source = "/installation/app";
+    private const string Root = "/home/user/.nuget/plugins/netcore/azureauth-credprovider";
     private const string Marker = Root + "/.azureauth-credprovider.nuget-plugin-layout";
 
     [Fact]
-    public void WriteAndRemoveMarkerPreserveUnrelatedLayout()
+    public void WriteCopiesPayloadAndRemovePreservesUnrelatedFiles()
     {
         var fileSystem = new InMemoryFileSystem(InMemoryPathSemantics.Posix);
-        fileSystem.AtomicWriteAllText(Root + "/other/plugin", "keep");
+        fileSystem.AtomicWriteAllText(Source + "/azureauth-credprovider.dll", "plugin");
+        fileSystem.AtomicWriteAllText(Source + "/nested/dependency.dll", "dependency");
         var writer = new NuGetPluginLayoutPhysicalTargetWriter(fileSystem);
-        ConfigurationChange apply = CreateChange(ConfigurationChangeOperation.Set, "owned");
+        ConfigurationChange apply = CreateChange(ConfigurationChangeOperation.Set, Source);
+
         writer.Write(CreateRequest(apply), TestContext.Current.CancellationToken);
+        fileSystem.AtomicWriteAllText(Root + "/preserve.txt", "keep");
+        fileSystem.CreateDirectory(Root + "/unrelated/empty/subtree");
 
         ConfigurationChange remove = CreateChange(ConfigurationChangeOperation.Remove, null);
         writer.Write(
@@ -26,24 +31,120 @@ public sealed class ConfigurationNuGetPluginLayoutPhysicalWriterPhase4DTests
         );
 
         Assert.False(fileSystem.FileExists(Marker));
-        Assert.Equal("keep", fileSystem.ReadAllText(Root + "/other/plugin"));
+        Assert.False(fileSystem.FileExists(Root + "/azureauth-credprovider.dll"));
+        Assert.False(fileSystem.FileExists(Root + "/nested/dependency.dll"));
+        Assert.Equal("keep", fileSystem.ReadAllText(Root + "/preserve.txt"));
+        Assert.True(fileSystem.DirectoryExists(Root + "/unrelated/empty/subtree"));
     }
 
     [Fact]
-    public void ExistingUnownedMarkerIsRejected()
+    public void ExistingUnownedDirectoryIsRejected()
     {
         var fileSystem = new InMemoryFileSystem(InMemoryPathSemantics.Posix);
-        fileSystem.AtomicWriteAllText(Marker, "foreign");
+        fileSystem.AtomicWriteAllText(Source + "/azureauth-credprovider.dll", "plugin");
+        fileSystem.AtomicWriteAllText(Root + "/foreign", "keep");
         var writer = new NuGetPluginLayoutPhysicalTargetWriter(fileSystem);
 
         Assert.Throws<InvalidOperationException>(() =>
             writer.Write(
-                CreateRequest(CreateChange(ConfigurationChangeOperation.Set, "owned")),
+                CreateRequest(CreateChange(ConfigurationChangeOperation.Set, Source)),
                 TestContext.Current.CancellationToken
             )
         );
 
-        Assert.Equal("foreign", fileSystem.ReadAllText(Marker));
+        Assert.Equal("keep", fileSystem.ReadAllText(Root + "/foreign"));
+    }
+
+    [Fact]
+    public void WindowsReservedMarkerCaseVariantIsRejectedWithoutCreatingActivation()
+    {
+        const string windowsSource = @"C:\installation\app";
+        const string windowsRoot =
+            @"C:\Users\user\.nuget\plugins\netcore\azureauth-credprovider";
+        var fileSystem = new InMemoryFileSystem(InMemoryPathSemantics.Windows);
+        fileSystem.AtomicWriteAllText(
+            windowsSource + @"\azureauth-credprovider.dll",
+            "plugin"
+        );
+        fileSystem.AtomicWriteAllText(
+            windowsSource + @"\.AZUREAUTH-CREDPROVIDER.NUGET-PLUGIN-LAYOUT",
+            "reserved"
+        );
+        var writer = new NuGetPluginLayoutPhysicalTargetWriter(fileSystem);
+
+        Assert.Throws<InvalidOperationException>(() =>
+            writer.Write(
+                CreateRequest(
+                    CreateChange(
+                        ConfigurationChangeOperation.Set,
+                        windowsSource,
+                        windowsRoot
+                    )
+                ),
+                TestContext.Current.CancellationToken
+            )
+        );
+
+        Assert.False(fileSystem.DirectoryExists(windowsRoot));
+        Assert.False(
+            fileSystem.FileExists(
+                windowsRoot + @"\.azureauth-credprovider.nuget-plugin-layout"
+            )
+        );
+    }
+
+    [Fact]
+    public void MarkerWriteFailureRestoresV1AndRetryConvergesToV2()
+    {
+        var fileSystem = new InMemoryFileSystem(InMemoryPathSemantics.Posix);
+        fileSystem.AtomicWriteAllText(Source + "/azureauth-credprovider.dll", "plugin-v1");
+        fileSystem.AtomicWriteAllText(Source + "/old/obsolete.dll", "obsolete-v1");
+        var writer = new NuGetPluginLayoutPhysicalTargetWriter(fileSystem);
+        ConfigurationChange apply = CreateChange(ConfigurationChangeOperation.Set, Source);
+        writer.Write(CreateRequest(apply), TestContext.Current.CancellationToken);
+        string v1Marker = fileSystem.ReadAllText(Marker);
+
+        fileSystem.AtomicWriteAllText(Source + "/azureauth-credprovider.dll", "plugin-v2");
+        fileSystem.DeleteFile(Source + "/old/obsolete.dll");
+        fileSystem.AtomicWriteAllText(Source + "/new/addition.dll", "addition-v2");
+        fileSystem.FailMatchingCall(
+            nameof(InMemoryFileSystem.AtomicWriteAllText),
+            Marker,
+            1,
+            new IOException("Injected marker write failure.")
+        );
+
+        Assert.Throws<IOException>(() =>
+            writer.Write(
+                CreateRequest(apply, ownership: [Owned(apply)]),
+                TestContext.Current.CancellationToken
+            )
+        );
+
+        Assert.Equal("plugin-v1", fileSystem.ReadAllText(Root + "/azureauth-credprovider.dll"));
+        Assert.Equal("obsolete-v1", fileSystem.ReadAllText(Root + "/old/obsolete.dll"));
+        Assert.False(fileSystem.FileExists(Root + "/new/addition.dll"));
+        Assert.Equal(v1Marker, fileSystem.ReadAllText(Marker));
+
+        writer.Write(
+            CreateRequest(apply, ownership: [Owned(apply)]),
+            TestContext.Current.CancellationToken
+        );
+
+        Assert.Equal("plugin-v2", fileSystem.ReadAllText(Root + "/azureauth-credprovider.dll"));
+        Assert.False(fileSystem.FileExists(Root + "/old/obsolete.dll"));
+        Assert.False(fileSystem.DirectoryExists(Root + "/old"));
+        Assert.Equal("addition-v2", fileSystem.ReadAllText(Root + "/new/addition.dll"));
+        Assert.Contains(
+            "new/addition.dll",
+            fileSystem.ReadAllText(Marker),
+            StringComparison.Ordinal
+        );
+        Assert.DoesNotContain(
+            "old/obsolete.dll",
+            fileSystem.ReadAllText(Marker),
+            StringComparison.Ordinal
+        );
     }
 
     private static ConfigurationPhysicalTargetWriterRequest CreateRequest(
@@ -54,13 +155,14 @@ public sealed class ConfigurationNuGetPluginLayoutPhysicalWriterPhase4DTests
 
     private static ConfigurationChange CreateChange(
         ConfigurationChangeOperation operation,
-        string? value
+        string? value,
+        string targetRoot = Root
     ) =>
         new()
         {
             Operation = operation,
             TargetKind = ConfigurationTargetKind.NuGetPluginLayout,
-            TargetPathOrName = Root,
+            TargetPathOrName = targetRoot,
             Key = "physical-target",
             Value = value,
             RequiresOwnershipRecord = true,

--- a/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform.Tests/ConfigurationNuGetPluginLayoutPhysicalWriterPhase4DTests.cs
+++ b/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform.Tests/ConfigurationNuGetPluginLayoutPhysicalWriterPhase4DTests.cs
@@ -38,21 +38,42 @@ public sealed class ConfigurationNuGetPluginLayoutPhysicalWriterPhase4DTests
     }
 
     [Fact]
-    public void ExistingUnownedDirectoryIsRejected()
+    public void ExistingMarkerlessDirectoryWithUnrelatedFileIsPreserved()
     {
         var fileSystem = new InMemoryFileSystem(InMemoryPathSemantics.Posix);
         fileSystem.AtomicWriteAllText(Source + "/azureauth-credprovider.dll", "plugin");
         fileSystem.AtomicWriteAllText(Root + "/foreign", "keep");
         var writer = new NuGetPluginLayoutPhysicalTargetWriter(fileSystem);
 
+        writer.Write(
+            CreateRequest(CreateChange(ConfigurationChangeOperation.Set, Source)),
+            TestContext.Current.CancellationToken
+        );
+
+        Assert.Equal("keep", fileSystem.ReadAllText(Root + "/foreign"));
+        Assert.Equal("plugin", fileSystem.ReadAllText(Root + "/azureauth-credprovider.dll"));
+        Assert.True(fileSystem.FileExists(Marker));
+    }
+
+    [Fact]
+    public void MarkerlessDirectoryWithOwnershipClaimIsRejectedDuringValidation()
+    {
+        var fileSystem = new InMemoryFileSystem(InMemoryPathSemantics.Posix);
+        fileSystem.AtomicWriteAllText(Source + "/azureauth-credprovider.dll", "plugin");
+        fileSystem.AtomicWriteAllText(Root + "/foreign", "keep");
+        var writer = new NuGetPluginLayoutPhysicalTargetWriter(fileSystem);
+        ConfigurationChange apply = CreateChange(ConfigurationChangeOperation.Set, Source);
+
         Assert.Throws<InvalidOperationException>(() =>
-            writer.Write(
-                CreateRequest(CreateChange(ConfigurationChangeOperation.Set, Source)),
+            writer.Validate(
+                CreateRequest(apply, ownership: [Owned(apply)]),
                 TestContext.Current.CancellationToken
             )
         );
 
         Assert.Equal("keep", fileSystem.ReadAllText(Root + "/foreign"));
+        Assert.False(fileSystem.FileExists(Root + "/azureauth-credprovider.dll"));
+        Assert.False(fileSystem.FileExists(Marker));
     }
 
     [Fact]

--- a/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform.Tests/ConfigurationPhase14VerticalSliceServiceTests.cs
+++ b/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform.Tests/ConfigurationPhase14VerticalSliceServiceTests.cs
@@ -531,17 +531,39 @@ public sealed class ConfigurationPhase14VerticalSliceServiceTests
             ConfigurationOwnershipManifestSerializer.Deserialize(
                 fileSystem.ReadAllText(manifestPath)
             );
-        Assert.Equal(ecosystem == CredentialEcosystem.Npm ? 2 : 4, transitional.Entries.Count);
+        bool cancellationBeforePhysicalRemoval =
+            failurePoint == PackageReplacementFailurePoint.CancellationAfterIntent;
+        Assert.Equal(
+            ecosystem == CredentialEcosystem.Npm
+                ? cancellationBeforePhysicalRemoval ? 1 : 2
+                : cancellationBeforePhysicalRemoval ? 2 : 4,
+            transitional.Entries.Count
+        );
         Assert.Contains(
             transitional.Entries,
             entry => entry.Key.Contains("test-feed", StringComparison.Ordinal)
         );
-        Assert.Contains(
-            transitional.Entries,
-            entry => entry.Key.Contains("replacement-feed", StringComparison.Ordinal)
-        );
+        if (cancellationBeforePhysicalRemoval)
+        {
+            Assert.DoesNotContain(
+                transitional.Entries,
+                entry => entry.Key.Contains("replacement-feed", StringComparison.Ordinal)
+            );
+        }
+        else
+        {
+            Assert.Contains(
+                transitional.Entries,
+                entry => entry.Key.Contains("replacement-feed", StringComparison.Ordinal)
+            );
+        }
         Assert.Equal(
-            replacementRegistry,
+            cancellationBeforePhysicalRemoval
+                ? original.ResolvePersistedRegistryUrl(
+                    ecosystem,
+                    ConfigurationPhase14Scope.User
+                )
+                : replacementRegistry,
             replacement.ResolvePersistedRegistryUrl(
                 ecosystem,
                 ConfigurationPhase14Scope.User

--- a/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform.Tests/DeploymentValidationNuGetLifecycleHarness.cs
+++ b/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform.Tests/DeploymentValidationNuGetLifecycleHarness.cs
@@ -1,0 +1,78 @@
+using Hcoona.AzureAuth.CredProvider.Platform.VerticalSlice;
+
+namespace Hcoona.AzureAuth.CredProvider.Platform.Tests;
+
+internal static class DeploymentValidationNuGetLifecycleHarness
+{
+    internal const string Command = "deployment-validation-nuget-lifecycle";
+
+    internal static void Run(string[] args)
+    {
+        if (
+            args.Length != 4
+            || !TryResolveExplicitPath(args[1], out string stateDirectoryPath)
+            || !TryResolveExplicitPath(args[2], out string applicationPayloadRootPath)
+            || !TryResolveExplicitPath(args[3], out string userHomeDirectoryPath)
+        )
+        {
+            Environment.Exit(64);
+            return;
+        }
+
+        try
+        {
+            var service = new NuGetPhase10VerticalSliceService(
+                new NuGetPhase10VerticalSliceOptions
+                {
+                    StateDirectoryPath = stateDirectoryPath,
+                    ApplicationPayloadRootPath = applicationPayloadRootPath,
+                    UserHomeDirectoryPath = userHomeDirectoryPath,
+                    EnvironmentVariableReader = static _ => null,
+                }
+            );
+
+            if (string.Equals(args[0], "configure", StringComparison.Ordinal))
+            {
+                service.ConfigureAsync().AsTask().GetAwaiter().GetResult();
+            }
+            else if (string.Equals(args[0], "unconfigure", StringComparison.Ordinal))
+            {
+                service.UnconfigureAsync().AsTask().GetAwaiter().GetResult();
+            }
+            else
+            {
+                Environment.Exit(64);
+                return;
+            }
+
+            Console.WriteLine(args[0]);
+            Environment.Exit(0);
+        }
+        catch (Exception exception)
+        {
+            Console.Error.WriteLine($"NuGet lifecycle harness failed: {exception.Message}");
+            Console.Error.Flush();
+            Environment.Exit(1);
+        }
+    }
+
+    private static bool TryResolveExplicitPath(string value, out string path)
+    {
+        path = string.Empty;
+        if (string.IsNullOrWhiteSpace(value) || !Path.IsPathFullyQualified(value))
+        {
+            return false;
+        }
+
+        try
+        {
+            path = Path.GetFullPath(value);
+            return true;
+        }
+        catch (Exception exception)
+            when (exception is ArgumentException or NotSupportedException or PathTooLongException)
+        {
+            return false;
+        }
+    }
+}

--- a/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform.Tests/GitPhase8DoctorTests.cs
+++ b/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform.Tests/GitPhase8DoctorTests.cs
@@ -2468,12 +2468,11 @@ public sealed class GitPhase8DoctorTests
             );
             Assert.Equal(1, fileSystem.MatchingDeleteAttempts);
             Assert.Equal(1, fileSystem.InjectedFailureCount);
-            AssertOwnedGitActivationAbsent(service);
-            await AssertGitSelectorAbsentAsync(
+            await AssertGitSelectorPresentAsync(
                 service.Paths.GitConfigPath,
                 GitPhase8VerticalSliceService.GitCredentialHelperKey
             );
-            await AssertGitSelectorAbsentAsync(
+            await AssertGitSelectorPresentAsync(
                 service.Paths.GitConfigPath,
                 GitPhase8VerticalSliceService.GitUseHttpPathKey
             );
@@ -2579,6 +2578,24 @@ public sealed class GitPhase8DoctorTests
 
         Assert.Equal(1, result.ExitCode);
         Assert.Empty(result.StandardOutput);
+    }
+
+    private static async Task AssertGitSelectorPresentAsync(
+        string gitConfigPath,
+        string selector
+    )
+    {
+        ProcessResult result = await new SystemProcessRunner()
+            .RunAsync(
+                new ProcessStartSpec(
+                    "git",
+                    ["config", "--file", gitConfigPath, "--get-all", selector]
+                ),
+                TestContext.Current.CancellationToken
+            );
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.NotEmpty(result.StandardOutput);
     }
 
     private sealed class OneShotManifestDeleteFailureFileSystem

--- a/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform.Tests/NuGetPhase10VerticalSliceServiceTests.cs
+++ b/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform.Tests/NuGetPhase10VerticalSliceServiceTests.cs
@@ -11,7 +11,7 @@ namespace Hcoona.AzureAuth.CredProvider.Platform.Tests;
 public sealed class NuGetPhase10VerticalSliceServiceTests
 {
     [Fact]
-    public async Task DryRunConfigurePlansCanonicalNuGetPluginLayoutMarker()
+    public async Task DryRunConfigurePlansCanonicalNuGetPluginActivation()
     {
         var fileSystem = new InMemoryFileSystem(InMemoryPathSemantics.Host);
         NuGetPhase10VerticalSliceService service = CreateService(fileSystem);
@@ -33,11 +33,10 @@ public sealed class NuGetPhase10VerticalSliceServiceTests
     }
 
     [Fact]
-    public async Task ConfigureWritesMarkerAndManifestAndDoctorPassesWhenEntrypointExists()
+    public async Task ConfigureCopiesPayloadAndWritesOwnershipAndDoctorPasses()
     {
         var fileSystem = new InMemoryFileSystem(InMemoryPathSemantics.Host);
         NuGetPhase10VerticalSliceService service = CreateService(fileSystem);
-        fileSystem.AtomicWriteAllText(service.Paths.PluginEntrypointPath, "fake-assembly");
 
         NuGetPhase10ConfigureResult configureResult = await service.ConfigureAsync(
             TestContext.Current.CancellationToken
@@ -50,8 +49,13 @@ public sealed class NuGetPhase10VerticalSliceServiceTests
         Assert.True(configureResult.PluginLayoutMarkerPresent);
         Assert.True(configureResult.OwnershipManifestPresent);
         Assert.Equal(
-            NuGetPhase10VerticalSliceService.MarkerValue,
-            fileSystem.ReadAllText(service.Paths.PluginLayoutMarkerPath)
+            "fake-assembly",
+            fileSystem.ReadAllText(service.Paths.PluginEntrypointPath)
+        );
+        Assert.Contains(
+            "azureauth-credprovider-nuget-plugin-activation-v1",
+            fileSystem.ReadAllText(service.Paths.PluginLayoutMarkerPath),
+            StringComparison.Ordinal
         );
         Assert.True(fileSystem.FileExists(service.Paths.OwnershipManifestPath));
         Assert.True(doctorResult.ConfigurationPlanValid);
@@ -65,12 +69,15 @@ public sealed class NuGetPhase10VerticalSliceServiceTests
     }
 
     [Fact]
-    public async Task UnconfigureRemovesManifestAndLayoutMarker()
+    public async Task UnconfigureRemovesOnlyOwnedActivation()
     {
         var fileSystem = new InMemoryFileSystem(InMemoryPathSemantics.Host);
         NuGetPhase10VerticalSliceService service = CreateService(fileSystem);
-        fileSystem.AtomicWriteAllText(service.Paths.PluginEntrypointPath, "fake-assembly");
         await service.ConfigureAsync(TestContext.Current.CancellationToken);
+        fileSystem.AtomicWriteAllText(
+            service.Paths.PluginTargetRootPath + "/preserve.txt",
+            "unrelated"
+        );
 
         NuGetPhase10UnconfigureResult result = await service.UnconfigureAsync(
             TestContext.Current.CancellationToken
@@ -82,6 +89,177 @@ public sealed class NuGetPhase10VerticalSliceServiceTests
         Assert.False(result.OwnershipManifestPresent);
         Assert.False(fileSystem.FileExists(service.Paths.PluginLayoutMarkerPath));
         Assert.False(fileSystem.FileExists(service.Paths.OwnershipManifestPath));
+        Assert.False(fileSystem.FileExists(service.Paths.PluginEntrypointPath));
+        Assert.Equal(
+            "unrelated",
+            fileSystem.ReadAllText(service.Paths.PluginTargetRootPath + "/preserve.txt")
+        );
+
+        NuGetPhase10UnconfigureResult repeated = await service.UnconfigureAsync(
+            TestContext.Current.CancellationToken
+        );
+
+        Assert.False(repeated.HadOwnedConfiguration);
+        Assert.Null(repeated.PlanResult);
+        Assert.False(repeated.PluginLayoutMarkerPresent);
+        Assert.False(repeated.OwnershipManifestPresent);
+        Assert.Equal(
+            "unrelated",
+            fileSystem.ReadAllText(service.Paths.PluginTargetRootPath + "/preserve.txt")
+        );
+    }
+
+    [Fact]
+    public async Task UnconfigureRejectsDamagedOwnedActivation()
+    {
+        var fileSystem = new InMemoryFileSystem(InMemoryPathSemantics.Host);
+        NuGetPhase10VerticalSliceService service = CreateService(fileSystem);
+        await service.ConfigureAsync(TestContext.Current.CancellationToken);
+        fileSystem.AtomicWriteAllText(service.Paths.PluginEntrypointPath, "damaged");
+
+        await Assert.ThrowsAsync<NuGetPhase10UnrecognizedStateException>(async () =>
+            await service.UnconfigureAsync(TestContext.Current.CancellationToken)
+        );
+
+        Assert.Equal("damaged", fileSystem.ReadAllText(service.Paths.PluginEntrypointPath));
+        Assert.True(fileSystem.FileExists(service.Paths.PluginLayoutMarkerPath));
+        Assert.True(fileSystem.FileExists(service.Paths.OwnershipManifestPath));
+    }
+
+    [Fact]
+    public async Task UnconfigureRejectsCanonicalPayloadWithoutOwnershipManifest()
+    {
+        var fileSystem = new InMemoryFileSystem(InMemoryPathSemantics.Posix);
+        NuGetPhase10VerticalSliceService service = CreateService(fileSystem);
+        fileSystem.AtomicWriteAllText(service.Paths.PluginEntrypointPath, "orphaned-payload");
+
+        await Assert.ThrowsAsync<NuGetPhase10UnrecognizedStateException>(async () =>
+            await service.UnconfigureAsync(TestContext.Current.CancellationToken)
+        );
+
+        Assert.Equal(
+            "orphaned-payload",
+            fileSystem.ReadAllText(service.Paths.PluginEntrypointPath)
+        );
+    }
+
+    [Fact]
+    public async Task ReconfigureRefreshesActivationAndUnconfigurePreservesUnrelatedState()
+    {
+        var fileSystem = new InMemoryFileSystem(InMemoryPathSemantics.Posix);
+        NuGetPhase10VerticalSliceService service = CreateService(fileSystem);
+        string applicationRoot = service.Paths.ApplicationPayloadRootPath;
+        string targetRoot = service.Paths.PluginTargetRootPath;
+        fileSystem.AtomicWriteAllText(
+            applicationRoot + "/azureauth-credprovider.dll",
+            "entrypoint-v1"
+        );
+        fileSystem.AtomicWriteAllText(applicationRoot + "/old/obsolete.dll", "old-only");
+
+        await service.ConfigureAsync(TestContext.Current.CancellationToken);
+        fileSystem.AtomicWriteAllText(targetRoot + "/preserve.txt", "unrelated");
+        fileSystem.CreateDirectory(targetRoot + "/unrelated/empty/subtree");
+
+        fileSystem.AtomicWriteAllText(
+            applicationRoot + "/azureauth-credprovider.dll",
+            "entrypoint-v2"
+        );
+        fileSystem.DeleteFile(applicationRoot + "/old/obsolete.dll");
+        fileSystem.AtomicWriteAllText(applicationRoot + "/new/addition.dll", "new-only");
+
+        await service.ConfigureAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(
+            "entrypoint-v2",
+            fileSystem.ReadAllText(service.Paths.PluginEntrypointPath)
+        );
+        Assert.False(fileSystem.FileExists(targetRoot + "/old/obsolete.dll"));
+        Assert.False(fileSystem.DirectoryExists(targetRoot + "/old"));
+        Assert.Equal("new-only", fileSystem.ReadAllText(targetRoot + "/new/addition.dll"));
+        Assert.Equal("unrelated", fileSystem.ReadAllText(targetRoot + "/preserve.txt"));
+        Assert.True(fileSystem.DirectoryExists(targetRoot + "/unrelated/empty/subtree"));
+        string refreshedInventory = fileSystem.ReadAllText(service.Paths.PluginLayoutMarkerPath);
+        Assert.Contains("new/addition.dll", refreshedInventory, StringComparison.Ordinal);
+        Assert.DoesNotContain("old/obsolete.dll", refreshedInventory, StringComparison.Ordinal);
+
+        await service.UnconfigureAsync(TestContext.Current.CancellationToken);
+
+        Assert.False(fileSystem.FileExists(service.Paths.PluginEntrypointPath));
+        Assert.False(fileSystem.FileExists(targetRoot + "/dependency.dll"));
+        Assert.False(fileSystem.FileExists(targetRoot + "/new/addition.dll"));
+        Assert.False(fileSystem.FileExists(service.Paths.PluginLayoutMarkerPath));
+        Assert.False(fileSystem.FileExists(service.Paths.OwnershipManifestPath));
+        Assert.Equal("unrelated", fileSystem.ReadAllText(targetRoot + "/preserve.txt"));
+        Assert.True(fileSystem.DirectoryExists(targetRoot + "/unrelated/empty/subtree"));
+    }
+
+    [Fact]
+    public async Task RefreshRejectsNewFileUnderPreExistingUnownedDirectory()
+    {
+        var fileSystem = new InMemoryFileSystem(InMemoryPathSemantics.Posix);
+        NuGetPhase10VerticalSliceService service = CreateService(fileSystem);
+        await service.ConfigureAsync(TestContext.Current.CancellationToken);
+        string targetRoot = service.Paths.PluginTargetRootPath;
+        string sharedDirectory = targetRoot + "/shared";
+        string originalMarker = fileSystem.ReadAllText(service.Paths.PluginLayoutMarkerPath);
+        fileSystem.CreateDirectory(sharedDirectory);
+        fileSystem.AtomicWriteAllText(
+            service.Paths.ApplicationPayloadRootPath + "/shared/transient.dll",
+            "transient"
+        );
+
+        await Assert.ThrowsAsync<NuGetPhase10UnrecognizedStateException>(async () =>
+            await service.ConfigureAsync(TestContext.Current.CancellationToken)
+        );
+
+        Assert.True(fileSystem.DirectoryExists(sharedDirectory));
+        Assert.False(fileSystem.FileExists(sharedDirectory + "/transient.dll"));
+        Assert.Equal(
+            "fake-assembly",
+            fileSystem.ReadAllText(service.Paths.PluginEntrypointPath)
+        );
+        Assert.Equal(originalMarker, fileSystem.ReadAllText(service.Paths.PluginLayoutMarkerPath));
+
+        await service.UnconfigureAsync(TestContext.Current.CancellationToken);
+
+        Assert.True(fileSystem.DirectoryExists(sharedDirectory));
+        Assert.Empty(fileSystem.EnumerateFiles(sharedDirectory));
+        Assert.Empty(fileSystem.EnumerateDirectories(sharedDirectory));
+    }
+
+    [Fact]
+    public async Task UnconfigureOwnershipDeletionFailureLeavesRetryableActivation()
+    {
+        var fileSystem = new InMemoryFileSystem(InMemoryPathSemantics.Posix);
+        NuGetPhase10VerticalSliceService service = CreateService(fileSystem);
+        await service.ConfigureAsync(TestContext.Current.CancellationToken);
+        string unrelatedPath = service.Paths.PluginTargetRootPath + "/preserve.txt";
+        fileSystem.AtomicWriteAllText(unrelatedPath, "unrelated");
+        fileSystem.FailMatchingCall(
+            nameof(InMemoryFileSystem.DeleteFile),
+            service.Paths.OwnershipManifestPath,
+            1,
+            new IOException("Injected ownership manifest deletion failure.")
+        );
+
+        await Assert.ThrowsAsync<NuGetPhase10UnrecognizedStateException>(async () =>
+            await service.UnconfigureAsync(TestContext.Current.CancellationToken)
+        );
+
+        Assert.Equal("fake-assembly", fileSystem.ReadAllText(service.Paths.PluginEntrypointPath));
+        Assert.True(fileSystem.FileExists(service.Paths.PluginLayoutMarkerPath));
+        Assert.True(fileSystem.FileExists(service.Paths.OwnershipManifestPath));
+        Assert.Equal("unrelated", fileSystem.ReadAllText(unrelatedPath));
+
+        NuGetPhase10UnconfigureResult retry = await service.UnconfigureAsync(
+            TestContext.Current.CancellationToken
+        );
+
+        Assert.True(retry.HadOwnedConfiguration);
+        Assert.False(fileSystem.FileExists(service.Paths.PluginEntrypointPath));
+        Assert.False(fileSystem.FileExists(service.Paths.PluginLayoutMarkerPath));
+        Assert.False(fileSystem.FileExists(service.Paths.OwnershipManifestPath));
+        Assert.Equal("unrelated", fileSystem.ReadAllText(unrelatedPath));
     }
 
     [Fact]
@@ -95,7 +273,6 @@ public sealed class NuGetPhase10VerticalSliceServiceTests
                     ? "/tmp/plugin.dll"
                     : null
         );
-        fileSystem.AtomicWriteAllText(service.Paths.PluginEntrypointPath, "fake-assembly");
         await service.ConfigureAsync(TestContext.Current.CancellationToken);
 
         NuGetPhase10DoctorResult result = await service.DoctorAsync(
@@ -113,6 +290,7 @@ public sealed class NuGetPhase10VerticalSliceServiceTests
         var fileSystem = new InMemoryFileSystem(InMemoryPathSemantics.Host);
         NuGetPhase10VerticalSliceService service = CreateService(fileSystem);
         await service.ConfigureAsync(TestContext.Current.CancellationToken);
+        fileSystem.DeleteFile(service.Paths.PluginEntrypointPath);
 
         NuGetPhase10DoctorResult result = await service.DoctorAsync(
             TestContext.Current.CancellationToken
@@ -120,6 +298,7 @@ public sealed class NuGetPhase10VerticalSliceServiceTests
 
         Assert.True(result.PluginLayoutMarkerPresent);
         Assert.True(result.OwnershipManifestPresent);
+        Assert.False(result.ConfigurationPlanValid);
         Assert.False(result.NetCorePluginEntrypointPresent);
         Assert.False(result.PluginModeEntrypointResolvable);
     }
@@ -131,7 +310,7 @@ public sealed class NuGetPhase10VerticalSliceServiceTests
         NuGetPhase10VerticalSliceService service = CreateService(fileSystem);
         fileSystem.AtomicWriteAllText(
             service.Paths.PluginLayoutMarkerPath,
-            NuGetPhase10VerticalSliceService.MarkerValue
+            """{"schemaVersion":"azureauth-credprovider-nuget-plugin-activation-v1"}"""
         );
 
         await Assert.ThrowsAsync<NuGetPhase10UnrecognizedStateException>(async () =>
@@ -154,32 +333,46 @@ public sealed class NuGetPhase10VerticalSliceServiceTests
     private static NuGetPhase10VerticalSliceService CreateService(
         InMemoryFileSystem fileSystem,
         Func<string, string?>? environmentVariableReader = null
-    ) =>
-        new(
+    )
+    {
+        const string applicationRoot = "/installation/app";
+        fileSystem.AtomicWriteAllText(
+            applicationRoot + "/azureauth-credprovider.dll",
+            "fake-assembly"
+        );
+        fileSystem.AtomicWriteAllText(applicationRoot + "/dependency.dll", "dependency");
+        return new(
             new NuGetPhase10VerticalSliceOptions
             {
                 StateDirectoryPath = "/state/azureauth-credprovider/phase10",
+                ApplicationPayloadRootPath = applicationRoot,
                 FileSystem = fileSystem,
                 EnvironmentVariableReader = environmentVariableReader ?? (_ => null),
             }
         );
+    }
 
     [Fact]
     public async Task DoctorValidatesParserWithoutCredentialAcquisition()
     {
         var fileSystem = new InMemoryFileSystem(InMemoryPathSemantics.Host);
         var acquisition = new ThrowingNuGetDoctorCredentialAcquisitionService();
+        const string applicationRoot = "/installation/app";
+        fileSystem.AtomicWriteAllText(
+            applicationRoot + "/azureauth-credprovider.dll",
+            "fake-assembly"
+        );
         var service = new NuGetPhase10VerticalSliceService(
             new NuGetPhase10VerticalSliceOptions
             {
                 StateDirectoryPath = "/state/azureauth-credprovider/phase10",
+                ApplicationPayloadRootPath = applicationRoot,
                 FileSystem = fileSystem,
                 EnvironmentVariableReader = _ => null,
                 CredentialAcquisition =
                     new BoundedCredentialAcquisitionAdapter(acquisition),
             }
         );
-        fileSystem.AtomicWriteAllText(service.Paths.PluginEntrypointPath, "fake-assembly");
         await service.ConfigureAsync(TestContext.Current.CancellationToken);
 
         NuGetPhase10DoctorResult result = await service.DoctorAsync(

--- a/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform.Tests/NuGetPhase10VerticalSliceServiceTests.cs
+++ b/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform.Tests/NuGetPhase10VerticalSliceServiceTests.cs
@@ -88,12 +88,7 @@ public sealed class NuGetPhase10VerticalSliceServiceTests
     {
         var fileSystem = new InMemoryFileSystem(InMemoryPathSemantics.Posix);
         NuGetPhase10VerticalSliceService service = CreateService(fileSystem);
-        string sourceRoot = service.Paths.ApplicationPayloadRootPath;
-        string targetRoot = service.Paths.PluginTargetRootPath;
-        fileSystem.AtomicWriteAllText(sourceRoot + "/shared/legacy.dll", "legacy-only");
         string ownershipBefore = await SeedExactF1LegacyActivationAsync(fileSystem, service);
-        fileSystem.DeleteFile(sourceRoot + "/shared/legacy.dll");
-        fileSystem.AtomicWriteAllText(sourceRoot + "/shared/current.dll", "current-only");
 
         NuGetPhase10ConfigureResult result = await service.ConfigureAsync(
             TestContext.Current.CancellationToken
@@ -116,16 +111,6 @@ public sealed class NuGetPhase10VerticalSliceServiceTests
             StringComparison.Ordinal
         );
         Assert.Contains("\"dependency.dll\"", marker, StringComparison.Ordinal);
-        Assert.Contains("\"shared/current.dll\"", marker, StringComparison.Ordinal);
-        Assert.DoesNotContain("\"shared/legacy.dll\"", marker, StringComparison.Ordinal);
-        Assert.Equal(
-            "legacy-only",
-            fileSystem.ReadAllText(targetRoot + "/shared/legacy.dll")
-        );
-        Assert.Equal(
-            "current-only",
-            fileSystem.ReadAllText(targetRoot + "/shared/current.dll")
-        );
         Assert.Equal(
             ownershipBefore,
             fileSystem.ReadAllText(service.Paths.OwnershipManifestPath)
@@ -133,7 +118,7 @@ public sealed class NuGetPhase10VerticalSliceServiceTests
     }
 
     [Fact]
-    public async Task UnconfigureRemovesOnlyExactF1LegacyEntrypointAndMarker()
+    public async Task UnconfigureRemovesOnlyExactF1LegacyMetadata()
     {
         var fileSystem = new InMemoryFileSystem(InMemoryPathSemantics.Posix);
         NuGetPhase10VerticalSliceService service = CreateService(fileSystem);
@@ -146,7 +131,10 @@ public sealed class NuGetPhase10VerticalSliceServiceTests
         );
 
         Assert.True(result.HadOwnedConfiguration);
-        Assert.False(fileSystem.FileExists(service.Paths.PluginEntrypointPath));
+        Assert.Equal(
+            "fake-assembly",
+            fileSystem.ReadAllText(service.Paths.PluginEntrypointPath)
+        );
         Assert.False(fileSystem.FileExists(service.Paths.PluginLayoutMarkerPath));
         Assert.False(fileSystem.FileExists(service.Paths.OwnershipManifestPath));
         Assert.Equal(
@@ -154,6 +142,65 @@ public sealed class NuGetPhase10VerticalSliceServiceTests
             fileSystem.ReadAllText(service.Paths.PluginTargetRootPath + "/dependency.dll")
         );
         Assert.Equal("unrelated", fileSystem.ReadAllText(unrelatedPath));
+    }
+
+    [Fact]
+    public async Task ModifiedF1LegacyEntrypointIsPreservedAndCannotBeConfigured()
+    {
+        var fileSystem = new InMemoryFileSystem(InMemoryPathSemantics.Posix);
+        NuGetPhase10VerticalSliceService service = CreateService(fileSystem);
+        await SeedExactF1LegacyActivationAsync(fileSystem, service);
+        fileSystem.AtomicWriteAllText(service.Paths.PluginEntrypointPath, "modified");
+        string markerBefore = fileSystem.ReadAllText(service.Paths.PluginLayoutMarkerPath);
+        string ownershipBefore = fileSystem.ReadAllText(service.Paths.OwnershipManifestPath);
+        fileSystem.Calls.Clear();
+
+        await Assert.ThrowsAsync<NuGetPhase10UnrecognizedStateException>(async () =>
+            await service.ConfigureAsync(TestContext.Current.CancellationToken)
+        );
+
+        Assert.DoesNotContain(fileSystem.Calls, call => IsMutation(call.Operation));
+        Assert.Equal("modified", fileSystem.ReadAllText(service.Paths.PluginEntrypointPath));
+        Assert.Equal(markerBefore, fileSystem.ReadAllText(service.Paths.PluginLayoutMarkerPath));
+        Assert.Equal(
+            ownershipBefore,
+            fileSystem.ReadAllText(service.Paths.OwnershipManifestPath)
+        );
+
+        await service.UnconfigureAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal("modified", fileSystem.ReadAllText(service.Paths.PluginEntrypointPath));
+        Assert.False(fileSystem.FileExists(service.Paths.PluginLayoutMarkerPath));
+        Assert.False(fileSystem.FileExists(service.Paths.OwnershipManifestPath));
+    }
+
+    [Fact]
+    public async Task LegacyConfigureRejectsPreExistingEmptyAncestorWithoutMutation()
+    {
+        var fileSystem = new InMemoryFileSystem(InMemoryPathSemantics.Posix);
+        NuGetPhase10VerticalSliceService service = CreateService(fileSystem);
+        await SeedExactF1LegacyActivationAsync(fileSystem, service);
+        string sourcePath = service.Paths.ApplicationPayloadRootPath + "/shared/new.dll";
+        string targetDirectory = service.Paths.PluginTargetRootPath + "/shared";
+        fileSystem.AtomicWriteAllText(sourcePath, "new");
+        fileSystem.CreateDirectory(targetDirectory);
+        string markerBefore = fileSystem.ReadAllText(service.Paths.PluginLayoutMarkerPath);
+        string ownershipBefore = fileSystem.ReadAllText(service.Paths.OwnershipManifestPath);
+        fileSystem.Calls.Clear();
+
+        await Assert.ThrowsAsync<NuGetPhase10UnrecognizedStateException>(async () =>
+            await service.ConfigureAsync(TestContext.Current.CancellationToken)
+        );
+
+        Assert.DoesNotContain(fileSystem.Calls, call => IsMutation(call.Operation));
+        Assert.True(fileSystem.DirectoryExists(targetDirectory));
+        Assert.Empty(fileSystem.EnumerateFiles(targetDirectory));
+        Assert.Empty(fileSystem.EnumerateDirectories(targetDirectory));
+        Assert.Equal(markerBefore, fileSystem.ReadAllText(service.Paths.PluginLayoutMarkerPath));
+        Assert.Equal(
+            ownershipBefore,
+            fileSystem.ReadAllText(service.Paths.OwnershipManifestPath)
+        );
     }
 
     [Theory]
@@ -994,6 +1041,7 @@ public sealed class NuGetPhase10VerticalSliceServiceTests
     [InlineData("target-root-file")]
     [InlineData("orphan-entrypoint-file")]
     [InlineData("entrypoint-directory")]
+    [InlineData("source-payload-file")]
     [InlineData("ownership-manifest-directory")]
     [InlineData("marker-directory")]
     public async Task DoctorAndConfigureRejectOwnershiplessCollision(string scenario)
@@ -1011,6 +1059,31 @@ public sealed class NuGetPhase10VerticalSliceServiceTests
         await Assert.ThrowsAsync<NuGetPhase10UnrecognizedStateException>(async () =>
             await service.ConfigureAsync(TestContext.Current.CancellationToken)
         );
+    }
+
+    [Fact]
+    public async Task DoctorValidatesNeutralActivationWithoutFilesystemMutation()
+    {
+        var fileSystem = new InMemoryFileSystem(InMemoryPathSemantics.Posix);
+        NuGetPhase10VerticalSliceService service = CreateService(fileSystem);
+        string unrelatedPath = service.Paths.PluginTargetRootPath + "/unrelated.txt";
+        fileSystem.AtomicWriteAllText(unrelatedPath, "unrelated");
+        fileSystem.Calls.Clear();
+
+        NuGetPhase10DoctorResult doctor = await service.DoctorAsync(
+            TestContext.Current.CancellationToken
+        );
+
+        Assert.Equal(NuGetConfigurationState.Valid, doctor.ConfigurationState);
+        Assert.True(doctor.ConfigurationPlanValid);
+        Assert.Contains(
+            fileSystem.Calls,
+            call =>
+                call.Operation == nameof(InMemoryFileSystem.EnumerateFiles)
+                && call.Path == service.Paths.ApplicationPayloadRootPath
+        );
+        Assert.DoesNotContain(fileSystem.Calls, call => IsMutation(call.Operation));
+        Assert.Equal("unrelated", fileSystem.ReadAllText(unrelatedPath));
     }
 
     [Fact]
@@ -1042,6 +1115,48 @@ public sealed class NuGetPhase10VerticalSliceServiceTests
         Assert.False(fileSystem.DirectoryExists(service.Paths.PluginLayoutMarkerPath));
         Assert.True(fileSystem.FileExists(service.Paths.OwnershipManifestPath));
         Assert.False(fileSystem.DirectoryExists(service.Paths.OwnershipManifestPath));
+    }
+
+    [Theory]
+    [InlineData("payload")]
+    [InlineData("marker")]
+    public async Task ConfigureFailureInNeutralDirectoryRollsBackOwnershipAndRetrySucceeds(
+        string failurePoint
+    )
+    {
+        var fileSystem = new InMemoryFileSystem(InMemoryPathSemantics.Posix);
+        NuGetPhase10VerticalSliceService service = CreateService(fileSystem);
+        string unrelatedPath = service.Paths.PluginTargetRootPath + "/unrelated.txt";
+        fileSystem.AtomicWriteAllText(unrelatedPath, "unrelated");
+        fileSystem.FailMatchingCall(
+            failurePoint == "payload"
+                ? nameof(InMemoryFileSystem.AtomicWriteAllBytes)
+                : nameof(InMemoryFileSystem.AtomicWriteAllText),
+            failurePoint == "payload"
+                ? service.Paths.PluginEntrypointPath
+                : service.Paths.PluginLayoutMarkerPath,
+            1,
+            new IOException($"Injected {failurePoint} write failure.")
+        );
+
+        await Assert.ThrowsAsync<NuGetPhase10UnrecognizedStateException>(async () =>
+            await service.ConfigureAsync(TestContext.Current.CancellationToken)
+        );
+
+        Assert.False(fileSystem.FileExists(service.Paths.OwnershipManifestPath));
+        Assert.False(fileSystem.FileExists(service.Paths.PluginEntrypointPath));
+        Assert.False(fileSystem.FileExists(service.Paths.PluginLayoutMarkerPath));
+        Assert.Equal("unrelated", fileSystem.ReadAllText(unrelatedPath));
+
+        NuGetPhase10ConfigureResult retry = await service.ConfigureAsync(
+            TestContext.Current.CancellationToken
+        );
+
+        Assert.Single(retry.PlanResult.Changes);
+        Assert.True(fileSystem.FileExists(service.Paths.OwnershipManifestPath));
+        Assert.True(fileSystem.FileExists(service.Paths.PluginEntrypointPath));
+        Assert.True(fileSystem.FileExists(service.Paths.PluginLayoutMarkerPath));
+        Assert.Equal("unrelated", fileSystem.ReadAllText(unrelatedPath));
     }
 
     [Fact]
@@ -1082,6 +1197,12 @@ public sealed class NuGetPhase10VerticalSliceServiceTests
                 break;
             case "entrypoint-directory":
                 fileSystem.CreateDirectory(service.Paths.PluginEntrypointPath);
+                break;
+            case "source-payload-file":
+                fileSystem.AtomicWriteAllText(
+                    service.Paths.PluginTargetRootPath + "/dependency.dll",
+                    "foreign"
+                );
                 break;
             case "ownership-manifest-directory":
                 fileSystem.CreateDirectory(service.Paths.OwnershipManifestPath);

--- a/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform.Tests/NuGetPhase10VerticalSliceServiceTests.cs
+++ b/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform.Tests/NuGetPhase10VerticalSliceServiceTests.cs
@@ -10,16 +10,24 @@ namespace Hcoona.AzureAuth.CredProvider.Platform.Tests;
 [Collection("ConfigurationManagerExecution")]
 public sealed class NuGetPhase10VerticalSliceServiceTests
 {
+    private const string F1LegacyMarker =
+        "azureauth-credprovider nuget-plugin-layout\n"
+        + "phase=10\n"
+        + "runtime=netcore\n"
+        + "entrypoint=azureauth-credprovider.dll\n";
+
     [Fact]
-    public async Task DryRunConfigurePlansCanonicalNuGetPluginActivation()
+    public async Task ValidConfigureDryRunPlansActivationWithoutFilesystemMutation()
     {
-        var fileSystem = new InMemoryFileSystem(InMemoryPathSemantics.Host);
+        var fileSystem = new InMemoryFileSystem(InMemoryPathSemantics.Posix);
         NuGetPhase10VerticalSliceService service = CreateService(fileSystem);
+        fileSystem.Calls.Clear();
 
         NuGetPhase10ConfigureDryRunResult result = await service.DryRunConfigureAsync(
             TestContext.Current.CancellationToken
         );
 
+        Assert.DoesNotContain(fileSystem.Calls, call => IsMutation(call.Operation));
         Assert.True(result.Validation.IsValid);
         Assert.Equal(ConfigurationPlanOperation.DryRun, result.PlanResult.Operation);
         ConfigurationPlannedChange change = Assert.Single(result.PlanResult.Changes);
@@ -28,8 +36,166 @@ public sealed class NuGetPhase10VerticalSliceServiceTests
         Assert.Equal(service.Paths.PluginTargetRootPath, change.TargetPathOrName);
         Assert.Equal("physical-target", change.Key);
         Assert.True(change.HasPlannedValue);
+        Assert.False(fileSystem.DirectoryExists(service.Paths.PluginTargetRootPath));
+        Assert.False(fileSystem.FileExists(service.Paths.PluginEntrypointPath));
+        Assert.False(
+            fileSystem.FileExists(service.Paths.PluginTargetRootPath + "/dependency.dll")
+        );
         Assert.False(fileSystem.FileExists(service.Paths.PluginLayoutMarkerPath));
         Assert.False(fileSystem.FileExists(service.Paths.OwnershipManifestPath));
+    }
+
+    [Fact]
+    public async Task ConfiguredUnconfigureDryRunPreservesOwnedFilesWithoutFilesystemMutation()
+    {
+        var fileSystem = new InMemoryFileSystem(InMemoryPathSemantics.Posix);
+        NuGetPhase10VerticalSliceService service = CreateService(fileSystem);
+        await service.ConfigureAsync(TestContext.Current.CancellationToken);
+        string[] ownedPaths =
+        [
+            service.Paths.PluginEntrypointPath,
+            service.Paths.PluginTargetRootPath + "/dependency.dll",
+            service.Paths.PluginLayoutMarkerPath,
+            service.Paths.OwnershipManifestPath,
+        ];
+        Dictionary<string, OwnedFileSnapshot> snapshots = ownedPaths.ToDictionary(
+            path => path,
+            path =>
+                new OwnedFileSnapshot(
+                    fileSystem.ReadAllBytes(path),
+                    fileSystem.GetUnixFileMode(path)
+                ),
+            StringComparer.Ordinal
+        );
+        fileSystem.Calls.Clear();
+
+        await service.ValidateUnconfigureDryRunAsync(
+            TestContext.Current.CancellationToken
+        );
+
+        Assert.DoesNotContain(fileSystem.Calls, call => IsMutation(call.Operation));
+        foreach ((string path, OwnedFileSnapshot snapshot) in snapshots)
+        {
+            Assert.True(fileSystem.FileExists(path));
+            Assert.Equal(snapshot.Contents, fileSystem.ReadAllBytes(path));
+            Assert.Equal(snapshot.Mode, fileSystem.GetUnixFileMode(path));
+        }
+        Assert.DoesNotContain(fileSystem.Calls, call => IsMutation(call.Operation));
+    }
+
+    [Fact]
+    public async Task ConfigureMigratesExactF1LegacyActivationToJsonInventory()
+    {
+        var fileSystem = new InMemoryFileSystem(InMemoryPathSemantics.Posix);
+        NuGetPhase10VerticalSliceService service = CreateService(fileSystem);
+        string sourceRoot = service.Paths.ApplicationPayloadRootPath;
+        string targetRoot = service.Paths.PluginTargetRootPath;
+        fileSystem.AtomicWriteAllText(sourceRoot + "/shared/legacy.dll", "legacy-only");
+        string ownershipBefore = await SeedExactF1LegacyActivationAsync(fileSystem, service);
+        fileSystem.DeleteFile(sourceRoot + "/shared/legacy.dll");
+        fileSystem.AtomicWriteAllText(sourceRoot + "/shared/current.dll", "current-only");
+
+        NuGetPhase10ConfigureResult result = await service.ConfigureAsync(
+            TestContext.Current.CancellationToken
+        );
+
+        Assert.Single(result.PlanResult.Changes);
+        Assert.Equal(
+            "fake-assembly",
+            fileSystem.ReadAllText(service.Paths.PluginEntrypointPath)
+        );
+        Assert.Equal(
+            "dependency",
+            fileSystem.ReadAllText(service.Paths.PluginTargetRootPath + "/dependency.dll")
+        );
+        string marker = fileSystem.ReadAllText(service.Paths.PluginLayoutMarkerPath);
+        Assert.StartsWith("{", marker, StringComparison.Ordinal);
+        Assert.Contains(
+            "\"schemaVersion\": \"azureauth-credprovider-nuget-plugin-activation-v1\"",
+            marker,
+            StringComparison.Ordinal
+        );
+        Assert.Contains("\"dependency.dll\"", marker, StringComparison.Ordinal);
+        Assert.Contains("\"shared/current.dll\"", marker, StringComparison.Ordinal);
+        Assert.DoesNotContain("\"shared/legacy.dll\"", marker, StringComparison.Ordinal);
+        Assert.Equal(
+            "legacy-only",
+            fileSystem.ReadAllText(targetRoot + "/shared/legacy.dll")
+        );
+        Assert.Equal(
+            "current-only",
+            fileSystem.ReadAllText(targetRoot + "/shared/current.dll")
+        );
+        Assert.Equal(
+            ownershipBefore,
+            fileSystem.ReadAllText(service.Paths.OwnershipManifestPath)
+        );
+    }
+
+    [Fact]
+    public async Task UnconfigureRemovesOnlyExactF1LegacyEntrypointAndMarker()
+    {
+        var fileSystem = new InMemoryFileSystem(InMemoryPathSemantics.Posix);
+        NuGetPhase10VerticalSliceService service = CreateService(fileSystem);
+        await SeedExactF1LegacyActivationAsync(fileSystem, service);
+        string unrelatedPath = service.Paths.PluginTargetRootPath + "/preserve.txt";
+        fileSystem.AtomicWriteAllText(unrelatedPath, "unrelated");
+
+        NuGetPhase10UnconfigureResult result = await service.UnconfigureAsync(
+            TestContext.Current.CancellationToken
+        );
+
+        Assert.True(result.HadOwnedConfiguration);
+        Assert.False(fileSystem.FileExists(service.Paths.PluginEntrypointPath));
+        Assert.False(fileSystem.FileExists(service.Paths.PluginLayoutMarkerPath));
+        Assert.False(fileSystem.FileExists(service.Paths.OwnershipManifestPath));
+        Assert.Equal(
+            "dependency",
+            fileSystem.ReadAllText(service.Paths.PluginTargetRootPath + "/dependency.dll")
+        );
+        Assert.Equal("unrelated", fileSystem.ReadAllText(unrelatedPath));
+    }
+
+    [Theory]
+    [InlineData("marker")]
+    [InlineData("manifest")]
+    public async Task DriftedF1LegacyStateRemainsUnrecognized(string scenario)
+    {
+        var fileSystem = new InMemoryFileSystem(InMemoryPathSemantics.Posix);
+        NuGetPhase10VerticalSliceService service = CreateService(fileSystem);
+        string ownershipBefore = await SeedExactF1LegacyActivationAsync(fileSystem, service);
+        string markerBefore = fileSystem.ReadAllText(service.Paths.PluginLayoutMarkerPath);
+        if (scenario == "marker")
+        {
+            markerBefore += " ";
+            fileSystem.AtomicWriteAllText(service.Paths.PluginLayoutMarkerPath, markerBefore);
+        }
+        else
+        {
+            ownershipBefore += " ";
+            fileSystem.AtomicWriteAllText(service.Paths.OwnershipManifestPath, ownershipBefore);
+        }
+
+        NuGetPhase10DoctorResult doctor = await service.DoctorAsync(
+            TestContext.Current.CancellationToken
+        );
+        await Assert.ThrowsAsync<NuGetPhase10UnrecognizedStateException>(async () =>
+            await service.ConfigureAsync(TestContext.Current.CancellationToken)
+        );
+        await Assert.ThrowsAsync<NuGetPhase10UnrecognizedStateException>(async () =>
+            await service.UnconfigureAsync(TestContext.Current.CancellationToken)
+        );
+
+        Assert.Equal(NuGetConfigurationState.Unrecognized, doctor.ConfigurationState);
+        Assert.Equal(
+            "fake-assembly",
+            fileSystem.ReadAllText(service.Paths.PluginEntrypointPath)
+        );
+        Assert.Equal(markerBefore, fileSystem.ReadAllText(service.Paths.PluginLayoutMarkerPath));
+        Assert.Equal(
+            ownershipBefore,
+            fileSystem.ReadAllText(service.Paths.OwnershipManifestPath)
+        );
     }
 
     [Fact]
@@ -494,15 +660,14 @@ public sealed class NuGetPhase10VerticalSliceServiceTests
         Assert.False(result.PluginModeEntrypointResolvable);
     }
 
-    [Fact]
-    public async Task ConfigureRejectsProductOwnedMarkerWithoutManifest()
+    [Theory]
+    [InlineData("""{"schemaVersion":"azureauth-credprovider-nuget-plugin-activation-v1"}""")]
+    [InlineData(F1LegacyMarker)]
+    public async Task ConfigureRejectsProductOwnedMarkerWithoutManifest(string marker)
     {
         var fileSystem = new InMemoryFileSystem(InMemoryPathSemantics.Host);
         NuGetPhase10VerticalSliceService service = CreateService(fileSystem);
-        fileSystem.AtomicWriteAllText(
-            service.Paths.PluginLayoutMarkerPath,
-            """{"schemaVersion":"azureauth-credprovider-nuget-plugin-activation-v1"}"""
-        );
+        fileSystem.AtomicWriteAllText(service.Paths.PluginLayoutMarkerPath, marker);
 
         await Assert.ThrowsAsync<NuGetPhase10UnrecognizedStateException>(async () =>
             await service.ConfigureAsync(TestContext.Current.CancellationToken)
@@ -635,6 +800,35 @@ public sealed class NuGetPhase10VerticalSliceServiceTests
         );
     }
 
+    private static async Task<string> SeedExactF1LegacyActivationAsync(
+        InMemoryFileSystem fileSystem,
+        NuGetPhase10VerticalSliceService service
+    )
+    {
+        await service.ConfigureAsync(TestContext.Current.CancellationToken);
+        string ownership = fileSystem.ReadAllText(service.Paths.OwnershipManifestPath);
+        ConfigurationOwnershipManifest manifest =
+            ConfigurationOwnershipManifestSerializer.Deserialize(ownership);
+        ConfigurationOwnershipManifestEntry entry = Assert.Single(manifest.Entries);
+        Assert.Equal(1, manifest.SchemaVersion);
+        Assert.Equal("phase10-nuget-plugin-layout", manifest.ManifestId);
+        Assert.Equal("azureauth-credprovider", manifest.OwnerProductId);
+        Assert.Equal(ConfigurationScope.User, manifest.Scope);
+        Assert.Equal("nuget.plugin-layout", manifest.EntrySelector);
+        Assert.Equal("phase10", manifest.ProductVersion);
+        Assert.Empty(manifest.SafeMetadata);
+        Assert.Equal(1, entry.Sequence);
+        Assert.Equal(ConfigurationTargetKind.NuGetPluginLayout, entry.TargetKind);
+        Assert.Equal(service.Paths.PluginTargetRootPath, entry.TargetPathOrName);
+        Assert.Equal("physical-target", entry.Key);
+        Assert.Equal(
+            ConfigurationOwnershipManifestSerializer.Serialize(manifest),
+            ownership
+        );
+        fileSystem.AtomicWriteAllText(service.Paths.PluginLayoutMarkerPath, F1LegacyMarker);
+        return ownership;
+    }
+
     private static void AssertRejectedConfigureWasNonMutating(
         InMemoryFileSystem fileSystem,
         InvalidNuGetPayloadFixture fixture
@@ -725,6 +919,8 @@ public sealed class NuGetPhase10VerticalSliceServiceTests
         string ForeignContents,
         string ExpectedDiagnostic
     );
+
+    private sealed record OwnedFileSnapshot(byte[] Contents, UnixFileMode Mode);
 
     private static string GetIsolatedHomePath() =>
         Path.Combine(
@@ -818,7 +1014,7 @@ public sealed class NuGetPhase10VerticalSliceServiceTests
     }
 
     [Fact]
-    public async Task DoctorTreatsTargetDirectoryContainingOnlyUnrelatedFilesAsValid()
+    public async Task ConfigureAndDoctorPreserveMarkerlessDirectoryWithOnlyUnrelatedFiles()
     {
         var fileSystem = new InMemoryFileSystem(InMemoryPathSemantics.Posix);
         NuGetPhase10VerticalSliceService service = CreateService(fileSystem);
@@ -827,16 +1023,47 @@ public sealed class NuGetPhase10VerticalSliceServiceTests
             "unrelated"
         );
 
+        NuGetPhase10ConfigureResult configure = await service.ConfigureAsync(
+            TestContext.Current.CancellationToken
+        );
         NuGetPhase10DoctorResult doctor = await service.DoctorAsync(
             TestContext.Current.CancellationToken
         );
 
+        Assert.Single(configure.PlanResult.Changes);
         Assert.Equal(NuGetConfigurationState.Valid, doctor.ConfigurationState);
         Assert.True(doctor.ConfigurationPlanValid);
-        Assert.False(fileSystem.FileExists(service.Paths.PluginLayoutMarkerPath));
+        Assert.Equal(
+            "unrelated",
+            fileSystem.ReadAllText(service.Paths.PluginTargetRootPath + "/unrelated.txt")
+        );
+        Assert.True(fileSystem.FileExists(service.Paths.PluginEntrypointPath));
+        Assert.True(fileSystem.FileExists(service.Paths.PluginLayoutMarkerPath));
         Assert.False(fileSystem.DirectoryExists(service.Paths.PluginLayoutMarkerPath));
-        Assert.False(fileSystem.FileExists(service.Paths.OwnershipManifestPath));
+        Assert.True(fileSystem.FileExists(service.Paths.OwnershipManifestPath));
         Assert.False(fileSystem.DirectoryExists(service.Paths.OwnershipManifestPath));
+    }
+
+    [Fact]
+    public async Task ConfigureAndDoctorRejectOwnershipManifestClaimWithoutMarker()
+    {
+        var fileSystem = new InMemoryFileSystem(InMemoryPathSemantics.Posix);
+        NuGetPhase10VerticalSliceService service = CreateService(fileSystem);
+        await service.ConfigureAsync(TestContext.Current.CancellationToken);
+        fileSystem.DeleteFile(service.Paths.PluginLayoutMarkerPath);
+
+        NuGetPhase10DoctorResult doctor = await service.DoctorAsync(
+            TestContext.Current.CancellationToken
+        );
+
+        Assert.Equal(NuGetConfigurationState.Unrecognized, doctor.ConfigurationState);
+        Assert.False(doctor.ConfigurationPlanValid);
+        await Assert.ThrowsAsync<NuGetPhase10UnrecognizedStateException>(async () =>
+            await service.ConfigureAsync(TestContext.Current.CancellationToken)
+        );
+        Assert.True(fileSystem.FileExists(service.Paths.OwnershipManifestPath));
+        Assert.True(fileSystem.FileExists(service.Paths.PluginEntrypointPath));
+        Assert.False(fileSystem.FileExists(service.Paths.PluginLayoutMarkerPath));
     }
 
     private static void ApplyOwnershiplessCollision(

--- a/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform.Tests/NuGetPhase10VerticalSliceServiceTests.cs
+++ b/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform.Tests/NuGetPhase10VerticalSliceServiceTests.cs
@@ -45,7 +45,10 @@ public sealed class NuGetPhase10VerticalSliceServiceTests
             TestContext.Current.CancellationToken
         );
 
-        Assert.NotEqual(ConfigurationPlanOperation.DryRun, configureResult.PlanResult.Operation);
+        Assert.Equal(ConfigurationPlanOperation.Apply, configureResult.PlanResult.Operation);
+        Assert.Single(configureResult.PlanResult.Plan.Changes);
+        Assert.Single(configureResult.PlanResult.Changes);
+        Assert.Single(configureResult.PlanResult.PlannedOperations);
         Assert.True(configureResult.PluginLayoutMarkerPresent);
         Assert.True(configureResult.OwnershipManifestPresent);
         Assert.Equal(
@@ -58,6 +61,7 @@ public sealed class NuGetPhase10VerticalSliceServiceTests
             StringComparison.Ordinal
         );
         Assert.True(fileSystem.FileExists(service.Paths.OwnershipManifestPath));
+        Assert.Equal(NuGetConfigurationState.Valid, doctorResult.ConfigurationState);
         Assert.True(doctorResult.ConfigurationPlanValid);
         Assert.True(doctorResult.PluginLayoutMarkerPresent);
         Assert.True(doctorResult.OwnershipManifestPresent);
@@ -193,6 +197,193 @@ public sealed class NuGetPhase10VerticalSliceServiceTests
         Assert.True(fileSystem.DirectoryExists(targetRoot + "/unrelated/empty/subtree"));
     }
 
+    [Theory]
+    [InlineData("missing-root")]
+    [InlineData("missing-entrypoint")]
+    [InlineData("source-contains-target")]
+    [InlineData("target-contains-source")]
+    [InlineData("unowned-file")]
+    [InlineData("unowned-directory")]
+    public async Task DryRunConfigureRejectsInvalidPayloadBeforeMutation(string scenario)
+    {
+        var fileSystem = new InMemoryFileSystem(InMemoryPathSemantics.Posix);
+        InvalidNuGetPayloadFixture fixture = await CreateInvalidPayloadFixtureAsync(
+            fileSystem,
+            scenario
+        );
+        fileSystem.Calls.Clear();
+
+        NuGetPhase10UnrecognizedStateException exception =
+            await Assert.ThrowsAsync<NuGetPhase10UnrecognizedStateException>(async () =>
+                await fixture.Service.DryRunConfigureAsync(
+                    TestContext.Current.CancellationToken
+                )
+            );
+
+        Assert.NotNull(exception.InnerException);
+        Assert.Contains(
+            fixture.ExpectedDiagnostic,
+            exception.InnerException.Message,
+            StringComparison.Ordinal
+        );
+        AssertRejectedConfigureWasNonMutating(fileSystem, fixture);
+    }
+
+    [Theory]
+    [InlineData("missing-root")]
+    [InlineData("missing-entrypoint")]
+    [InlineData("source-contains-target")]
+    [InlineData("target-contains-source")]
+    [InlineData("unowned-file")]
+    [InlineData("unowned-directory")]
+    public async Task ConfigureRejectsInvalidPayloadBeforePersistingOwnership(string scenario)
+    {
+        var fileSystem = new InMemoryFileSystem(InMemoryPathSemantics.Posix);
+        InvalidNuGetPayloadFixture fixture = await CreateInvalidPayloadFixtureAsync(
+            fileSystem,
+            scenario
+        );
+        fileSystem.Calls.Clear();
+
+        NuGetPhase10UnrecognizedStateException exception =
+            await Assert.ThrowsAsync<NuGetPhase10UnrecognizedStateException>(async () =>
+                await fixture.Service.ConfigureAsync(TestContext.Current.CancellationToken)
+            );
+
+        Assert.NotNull(exception.InnerException);
+        Assert.Contains(
+            fixture.ExpectedDiagnostic,
+            exception.InnerException.Message,
+            StringComparison.Ordinal
+        );
+        AssertRejectedConfigureWasNonMutating(fileSystem, fixture);
+    }
+
+    [Fact]
+    public async Task ConfigureWhenAppliedStateIsCurrentPerformsNoWrites()
+    {
+        var fileSystem = new InMemoryFileSystem(InMemoryPathSemantics.Posix);
+        NuGetPhase10VerticalSliceService service = CreateService(fileSystem);
+        await service.ConfigureAsync(TestContext.Current.CancellationToken);
+        string entrypointBefore = fileSystem.ReadAllText(service.Paths.PluginEntrypointPath);
+        string markerBefore = fileSystem.ReadAllText(service.Paths.PluginLayoutMarkerPath);
+        string ownershipBefore = fileSystem.ReadAllText(service.Paths.OwnershipManifestPath);
+        fileSystem.Calls.Clear();
+
+        NuGetPhase10ConfigureResult result = await service.ConfigureAsync(
+            TestContext.Current.CancellationToken
+        );
+
+        FileSystemCall[] ownedMutations = GetOwnedMutationCalls(fileSystem, service);
+        Assert.Empty(ownedMutations);
+        Assert.Equal(ConfigurationPlanOperation.Apply, result.PlanResult.Operation);
+        Assert.Empty(result.PlanResult.Plan.Changes);
+        Assert.Empty(result.PlanResult.Changes);
+        Assert.Empty(result.PlanResult.PlannedOperations);
+        Assert.Equal(entrypointBefore, fileSystem.ReadAllText(service.Paths.PluginEntrypointPath));
+        Assert.Equal(markerBefore, fileSystem.ReadAllText(service.Paths.PluginLayoutMarkerPath));
+        Assert.Equal(ownershipBefore, fileSystem.ReadAllText(service.Paths.OwnershipManifestPath));
+        Assert.True(result.PluginLayoutMarkerPresent);
+        Assert.True(result.OwnershipManifestPresent);
+    }
+
+    [Fact]
+    public async Task ConfigureWhenSourcePayloadChangesRefreshesActivationWithWrites()
+    {
+        var fileSystem = new InMemoryFileSystem(InMemoryPathSemantics.Posix);
+        NuGetPhase10VerticalSliceService service = CreateService(fileSystem);
+        await service.ConfigureAsync(TestContext.Current.CancellationToken);
+        string targetRoot = service.Paths.PluginTargetRootPath;
+        string sourceRoot = service.Paths.ApplicationPayloadRootPath;
+        string unrelatedPath = targetRoot + "/preserve.txt";
+        fileSystem.AtomicWriteAllText(unrelatedPath, "unrelated");
+        fileSystem.AtomicWriteAllText(
+            sourceRoot + "/azureauth-credprovider.dll",
+            "source-b"
+        );
+        fileSystem.DeleteFile(sourceRoot + "/dependency.dll");
+        fileSystem.AtomicWriteAllText(sourceRoot + "/new/addition.dll", "new-b");
+        fileSystem.Calls.Clear();
+
+        NuGetPhase10ConfigureResult result = await service.ConfigureAsync(
+            TestContext.Current.CancellationToken
+        );
+
+        FileSystemCall[] mutationCalls = GetOwnedMutationCalls(fileSystem, service);
+        Assert.Single(result.PlanResult.Plan.Changes);
+        Assert.Single(result.PlanResult.Changes);
+        Assert.Single(result.PlanResult.PlannedOperations);
+        Assert.Equal(
+            2,
+            mutationCalls.Count(call =>
+                call.Operation == nameof(InMemoryFileSystem.AtomicWriteAllBytes)
+                && IsSameOrDescendant(call.Path, targetRoot)
+            )
+        );
+        Assert.Single(
+            mutationCalls,
+            call =>
+                call.Operation == nameof(InMemoryFileSystem.AtomicWriteAllText)
+                && call.Path == service.Paths.PluginLayoutMarkerPath
+        );
+        Assert.Single(
+            mutationCalls,
+            call =>
+                call.Operation == nameof(InMemoryFileSystem.DeleteFile)
+                && call.Path == targetRoot + "/dependency.dll"
+        );
+        Assert.Equal("source-b", fileSystem.ReadAllText(service.Paths.PluginEntrypointPath));
+        Assert.Equal("new-b", fileSystem.ReadAllText(targetRoot + "/new/addition.dll"));
+        Assert.False(fileSystem.FileExists(targetRoot + "/dependency.dll"));
+        Assert.Equal("unrelated", fileSystem.ReadAllText(unrelatedPath));
+        string marker = fileSystem.ReadAllText(service.Paths.PluginLayoutMarkerPath);
+        Assert.Contains("new/addition.dll", marker, StringComparison.Ordinal);
+        Assert.DoesNotContain("dependency.dll", marker, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ConfigureWhenTargetUnixModeDriftsRepairsModeWithWrites()
+    {
+        const UnixFileMode sourceMode =
+            UnixFileMode.UserRead
+            | UnixFileMode.UserWrite
+            | UnixFileMode.UserExecute
+            | UnixFileMode.GroupRead
+            | UnixFileMode.GroupExecute;
+        var fileSystem = new InMemoryFileSystem(InMemoryPathSemantics.Posix);
+        NuGetPhase10VerticalSliceService service = CreateService(fileSystem);
+        string sourceEntrypoint =
+            service.Paths.ApplicationPayloadRootPath + "/azureauth-credprovider.dll";
+        fileSystem.SetUnixFileMode(sourceEntrypoint, sourceMode);
+        await service.ConfigureAsync(TestContext.Current.CancellationToken);
+        fileSystem.SetUnixFileMode(
+            service.Paths.PluginEntrypointPath,
+            UnixFileMode.UserRead | UnixFileMode.UserWrite
+        );
+        fileSystem.Calls.Clear();
+
+        await service.ConfigureAsync(TestContext.Current.CancellationToken);
+
+        FileSystemCall[] mutationCalls = GetOwnedMutationCalls(fileSystem, service);
+        Assert.Single(
+            mutationCalls,
+            call =>
+                call.Operation == nameof(InMemoryFileSystem.AtomicWriteAllBytes)
+                && call.Path == service.Paths.PluginEntrypointPath
+        );
+        Assert.Single(
+            mutationCalls,
+            call =>
+                call.Operation == nameof(InMemoryFileSystem.SetUnixFileMode)
+                && call.Path == service.Paths.PluginEntrypointPath
+        );
+        Assert.Equal(sourceMode, fileSystem.GetUnixFileMode(service.Paths.PluginEntrypointPath));
+        Assert.Equal(
+            "fake-assembly",
+            fileSystem.ReadAllText(service.Paths.PluginEntrypointPath)
+        );
+    }
+
     [Fact]
     public async Task RefreshRejectsNewFileUnderPreExistingUnownedDirectory()
     {
@@ -325,6 +516,12 @@ public sealed class NuGetPhase10VerticalSliceServiceTests
         NuGetPhase10VerticalSliceService service = CreateService(fileSystem);
         fileSystem.AtomicWriteAllText(service.Paths.OwnershipManifestPath, "{");
 
+        NuGetPhase10DoctorResult doctor = await service.DoctorAsync(
+            TestContext.Current.CancellationToken
+        );
+
+        Assert.Equal(NuGetConfigurationState.Unrecognized, doctor.ConfigurationState);
+        Assert.False(doctor.ConfigurationPlanValid);
         await Assert.ThrowsAsync<NuGetPhase10UnrecognizedStateException>(async () =>
             await service.ConfigureAsync(TestContext.Current.CancellationToken)
         );
@@ -332,15 +529,20 @@ public sealed class NuGetPhase10VerticalSliceServiceTests
 
     private static NuGetPhase10VerticalSliceService CreateService(
         InMemoryFileSystem fileSystem,
-        Func<string, string?>? environmentVariableReader = null
+        Func<string, string?>? environmentVariableReader = null,
+        string? applicationRootPath = null,
+        bool seedPayload = true
     )
     {
-        const string applicationRoot = "/installation/app";
-        fileSystem.AtomicWriteAllText(
-            applicationRoot + "/azureauth-credprovider.dll",
-            "fake-assembly"
-        );
-        fileSystem.AtomicWriteAllText(applicationRoot + "/dependency.dll", "dependency");
+        string applicationRoot = applicationRootPath ?? "/installation/app";
+        if (seedPayload)
+        {
+            fileSystem.AtomicWriteAllText(
+                applicationRoot + "/azureauth-credprovider.dll",
+                "fake-assembly"
+            );
+            fileSystem.AtomicWriteAllText(applicationRoot + "/dependency.dll", "dependency");
+        }
         return new(
             new NuGetPhase10VerticalSliceOptions
             {
@@ -351,6 +553,186 @@ public sealed class NuGetPhase10VerticalSliceServiceTests
             }
         );
     }
+
+    private static async Task<InvalidNuGetPayloadFixture> CreateInvalidPayloadFixtureAsync(
+        InMemoryFileSystem fileSystem,
+        string scenario
+    )
+    {
+        NuGetPhase10VerticalSliceService service;
+        string? foreignPath = null;
+        const string foreignContents = "foreign";
+        string expectedDiagnostic;
+        switch (scenario)
+        {
+            case "missing-root":
+                service = CreateService(
+                    fileSystem,
+                    applicationRootPath: "/missing/application",
+                    seedPayload: false
+                );
+                expectedDiagnostic = "source application root is unavailable";
+                break;
+            case "missing-entrypoint":
+                service = CreateService(fileSystem, seedPayload: false);
+                fileSystem.AtomicWriteAllText(
+                    service.Paths.ApplicationPayloadRootPath + "/dependency.dll",
+                    "dependency"
+                );
+                expectedDiagnostic = "source application payload is incomplete";
+                break;
+            case "source-contains-target":
+                service = CreateService(
+                    fileSystem,
+                    applicationRootPath: "/"
+                );
+                expectedDiagnostic = "source and activation roots must be disjoint";
+                break;
+            case "target-contains-source":
+                NuGetPhase10VerticalSliceService layout = CreateService(
+                    fileSystem,
+                    seedPayload: false
+                );
+                service = CreateService(
+                    fileSystem,
+                    applicationRootPath: layout.Paths.PluginTargetRootPath + "/application"
+                );
+                expectedDiagnostic = "source and activation roots must be disjoint";
+                break;
+            case "unowned-file":
+                service = CreateService(fileSystem);
+                await service.ConfigureAsync(TestContext.Current.CancellationToken);
+                fileSystem.AtomicWriteAllText(
+                    service.Paths.ApplicationPayloadRootPath + "/new/conflict.dll",
+                    "product"
+                );
+                foreignPath = service.Paths.PluginTargetRootPath + "/new/conflict.dll";
+                fileSystem.AtomicWriteAllText(foreignPath, foreignContents);
+                expectedDiagnostic = "overwrite an unowned path";
+                break;
+            case "unowned-directory":
+                service = CreateService(fileSystem);
+                await service.ConfigureAsync(TestContext.Current.CancellationToken);
+                fileSystem.AtomicWriteAllText(
+                    service.Paths.ApplicationPayloadRootPath + "/shared/addition.dll",
+                    "product"
+                );
+                foreignPath = service.Paths.PluginTargetRootPath + "/shared";
+                fileSystem.CreateDirectory(foreignPath);
+                expectedDiagnostic = "use an unowned existing directory";
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(scenario), scenario, null);
+        }
+
+        return new InvalidNuGetPayloadFixture(
+            service,
+            ReadTextIfPresent(fileSystem, service.Paths.PluginLayoutMarkerPath),
+            ReadTextIfPresent(fileSystem, service.Paths.OwnershipManifestPath),
+            foreignPath,
+            foreignContents,
+            expectedDiagnostic
+        );
+    }
+
+    private static void AssertRejectedConfigureWasNonMutating(
+        InMemoryFileSystem fileSystem,
+        InvalidNuGetPayloadFixture fixture
+    )
+    {
+        FileSystemCall[] mutationCalls = GetOwnedMutationCalls(fileSystem, fixture.Service);
+        Assert.Empty(mutationCalls);
+        AssertOptionalTextEquals(
+            fileSystem,
+            fixture.Service.Paths.PluginLayoutMarkerPath,
+            fixture.MarkerBefore
+        );
+        AssertOptionalTextEquals(
+            fileSystem,
+            fixture.Service.Paths.OwnershipManifestPath,
+            fixture.OwnershipBefore
+        );
+        if (fixture.ForeignPath is not null)
+        {
+            if (fileSystem.FileExists(fixture.ForeignPath))
+            {
+                Assert.Equal(
+                    fixture.ForeignContents,
+                    fileSystem.ReadAllText(fixture.ForeignPath)
+                );
+            }
+            else
+            {
+                Assert.True(fileSystem.DirectoryExists(fixture.ForeignPath));
+                Assert.Empty(fileSystem.EnumerateFiles(fixture.ForeignPath));
+                Assert.Empty(fileSystem.EnumerateDirectories(fixture.ForeignPath));
+            }
+        }
+    }
+
+    private static FileSystemCall[] GetOwnedMutationCalls(
+        InMemoryFileSystem fileSystem,
+        NuGetPhase10VerticalSliceService service
+    ) =>
+        fileSystem
+            .Calls.Where(call =>
+                IsMutation(call.Operation)
+                && (
+                    IsSameOrDescendant(call.Path, service.Paths.PluginTargetRootPath)
+                    || IsSameOrDescendant(call.Path, service.Paths.StateDirectoryPath)
+                )
+            )
+            .ToArray();
+
+    private static bool IsMutation(string operation) =>
+        operation
+            is nameof(InMemoryFileSystem.AtomicWriteAllBytes)
+                or nameof(InMemoryFileSystem.AtomicWriteAllText)
+                or nameof(InMemoryFileSystem.WriteAllText)
+                or nameof(InMemoryFileSystem.SetUnixFileMode)
+                or nameof(InMemoryFileSystem.CreateDirectory)
+                or nameof(InMemoryFileSystem.DeleteFile)
+                or nameof(InMemoryFileSystem.DeleteDirectory);
+
+    private static bool IsSameOrDescendant(string path, string root) =>
+        string.Equals(path, root, StringComparison.Ordinal)
+        || path.StartsWith(root + "/", StringComparison.Ordinal);
+
+    private static string? ReadTextIfPresent(InMemoryFileSystem fileSystem, string path) =>
+        fileSystem.FileExists(path) ? fileSystem.ReadAllText(path) : null;
+
+    private static void AssertOptionalTextEquals(
+        InMemoryFileSystem fileSystem,
+        string path,
+        string? expected
+    )
+    {
+        if (expected is null)
+        {
+            Assert.False(fileSystem.FileExists(path));
+        }
+        else
+        {
+            Assert.Equal(expected, fileSystem.ReadAllText(path));
+        }
+    }
+
+    private sealed record InvalidNuGetPayloadFixture(
+        NuGetPhase10VerticalSliceService Service,
+        string? MarkerBefore,
+        string? OwnershipBefore,
+        string? ForeignPath,
+        string ForeignContents,
+        string ExpectedDiagnostic
+    );
+
+    private static string GetIsolatedHomePath() =>
+        Path.Combine(
+            Path.GetPathRoot(Environment.CurrentDirectory)
+                ?? Path.DirectorySeparatorChar.ToString(),
+            "azureauth-credprovider-tests",
+            "user-home"
+        );
 
     [Fact]
     public async Task DoctorValidatesParserWithoutCredentialAcquisition()
@@ -388,6 +770,101 @@ public sealed class NuGetPhase10VerticalSliceServiceTests
         Assert.True(result.AzureArtifactsSourceCanonicalizationSuccess);
         Assert.True(result.InteractivePolicyGuidanceSuccess);
         Assert.True(result.OptionalEnvironmentOverridesAbsent);
+    }
+
+    [Fact]
+    public async Task DoctorClassifiesStaleSourceAsRefreshable()
+    {
+        var fileSystem = new InMemoryFileSystem(InMemoryPathSemantics.Posix);
+        NuGetPhase10VerticalSliceService service = CreateService(fileSystem);
+        await service.ConfigureAsync(TestContext.Current.CancellationToken);
+        fileSystem.AtomicWriteAllText(
+            service.Paths.ApplicationPayloadRootPath + "/azureauth-credprovider.dll",
+            "source-b"
+        );
+
+        NuGetPhase10DoctorResult result = await service.DoctorAsync(
+            TestContext.Current.CancellationToken
+        );
+
+        Assert.Equal(NuGetConfigurationState.Refreshable, result.ConfigurationState);
+        Assert.False(result.ConfigurationPlanValid);
+        Assert.Equal("fake-assembly", fileSystem.ReadAllText(service.Paths.PluginEntrypointPath));
+        Assert.True(result.PluginLayoutMarkerPresent);
+        Assert.True(result.OwnershipManifestPresent);
+    }
+
+    [Theory]
+    [InlineData("target-root-file")]
+    [InlineData("orphan-entrypoint-file")]
+    [InlineData("entrypoint-directory")]
+    [InlineData("ownership-manifest-directory")]
+    [InlineData("marker-directory")]
+    public async Task DoctorAndConfigureRejectOwnershiplessCollision(string scenario)
+    {
+        var fileSystem = new InMemoryFileSystem(InMemoryPathSemantics.Posix);
+        NuGetPhase10VerticalSliceService service = CreateService(fileSystem);
+        ApplyOwnershiplessCollision(fileSystem, service, scenario);
+
+        NuGetPhase10DoctorResult doctor = await service.DoctorAsync(
+            TestContext.Current.CancellationToken
+        );
+
+        Assert.Equal(NuGetConfigurationState.Unrecognized, doctor.ConfigurationState);
+        Assert.False(doctor.ConfigurationPlanValid);
+        await Assert.ThrowsAsync<NuGetPhase10UnrecognizedStateException>(async () =>
+            await service.ConfigureAsync(TestContext.Current.CancellationToken)
+        );
+    }
+
+    [Fact]
+    public async Task DoctorTreatsTargetDirectoryContainingOnlyUnrelatedFilesAsValid()
+    {
+        var fileSystem = new InMemoryFileSystem(InMemoryPathSemantics.Posix);
+        NuGetPhase10VerticalSliceService service = CreateService(fileSystem);
+        fileSystem.AtomicWriteAllText(
+            service.Paths.PluginTargetRootPath + "/unrelated.txt",
+            "unrelated"
+        );
+
+        NuGetPhase10DoctorResult doctor = await service.DoctorAsync(
+            TestContext.Current.CancellationToken
+        );
+
+        Assert.Equal(NuGetConfigurationState.Valid, doctor.ConfigurationState);
+        Assert.True(doctor.ConfigurationPlanValid);
+        Assert.False(fileSystem.FileExists(service.Paths.PluginLayoutMarkerPath));
+        Assert.False(fileSystem.DirectoryExists(service.Paths.PluginLayoutMarkerPath));
+        Assert.False(fileSystem.FileExists(service.Paths.OwnershipManifestPath));
+        Assert.False(fileSystem.DirectoryExists(service.Paths.OwnershipManifestPath));
+    }
+
+    private static void ApplyOwnershiplessCollision(
+        InMemoryFileSystem fileSystem,
+        NuGetPhase10VerticalSliceService service,
+        string scenario
+    )
+    {
+        switch (scenario)
+        {
+            case "target-root-file":
+                fileSystem.AtomicWriteAllText(service.Paths.PluginTargetRootPath, "foreign");
+                break;
+            case "orphan-entrypoint-file":
+                fileSystem.AtomicWriteAllText(service.Paths.PluginEntrypointPath, "foreign");
+                break;
+            case "entrypoint-directory":
+                fileSystem.CreateDirectory(service.Paths.PluginEntrypointPath);
+                break;
+            case "ownership-manifest-directory":
+                fileSystem.CreateDirectory(service.Paths.OwnershipManifestPath);
+                break;
+            case "marker-directory":
+                fileSystem.CreateDirectory(service.Paths.PluginLayoutMarkerPath);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(scenario), scenario, null);
+        }
     }
 
     private sealed class ThrowingNuGetDoctorCredentialAcquisitionService

--- a/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform.Tests/ProcessTestAppModuleInitializer.cs
+++ b/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform.Tests/ProcessTestAppModuleInitializer.cs
@@ -65,6 +65,9 @@ internal static class ProcessTestAppModuleInitializer
             case "adapter-host-proof":
                 AdapterHostProofProcess.Run(helperArguments.Skip(1).ToArray());
                 break;
+            case DeploymentValidationNuGetLifecycleHarness.Command:
+                DeploymentValidationNuGetLifecycleHarness.Run(helperArguments.Skip(1).ToArray());
+                break;
             case NuGetPluginProtocolTestProcess.Command:
                 NuGetPluginProtocolTestProcess.Run();
                 break;

--- a/tests/private/app/azureauth-credprovider/Install-DeploymentValidationBundle.Tests.ps1
+++ b/tests/private/app/azureauth-credprovider/Install-DeploymentValidationBundle.Tests.ps1
@@ -81,6 +81,58 @@ function Assert-BytesEqual {
     }
 }
 
+function Get-FileSnapshotSet {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string[]]$LiteralPath
+    )
+
+    $snapshots = [System.Collections.Generic.Dictionary[string, object]]::new(
+        [System.StringComparer]::Ordinal
+    )
+    foreach ($path in $LiteralPath) {
+        $snapshots.Add(
+            $path,
+            [pscustomobject]@{
+                Content      = [System.IO.File]::ReadAllBytes($path)
+                UnixFileMode = if ($IsWindows) {
+                    $null
+                }
+                else {
+                    [int][System.IO.File]::GetUnixFileMode($path)
+                }
+            }
+        )
+    }
+    return $snapshots
+}
+
+function Assert-FileSnapshotSet {
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.Collections.Generic.Dictionary[string, object]]$Expected,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Context
+    )
+
+    foreach ($entry in $Expected.GetEnumerator()) {
+        Assert-True (
+            Test-Path -LiteralPath $entry.Key -PathType Leaf
+        ) "A snapshotted file was removed during $Context`: $($entry.Key)"
+        Assert-BytesEqual `
+            -Expected $entry.Value.Content `
+            -Actual ([System.IO.File]::ReadAllBytes($entry.Key)) `
+            -Message "A snapshotted file changed during $Context`: $($entry.Key)"
+        if ($null -ne $entry.Value.UnixFileMode) {
+            Assert-Equal `
+                -Expected $entry.Value.UnixFileMode `
+                -Actual ([int][System.IO.File]::GetUnixFileMode($entry.Key)) `
+                -Message "A snapshotted file mode changed during $Context`: $($entry.Key)"
+        }
+    }
+}
+
 function Assert-InvocationFailure {
     param(
         [Parameter(Mandatory = $true)]
@@ -360,7 +412,7 @@ function New-F1LegacyInstallation {
     $receipt = [ordered]@{
         schemaVersion   = 'azureauth-credprovider-deployment-validation-install-v1'
         productVersion  = '1.0.0-test'
-        sourceRevision  = 'f1bf00d4'
+        sourceRevision  = 'f1bf00d412732739713a18e9a07e8738ff80c6f8'
         targetRid       = $targetRid
         installRoot     = [System.IO.Path]::GetFullPath($InstallRoot)
         applicationRoot = [System.IO.Path]::GetFullPath($applicationRoot)
@@ -764,6 +816,71 @@ try {
     $bundleRoot = Join-Path $testRoot 'bundle'
     New-TestBundle -BundleRoot $bundleRoot
 
+    $legacyRevisionRoot = Join-Path $testRoot 'legacy-revision-mismatch'
+    $legacyRevisionInstallRoot = Join-Path $legacyRevisionRoot 'install'
+    $legacyRevisionNuGetRoot = Join-Path $legacyRevisionRoot 'nuget'
+    $legacyRevisionManifestPath = Join-Path $legacyRevisionRoot 'state/ownership.json'
+    New-F1LegacyInstallation `
+        -InstallRoot $legacyRevisionInstallRoot `
+        -NuGetPluginRoot $legacyRevisionNuGetRoot `
+        -OwnershipManifestPath $legacyRevisionManifestPath
+    $legacyRevisionReceiptPath = Join-Path $legacyRevisionInstallRoot 'installation.json'
+    $legacyRevisionReceipt = Get-Content -LiteralPath $legacyRevisionReceiptPath -Raw |
+        ConvertFrom-Json
+    $legacyRevisionReceipt.sourceRevision = 'not-f1bf00d4'
+    $legacyRevisionReceipt | ConvertTo-Json -Depth 5 |
+        Set-Content -LiteralPath $legacyRevisionReceiptPath -Encoding utf8
+    $legacyRevisionSnapshots = Get-FileSnapshotSet -LiteralPath @(
+        $legacyRevisionReceiptPath,
+        (Join-Path $legacyRevisionInstallRoot 'app/azureauth-credprovider.dll'),
+        (Join-Path $legacyRevisionNuGetRoot 'azureauth-credprovider.dll'),
+        (Join-Path $legacyRevisionNuGetRoot '.azureauth-credprovider.nuget-plugin-layout'),
+        $legacyRevisionManifestPath
+    )
+
+    Assert-InvocationFailure {
+        Invoke-Installer `
+            -BundleRoot $bundleRoot `
+            -InstallRoot $legacyRevisionInstallRoot `
+            -LegacyNuGetOwnershipManifestPath $legacyRevisionManifestPath
+    } 'Expected a non-f1bf00d4 legacy receipt to block deployment replacement.'
+    Assert-FileSnapshotSet `
+        -Expected $legacyRevisionSnapshots `
+        -Context 'non-f1bf00d4 installer validation'
+
+    $legacyRidRoot = Join-Path $testRoot 'legacy-rid-mismatch'
+    $legacyRidInstallRoot = Join-Path $legacyRidRoot 'install'
+    $legacyRidNuGetRoot = Join-Path $legacyRidRoot 'nuget'
+    $legacyRidManifestPath = Join-Path $legacyRidRoot 'state/ownership.json'
+    New-F1LegacyInstallation `
+        -InstallRoot $legacyRidInstallRoot `
+        -NuGetPluginRoot $legacyRidNuGetRoot `
+        -OwnershipManifestPath $legacyRidManifestPath
+    $legacyRidReceiptPath = Join-Path $legacyRidInstallRoot 'installation.json'
+    $legacyRidReceipt = Get-Content -LiteralPath $legacyRidReceiptPath -Raw |
+        ConvertFrom-Json
+    $legacyRidReceipt.targetRid = if ($runningOnWindows) { 'linux-x64' } else { 'win-x64' }
+    $legacyRidReceipt | ConvertTo-Json -Depth 5 |
+        Set-Content -LiteralPath $legacyRidReceiptPath -Encoding utf8
+    $legacyRidSnapshots = Get-FileSnapshotSet -LiteralPath @(
+        $legacyRidReceiptPath,
+        (Join-Path $legacyRidInstallRoot 'app/azureauth-credprovider.dll'),
+        (Join-Path $legacyRidNuGetRoot 'azureauth-credprovider.dll'),
+        (Join-Path $legacyRidNuGetRoot '.azureauth-credprovider.nuget-plugin-layout'),
+        $legacyRidManifestPath
+    )
+
+    Assert-InvocationFailure {
+        & (Join-Path $bundleRoot 'uninstall.ps1') `
+            -InstallRoot $legacyRidInstallRoot `
+            -LegacyNuGetOwnershipManifestPath $legacyRidManifestPath `
+            -SkipConfigurationCleanup |
+            Out-Null
+    } 'Expected a mismatched legacy receipt RID to block uninstall.'
+    Assert-FileSnapshotSet `
+        -Expected $legacyRidSnapshots `
+        -Context 'legacy RID uninstaller validation'
+
     $legacyUpgradeRoot = Join-Path $testRoot 'legacy-upgrade'
     $legacyUpgradeInstallRoot = Join-Path $legacyUpgradeRoot 'install'
     $legacyUpgradeNuGetRoot = Join-Path $legacyUpgradeRoot 'nuget'
@@ -804,6 +921,130 @@ try {
     Assert-True (
         -not (Test-Path -LiteralPath $legacyUpgradeManifestPath)
     ) 'Installer left the exact f1bf00d4 ownership manifest.'
+
+    $legacyRetryRoot = Join-Path $testRoot 'legacy-cleanup-retry'
+    $legacyRetryInstallRoot = Join-Path $legacyRetryRoot 'install'
+    $legacyRetryNuGetRoot = Join-Path $legacyRetryRoot 'nuget'
+    $legacyRetryManifestPath = Join-Path $legacyRetryRoot 'state/ownership.json'
+    New-F1LegacyInstallation `
+        -InstallRoot $legacyRetryInstallRoot `
+        -NuGetPluginRoot $legacyRetryNuGetRoot `
+        -OwnershipManifestPath $legacyRetryManifestPath
+    $legacyRetrySnapshots = Get-FileSnapshotSet -LiteralPath @(
+        (Join-Path $legacyRetryInstallRoot 'installation.json'),
+        (Join-Path $legacyRetryInstallRoot 'app/azureauth-credprovider.dll'),
+        (Join-Path $legacyRetryNuGetRoot 'azureauth-credprovider.dll'),
+        (Join-Path $legacyRetryNuGetRoot 'nested/dependency.dll'),
+        (Join-Path $legacyRetryNuGetRoot '.azureauth-credprovider.nuget-plugin-layout'),
+        $legacyRetryManifestPath
+    )
+    $legacyNuGetCleanupFailureState = [pscustomobject]@{
+        FailurePath = Join-Path $legacyRetryNuGetRoot 'nested/dependency.dll'
+        Injected    = $false
+    }
+    $legacyNuGetRemoveItemOverride = {
+        [CmdletBinding(DefaultParameterSetName = 'Path')]
+        param(
+            [Parameter(Mandatory = $true, ParameterSetName = 'LiteralPath')]
+            [string[]]$LiteralPath,
+
+            [Parameter(Mandatory = $true, ParameterSetName = 'Path')]
+            [string[]]$Path,
+
+            [switch]$Recurse,
+
+            [switch]$Force
+        )
+
+        $requestedPaths = if ($PSCmdlet.ParameterSetName -eq 'LiteralPath') {
+            $LiteralPath
+        }
+        else {
+            $Path
+        }
+        foreach ($requestedPath in $requestedPaths) {
+            if (-not $legacyNuGetCleanupFailureState.Injected -and
+                $requestedPath -eq $legacyNuGetCleanupFailureState.FailurePath) {
+                $legacyNuGetCleanupFailureState.Injected = $true
+                throw 'Injected deterministic legacy NuGet cleanup failure.'
+            }
+
+            if ($PSCmdlet.ParameterSetName -eq 'LiteralPath') {
+                Microsoft.PowerShell.Management\Remove-Item `
+                    -LiteralPath $requestedPath `
+                    -Recurse:$Recurse `
+                    -Force:$Force
+            }
+            else {
+                Microsoft.PowerShell.Management\Remove-Item `
+                    -Path $requestedPath `
+                    -Recurse:$Recurse `
+                    -Force:$Force
+            }
+        }
+    }
+    Set-Item `
+        -LiteralPath Function:\Remove-Item `
+        -Value $legacyNuGetRemoveItemOverride.GetNewClosure()
+    try {
+        $legacyRetryFailure = $null
+        try {
+            Invoke-Installer `
+                -BundleRoot $bundleRoot `
+                -InstallRoot $legacyRetryInstallRoot `
+                -LegacyNuGetOwnershipManifestPath $legacyRetryManifestPath
+        }
+        catch {
+            $legacyRetryFailure = $_
+        }
+        Assert-True `
+            -Condition ($null -ne $legacyRetryFailure) `
+            -Message 'Expected the injected legacy NuGet cleanup failure.'
+    }
+    finally {
+        Microsoft.PowerShell.Management\Remove-Item `
+            -LiteralPath Function:\Remove-Item `
+            -Force
+    }
+    Assert-True (
+        $legacyNuGetCleanupFailureState.Injected
+    ) (
+        'The legacy NuGet cleanup failure was not injected. Installer failure: ' +
+        $legacyRetryFailure.Exception.Message
+    )
+    Assert-FileSnapshotSet `
+        -Expected $legacyRetrySnapshots `
+        -Context 'legacy NuGet cleanup rollback'
+
+    Invoke-Installer `
+        -BundleRoot $bundleRoot `
+        -InstallRoot $legacyRetryInstallRoot `
+        -LegacyNuGetOwnershipManifestPath $legacyRetryManifestPath
+    $legacyRetryReceipt = Get-Content -LiteralPath (
+        Join-Path $legacyRetryInstallRoot 'installation.json'
+    ) -Raw | ConvertFrom-Json
+    Assert-Equal `
+        -Expected 'azureauth-credprovider-deployment-validation-install-v2' `
+        -Actual $legacyRetryReceipt.schemaVersion `
+        -Message 'Retry did not commit the v2 installation receipt.'
+    Assert-True (
+        -not (Test-Path -LiteralPath $legacyRetryManifestPath)
+    ) 'Retry left the legacy NuGet ownership manifest.'
+    foreach ($relativePath in @(
+            'azureauth-credprovider.dll',
+            'nested/dependency.dll',
+            '.azureauth-credprovider.nuget-plugin-layout'
+        )) {
+        Assert-True (
+            -not (Test-Path -LiteralPath (Join-Path $legacyRetryNuGetRoot $relativePath))
+        ) "Retry left legacy NuGet content '$relativePath'."
+    }
+    Assert-Equal `
+        -Expected 'unrelated legacy-root content' `
+        -Actual (Get-Content -LiteralPath (
+            Join-Path $legacyRetryNuGetRoot 'preserve.txt'
+        ) -Raw) `
+        -Message 'Retry removed unrelated legacy NuGet content.'
 
     $legacyDriftRoot = Join-Path $testRoot 'legacy-drift'
     $legacyDriftInstallRoot = Join-Path $legacyDriftRoot 'install'
@@ -966,8 +1207,10 @@ try {
     $cleanupFailureInstallRoot = Join-Path $cleanupFailureRoot 'install'
     New-ExistingInstallation -InstallRoot $cleanupFailureInstallRoot
 
-    $script:DeploymentInstallerCleanupFailureInjected = $false
-    function global:Remove-Item {
+    $deploymentInstallerCleanupFailureState = [pscustomobject]@{
+        Injected = $false
+    }
+    $deploymentInstallerRemoveItemOverride = {
         [CmdletBinding(DefaultParameterSetName = 'Path')]
         param(
             [Parameter(Mandatory = $true, ParameterSetName = 'LiteralPath')]
@@ -988,9 +1231,9 @@ try {
             $Path
         }
         foreach ($requestedPath in $requestedPaths) {
-            if (-not $script:DeploymentInstallerCleanupFailureInjected -and
+            if (-not $deploymentInstallerCleanupFailureState.Injected -and
                 $requestedPath -like '*.install.backup.*') {
-                $script:DeploymentInstallerCleanupFailureInjected = $true
+                $deploymentInstallerCleanupFailureState.Injected = $true
                 $removedPayloadPath = Join-Path $requestedPath 'app/previous-product.txt'
                 if (Test-Path -LiteralPath $removedPayloadPath) {
                     Microsoft.PowerShell.Management\Remove-Item `
@@ -1014,6 +1257,9 @@ try {
             }
         }
     }
+    Set-Item `
+        -LiteralPath Function:\Remove-Item `
+        -Value $deploymentInstallerRemoveItemOverride.GetNewClosure()
     try {
         $savedWarningPreference = $WarningPreference
         $WarningPreference = 'Stop'
@@ -1098,8 +1344,4 @@ finally {
         @(Get-ChildItem -LiteralPath $testBase -Force).Count -eq 0) {
         Microsoft.PowerShell.Management\Remove-Item -LiteralPath $testBase -Force
     }
-    Remove-Variable `
-        -Name DeploymentInstallerCleanupFailureInjected `
-        -Scope Global `
-        -ErrorAction SilentlyContinue
 }

--- a/tests/private/app/azureauth-credprovider/Install-DeploymentValidationBundle.Tests.ps1
+++ b/tests/private/app/azureauth-credprovider/Install-DeploymentValidationBundle.Tests.ps1
@@ -249,10 +249,7 @@ function New-ExistingInstallation {
     [CmdletBinding(SupportsShouldProcess)]
     param(
         [Parameter(Mandatory = $true)]
-        [string]$InstallRoot,
-
-        [Parameter(Mandatory = $true)]
-        [string]$NuGetPluginRoot
+        [string]$InstallRoot
     )
 
     if (-not $PSCmdlet.ShouldProcess($InstallRoot, 'Create existing test installation')) {
@@ -261,24 +258,18 @@ function New-ExistingInstallation {
 
     $applicationRoot = Join-Path $InstallRoot 'app'
     New-Item -ItemType Directory -Path $applicationRoot -Force | Out-Null
-    New-Item -ItemType Directory -Path $NuGetPluginRoot -Force | Out-Null
     Set-Content `
         -LiteralPath (Join-Path $applicationRoot 'previous-product.txt') `
         -Value 'previous product payload' `
         -NoNewline
-    Set-Content `
-        -LiteralPath (Join-Path $NuGetPluginRoot 'previous-plugin.txt') `
-        -Value 'previous plugin payload' `
-        -NoNewline
 
     $receipt = [ordered]@{
-        schemaVersion   = 'azureauth-credprovider-deployment-validation-install-v1'
+        schemaVersion   = 'azureauth-credprovider-deployment-validation-install-v2'
         productVersion  = '1.0.0-test'
         sourceRevision  = 'previous-revision'
         targetRid       = $targetRid
         installRoot     = [System.IO.Path]::GetFullPath($InstallRoot)
         applicationRoot = [System.IO.Path]::GetFullPath($applicationRoot)
-        nugetPluginRoot = [System.IO.Path]::GetFullPath($NuGetPluginRoot)
     }
     $receipt | ConvertTo-Json -Depth 5 |
         Set-Content -LiteralPath (Join-Path $InstallRoot 'installation.json') -Encoding utf8
@@ -290,9 +281,6 @@ function Assert-PreviousInstallationRestored {
         [string]$InstallRoot,
 
         [Parameter(Mandatory = $true)]
-        [string]$NuGetPluginRoot,
-
-        [Parameter(Mandatory = $true)]
         [string]$Context
     )
 
@@ -302,12 +290,6 @@ function Assert-PreviousInstallationRestored {
             Join-Path $InstallRoot 'app/previous-product.txt'
         ) -Raw) `
         -Message "The previous product payload was not restored after $Context."
-    Assert-Equal `
-        -Expected 'previous plugin payload' `
-        -Actual (Get-Content -LiteralPath (
-            Join-Path $NuGetPluginRoot 'previous-plugin.txt'
-        ) -Raw) `
-        -Message "The previous plugin payload was not restored after $Context."
 
     $receipt = Get-Content -LiteralPath (
         Join-Path $InstallRoot 'installation.json'
@@ -321,30 +303,23 @@ function Assert-PreviousInstallationRestored {
                 Join-Path $InstallRoot "app/$productExecutableName"
             ))
     ) "The replacement product payload remains after $Context."
-    Assert-True (
-        -not (Test-Path -LiteralPath (
-                Join-Path $NuGetPluginRoot 'azureauth-credprovider.dll'
-            ))
-    ) "The replacement plugin payload remains after $Context."
 
-    foreach ($targetPath in @($InstallRoot, $NuGetPluginRoot)) {
-        $trimmedPath = $targetPath.TrimEnd(
-            [System.IO.Path]::DirectorySeparatorChar,
-            [System.IO.Path]::AltDirectorySeparatorChar
-        )
-        $parentPath = [System.IO.Path]::GetDirectoryName($trimmedPath)
-        $leafName = [System.IO.Path]::GetFileName($trimmedPath)
-        $workingPaths = @(
-            Get-ChildItem -LiteralPath $parentPath -Force |
-                Where-Object {
-                    $_.Name -like ".$leafName.installing.*" -or
-                    $_.Name -like ".$leafName.backup.*"
-                }
-        )
-        Assert-True (
-            $workingPaths.Count -eq 0
-        ) "Replacement staging remains after $Context."
-    }
+    $trimmedPath = $InstallRoot.TrimEnd(
+        [System.IO.Path]::DirectorySeparatorChar,
+        [System.IO.Path]::AltDirectorySeparatorChar
+    )
+    $parentPath = [System.IO.Path]::GetDirectoryName($trimmedPath)
+    $leafName = [System.IO.Path]::GetFileName($trimmedPath)
+    $workingPaths = @(
+        Get-ChildItem -LiteralPath $parentPath -Force |
+            Where-Object {
+                $_.Name -like ".$leafName.installing.*" -or
+                $_.Name -like ".$leafName.backup.*"
+            }
+    )
+    Assert-True (
+        $workingPaths.Count -eq 0
+    ) "Replacement staging remains after $Context."
 }
 
 function Invoke-Installer {
@@ -354,16 +329,12 @@ function Invoke-Installer {
         [string]$BundleRoot,
 
         [Parameter(Mandatory = $true)]
-        [string]$InstallRoot,
-
-        [Parameter(Mandatory = $true)]
-        [string]$NuGetPluginRoot
+        [string]$InstallRoot
     )
 
     $parameters = @{
-        InstallRoot     = $InstallRoot
-        NuGetPluginRoot = $NuGetPluginRoot
-        Force           = $true
+        InstallRoot = $InstallRoot
+        Force       = $true
     }
     if ($PSBoundParameters.ContainsKey('WarningAction')) {
         $parameters.WarningAction = $PSBoundParameters.WarningAction
@@ -378,9 +349,6 @@ function Assert-ReplacementInstallationActive {
         [string]$InstallRoot,
 
         [Parameter(Mandatory = $true)]
-        [string]$NuGetPluginRoot,
-
-        [Parameter(Mandatory = $true)]
         [string]$Context
     )
 
@@ -390,12 +358,6 @@ function Assert-ReplacementInstallationActive {
             Join-Path $InstallRoot "app/$productExecutableName"
         ) -Raw) `
         -Message "The replacement product payload is not active after $Context."
-    Assert-Equal `
-        -Expected 'new plugin payload' `
-        -Actual (Get-Content -LiteralPath (
-            Join-Path $NuGetPluginRoot 'azureauth-credprovider.dll'
-        ) -Raw) `
-        -Message "The replacement plugin payload is not active after $Context."
 
     $receipt = Get-Content -LiteralPath (
         Join-Path $InstallRoot 'installation.json'
@@ -416,8 +378,8 @@ function Invoke-ActualUninstallRegression {
     $actualRoot = Join-Path $testRoot 'actual-uninstall'
     $extractedBundleRoot = Join-Path $actualRoot 'bundle'
     $installRoot = Join-Path $actualRoot 'install'
-    $pluginRoot = Join-Path $actualRoot 'plugin'
     $isolatedHome = Join-Path $actualRoot 'home'
+    $pluginRoot = Join-Path $isolatedHome '.nuget/plugins/netcore/azureauth-credprovider'
     $isolatedLocalAppData = Join-Path $actualRoot 'local-app-data'
     $isolatedTemp = Join-Path $actualRoot 'temp'
     $npmConfigPath = Join-Path $actualRoot 'npm/userconfig.npmrc'
@@ -462,11 +424,38 @@ function Invoke-ActualUninstallRegression {
     $heldGitMarkerPath = Join-Path $repoRoot '.git.deployment-validation-test'
 
     try {
-        & (Join-Path $extractedBundleRoot 'install.ps1') `
-            -InstallRoot $installRoot `
-            -NuGetPluginRoot $pluginRoot | Out-Null
+        & (Join-Path $extractedBundleRoot 'install.ps1') -InstallRoot $installRoot | Out-Null
+
+        Assert-True (
+            -not (Test-Path -LiteralPath $pluginRoot)
+        ) 'Physical installation unexpectedly activated the NuGet plugin.'
+
+        & (Join-Path $extractedBundleRoot 'uninstall.ps1') -InstallRoot $installRoot | Out-Null
+        Assert-True (
+            -not (Test-Path -LiteralPath $installRoot)
+        ) 'Uninstall before NuGet configuration left the product payload.'
+        Assert-True (
+            -not (Test-Path -LiteralPath $pluginRoot)
+        ) 'Uninstall before NuGet configuration created a NuGet activation.'
+
+        & (Join-Path $extractedBundleRoot 'install.ps1') -InstallRoot $installRoot | Out-Null
 
         $productExecutablePath = Join-Path $installRoot "app/$productExecutableName"
+        & $productExecutablePath configure nuget | Out-Null
+        Assert-Equal `
+            -Expected 0 `
+            -Actual $LASTEXITCODE `
+            -Message 'Actual NuGet configuration failed.'
+        Assert-True (
+            Test-Path -LiteralPath (
+                Join-Path $pluginRoot 'azureauth-credprovider.dll'
+            ) -PathType Leaf
+        ) 'NuGet configuration did not create a discoverable plugin activation.'
+        Set-Content `
+            -LiteralPath (Join-Path $pluginRoot 'preserve.txt') `
+            -Value 'unrelated activation-root content' `
+            -NoNewline
+
         if (-not $runningOnWindows) {
             & $productExecutablePath configure python | Out-Null
             Assert-Equal `
@@ -553,16 +542,22 @@ function Invoke-ActualUninstallRegression {
             -Value 'another job remains' `
             -NoNewline
 
-        & (Join-Path $extractedBundleRoot 'uninstall.ps1') `
-            -InstallRoot $installRoot `
-            -NuGetPluginRoot $pluginRoot | Out-Null
+        & (Join-Path $extractedBundleRoot 'uninstall.ps1') -InstallRoot $installRoot | Out-Null
 
         Assert-True (
             -not (Test-Path -LiteralPath $installRoot)
         ) 'Actual uninstall left the installed product payload.'
         Assert-True (
-            -not (Test-Path -LiteralPath $pluginRoot)
-        ) 'Actual uninstall left the NuGet plugin payload.'
+            -not (Test-Path -LiteralPath (
+                    Join-Path $pluginRoot 'azureauth-credprovider.dll'
+                ))
+        ) 'Actual uninstall left the product-owned NuGet plugin activation.'
+        Assert-Equal `
+            -Expected 'unrelated activation-root content' `
+            -Actual (Get-Content -LiteralPath (
+                Join-Path $pluginRoot 'preserve.txt'
+            ) -Raw) `
+            -Message 'Actual uninstall removed unrelated NuGet activation-root content.'
         $remainingCurrentJobFiles = [System.Collections.Generic.List[string]]::new()
         if (Test-Path -LiteralPath $currentJobRoot) {
             foreach ($file in Get-ChildItem -LiteralPath $currentJobRoot -File -Recurse -Force) {
@@ -624,21 +619,14 @@ try {
         $twiceNoBuildBundleRoot
     )
     $twiceNoBuildInstallRoot = Join-Path $testRoot 'twice-no-build-install'
-    $twiceNoBuildPluginRoot = Join-Path $testRoot 'twice-no-build-plugin'
     Invoke-Installer `
         -BundleRoot $twiceNoBuildBundleRoot `
-        -InstallRoot $twiceNoBuildInstallRoot `
-        -NuGetPluginRoot $twiceNoBuildPluginRoot
+        -InstallRoot $twiceNoBuildInstallRoot
     Assert-True (
         Test-Path -LiteralPath (
             Join-Path $twiceNoBuildInstallRoot "app/$productExecutableName"
         ) -PathType Leaf
     ) 'The twice-NoBuild bundle did not install its product payload.'
-    Assert-True (
-        Test-Path -LiteralPath (
-            Join-Path $twiceNoBuildPluginRoot 'azureauth-credprovider.dll'
-        ) -PathType Leaf
-    ) 'The twice-NoBuild bundle did not install its NuGet plugin payload.'
     $twiceNoBuildReceipt = Get-Content -LiteralPath (
         Join-Path $twiceNoBuildInstallRoot 'installation.json'
     ) -Raw | ConvertFrom-Json
@@ -678,10 +666,7 @@ try {
 
     $receiptFailureRoot = Join-Path $testRoot 'receipt-failure'
     $receiptFailureInstallRoot = Join-Path $receiptFailureRoot 'install'
-    $receiptFailurePluginRoot = Join-Path $receiptFailureRoot 'plugin'
-    New-ExistingInstallation `
-        -InstallRoot $receiptFailureInstallRoot `
-        -NuGetPluginRoot $receiptFailurePluginRoot
+    New-ExistingInstallation -InstallRoot $receiptFailureInstallRoot
 
     function global:Set-Content {
         [CmdletBinding()]
@@ -708,8 +693,7 @@ try {
         Assert-InvocationFailure {
             Invoke-Installer `
                 -BundleRoot $bundleRoot `
-                -InstallRoot $receiptFailureInstallRoot `
-                -NuGetPluginRoot $receiptFailurePluginRoot
+                -InstallRoot $receiptFailureInstallRoot
         } 'Expected the injected receipt write failure.'
     }
     finally {
@@ -719,17 +703,13 @@ try {
     }
     Assert-PreviousInstallationRestored `
         -InstallRoot $receiptFailureInstallRoot `
-        -NuGetPluginRoot $receiptFailurePluginRoot `
         -Context 'receipt staging failure'
 
     $switchFailureRoot = Join-Path $testRoot 'switch-failure'
     $switchFailureInstallRoot = Join-Path $switchFailureRoot 'install'
-    $switchFailurePluginRoot = Join-Path $switchFailureRoot 'plugin'
-    New-ExistingInstallation `
-        -InstallRoot $switchFailureInstallRoot `
-        -NuGetPluginRoot $switchFailurePluginRoot
+    New-ExistingInstallation -InstallRoot $switchFailureInstallRoot
 
-    $failureDestination = $switchFailurePluginRoot
+    $failureDestination = $switchFailureInstallRoot
     $moveItemOverride = {
         [CmdletBinding()]
         param(
@@ -747,7 +727,7 @@ try {
                 [System.IO.Path]::GetFullPath($failureDestination),
                 $testPathComparison
             )) {
-            throw 'Injected deterministic plugin activation failure.'
+            throw 'Injected deterministic product activation failure.'
         }
         Microsoft.PowerShell.Management\Move-Item @PSBoundParameters
     }
@@ -758,9 +738,8 @@ try {
         Assert-InvocationFailure {
             Invoke-Installer `
                 -BundleRoot $bundleRoot `
-                -InstallRoot $switchFailureInstallRoot `
-                -NuGetPluginRoot $switchFailurePluginRoot
-        } 'Expected the injected plugin activation failure.'
+                -InstallRoot $switchFailureInstallRoot
+        } 'Expected the injected product activation failure.'
     }
     finally {
         Microsoft.PowerShell.Management\Remove-Item `
@@ -769,15 +748,11 @@ try {
     }
     Assert-PreviousInstallationRestored `
         -InstallRoot $switchFailureInstallRoot `
-        -NuGetPluginRoot $switchFailurePluginRoot `
-        -Context 'plugin activation failure'
+        -Context 'product activation failure'
 
     $cleanupFailureRoot = Join-Path $testRoot 'cleanup-failure'
     $cleanupFailureInstallRoot = Join-Path $cleanupFailureRoot 'install'
-    $cleanupFailurePluginRoot = Join-Path $cleanupFailureRoot 'plugin'
-    New-ExistingInstallation `
-        -InstallRoot $cleanupFailureInstallRoot `
-        -NuGetPluginRoot $cleanupFailurePluginRoot
+    New-ExistingInstallation -InstallRoot $cleanupFailureInstallRoot
 
     $script:DeploymentInstallerCleanupFailureInjected = $false
     function global:Remove-Item {
@@ -834,7 +809,6 @@ try {
             Invoke-Installer `
                 -BundleRoot $bundleRoot `
                 -InstallRoot $cleanupFailureInstallRoot `
-                -NuGetPluginRoot $cleanupFailurePluginRoot `
                 -WarningAction Stop 3>&1
         )
     }
@@ -847,7 +821,6 @@ try {
 
     Assert-ReplacementInstallationActive `
         -InstallRoot $cleanupFailureInstallRoot `
-        -NuGetPluginRoot $cleanupFailurePluginRoot `
         -Context 'post-commit cleanup failure'
     $retainedBackups = @(
         Get-ChildItem -LiteralPath $cleanupFailureRoot -Directory -Force |
@@ -873,11 +846,9 @@ try {
 
     Invoke-Installer `
         -BundleRoot $bundleRoot `
-        -InstallRoot $cleanupFailureInstallRoot `
-        -NuGetPluginRoot $cleanupFailurePluginRoot
+        -InstallRoot $cleanupFailureInstallRoot
     Assert-ReplacementInstallationActive `
         -InstallRoot $cleanupFailureInstallRoot `
-        -NuGetPluginRoot $cleanupFailurePluginRoot `
         -Context 'rerun after post-commit cleanup failure'
     Assert-True (
         Test-Path -LiteralPath $retainedBackups[0].FullName -PathType Container

--- a/tests/private/app/azureauth-credprovider/Install-DeploymentValidationBundle.Tests.ps1
+++ b/tests/private/app/azureauth-credprovider/Install-DeploymentValidationBundle.Tests.ps1
@@ -9,6 +9,8 @@ $ErrorActionPreference = 'Stop'
 
 $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../../..')).ProviderPath
 $installerSource = Join-Path $repoRoot 'eng/scripts/azureauth-credprovider/Install-DeploymentValidationBundle.ps1'
+$uninstallerSource = Join-Path $repoRoot 'eng/scripts/azureauth-credprovider/Uninstall-DeploymentValidationBundle.ps1'
+$legacyNuGetSupportSource = Join-Path $repoRoot 'eng/scripts/azureauth-credprovider/DeploymentValidationLegacyNuGet.ps1'
 $bundleGeneratorSource = Join-Path $repoRoot 'eng/scripts/azureauth-credprovider/New-DeploymentValidationBundle.ps1'
 $testBase = Join-Path $repoRoot 'artifacts/azureauth-credprovider/deployment-installer-tests'
 $testRoot = Join-Path $testBase ([System.Guid]::NewGuid().ToString('N'))
@@ -117,7 +119,10 @@ function New-TestBundle {
     New-Item -ItemType Directory -Path $pythonRoot -Force | Out-Null
 
     Copy-Item -LiteralPath $installerSource -Destination (Join-Path $BundleRoot 'install.ps1')
-    Set-Content -LiteralPath (Join-Path $BundleRoot 'uninstall.ps1') -Value 'exit 0'
+    Copy-Item -LiteralPath $uninstallerSource -Destination (Join-Path $BundleRoot 'uninstall.ps1')
+    Copy-Item `
+        -LiteralPath $legacyNuGetSupportSource `
+        -Destination (Join-Path $BundleRoot 'legacy-nuget.ps1')
     Set-Content `
         -LiteralPath (Join-Path $appRoot $productExecutableName) `
         -Value 'new executable payload' `
@@ -275,6 +280,96 @@ function New-ExistingInstallation {
         Set-Content -LiteralPath (Join-Path $InstallRoot 'installation.json') -Encoding utf8
 }
 
+function New-F1LegacyInstallation {
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$InstallRoot,
+
+        [Parameter(Mandatory = $true)]
+        [string]$NuGetPluginRoot,
+
+        [Parameter(Mandatory = $true)]
+        [string]$OwnershipManifestPath
+    )
+
+    if (-not $PSCmdlet.ShouldProcess($InstallRoot, 'Create f1bf00d4 test installation')) {
+        return
+    }
+
+    $applicationRoot = Join-Path $InstallRoot 'app'
+    New-Item -ItemType Directory -Path (Join-Path $applicationRoot 'nested') -Force |
+        Out-Null
+    New-Item -ItemType Directory -Path (Join-Path $NuGetPluginRoot 'nested') -Force |
+        Out-Null
+    $payload = [ordered]@{
+        $productExecutableName       = 'legacy executable payload'
+        'azureauth-credprovider.dll' = 'legacy plugin entrypoint'
+        'nested/dependency.dll'      = 'legacy plugin dependency'
+    }
+    foreach ($entry in $payload.GetEnumerator()) {
+        Set-Content `
+            -LiteralPath (Join-Path $applicationRoot $entry.Key) `
+            -Value $entry.Value `
+            -NoNewline
+        Set-Content `
+            -LiteralPath (Join-Path $NuGetPluginRoot $entry.Key) `
+            -Value $entry.Value `
+            -NoNewline
+    }
+    Set-Content `
+        -LiteralPath (Join-Path $NuGetPluginRoot 'preserve.txt') `
+        -Value 'unrelated legacy-root content' `
+        -NoNewline
+    $legacyMarker = (
+        "azureauth-credprovider nuget-plugin-layout`n" +
+        "phase=10`n" +
+        "runtime=netcore`n" +
+        "entrypoint=azureauth-credprovider.dll`n"
+    )
+    [System.IO.File]::WriteAllText(
+        (Join-Path $NuGetPluginRoot '.azureauth-credprovider.nuget-plugin-layout'),
+        $legacyMarker,
+        [System.Text.UTF8Encoding]::new($false)
+    )
+    $ownershipManifest = [ordered]@{
+        schemaVersion  = 1
+        manifestId     = 'phase10-nuget-plugin-layout'
+        ownerProductId = 'azureauth-credprovider'
+        scope          = 'user'
+        entrySelector  = 'nuget.plugin-layout'
+        productVersion = 'phase10'
+        safeMetadata   = [ordered]@{}
+        entries        = @(
+            [ordered]@{
+                sequence         = 1
+                targetKind       = 'nuGetPluginLayout'
+                targetPathOrName = [System.IO.Path]::GetFullPath($NuGetPluginRoot)
+                key              = 'physical-target'
+            }
+        )
+    }
+    $ownershipManifestDirectory = Split-Path -Parent $OwnershipManifestPath
+    New-Item -ItemType Directory -Path $ownershipManifestDirectory -Force | Out-Null
+    [System.IO.File]::WriteAllText(
+        $OwnershipManifestPath,
+        ($ownershipManifest | ConvertTo-Json -Depth 10 -Compress),
+        [System.Text.UTF8Encoding]::new($false)
+    )
+
+    $receipt = [ordered]@{
+        schemaVersion   = 'azureauth-credprovider-deployment-validation-install-v1'
+        productVersion  = '1.0.0-test'
+        sourceRevision  = 'f1bf00d4'
+        targetRid       = $targetRid
+        installRoot     = [System.IO.Path]::GetFullPath($InstallRoot)
+        applicationRoot = [System.IO.Path]::GetFullPath($applicationRoot)
+        nugetPluginRoot = [System.IO.Path]::GetFullPath($NuGetPluginRoot)
+    }
+    $receipt | ConvertTo-Json -Depth 5 |
+        Set-Content -LiteralPath (Join-Path $InstallRoot 'installation.json') -Encoding utf8
+}
+
 function Assert-PreviousInstallationRestored {
     param(
         [Parameter(Mandatory = $true)]
@@ -329,12 +424,17 @@ function Invoke-Installer {
         [string]$BundleRoot,
 
         [Parameter(Mandatory = $true)]
-        [string]$InstallRoot
+        [string]$InstallRoot,
+
+        [string]$LegacyNuGetOwnershipManifestPath
     )
 
     $parameters = @{
         InstallRoot = $InstallRoot
         Force       = $true
+    }
+    if (-not [string]::IsNullOrWhiteSpace($LegacyNuGetOwnershipManifestPath)) {
+        $parameters.LegacyNuGetOwnershipManifestPath = $LegacyNuGetOwnershipManifestPath
     }
     if ($PSBoundParameters.ContainsKey('WarningAction')) {
         $parameters.WarningAction = $PSBoundParameters.WarningAction
@@ -663,6 +763,118 @@ try {
 
     $bundleRoot = Join-Path $testRoot 'bundle'
     New-TestBundle -BundleRoot $bundleRoot
+
+    $legacyUpgradeRoot = Join-Path $testRoot 'legacy-upgrade'
+    $legacyUpgradeInstallRoot = Join-Path $legacyUpgradeRoot 'install'
+    $legacyUpgradeNuGetRoot = Join-Path $legacyUpgradeRoot 'nuget'
+    $legacyUpgradeManifestPath = Join-Path $legacyUpgradeRoot 'state/ownership.json'
+    New-F1LegacyInstallation `
+        -InstallRoot $legacyUpgradeInstallRoot `
+        -NuGetPluginRoot $legacyUpgradeNuGetRoot `
+        -OwnershipManifestPath $legacyUpgradeManifestPath
+
+    Invoke-Installer `
+        -BundleRoot $bundleRoot `
+        -InstallRoot $legacyUpgradeInstallRoot `
+        -LegacyNuGetOwnershipManifestPath $legacyUpgradeManifestPath
+
+    $upgradedReceipt = Get-Content -LiteralPath (
+        Join-Path $legacyUpgradeInstallRoot 'installation.json'
+    ) -Raw | ConvertFrom-Json
+    Assert-Equal `
+        -Expected 'azureauth-credprovider-deployment-validation-install-v2' `
+        -Actual $upgradedReceipt.schemaVersion `
+        -Message 'Installer did not migrate the exact f1bf00d4 receipt to v2.'
+    foreach ($relativePath in @(
+            $productExecutableName,
+            'azureauth-credprovider.dll',
+            'nested/dependency.dll',
+            '.azureauth-credprovider.nuget-plugin-layout'
+        )) {
+        Assert-True (
+            -not (Test-Path -LiteralPath (Join-Path $legacyUpgradeNuGetRoot $relativePath))
+        ) "Installer left legacy product-owned NuGet content '$relativePath'."
+    }
+    Assert-Equal `
+        -Expected 'unrelated legacy-root content' `
+        -Actual (Get-Content -LiteralPath (
+            Join-Path $legacyUpgradeNuGetRoot 'preserve.txt'
+        ) -Raw) `
+        -Message 'Installer removed unrelated content from the legacy NuGet root.'
+    Assert-True (
+        -not (Test-Path -LiteralPath $legacyUpgradeManifestPath)
+    ) 'Installer left the exact f1bf00d4 ownership manifest.'
+
+    $legacyDriftRoot = Join-Path $testRoot 'legacy-drift'
+    $legacyDriftInstallRoot = Join-Path $legacyDriftRoot 'install'
+    $legacyDriftNuGetRoot = Join-Path $legacyDriftRoot 'nuget'
+    $legacyDriftManifestPath = Join-Path $legacyDriftRoot 'state/ownership.json'
+    New-F1LegacyInstallation `
+        -InstallRoot $legacyDriftInstallRoot `
+        -NuGetPluginRoot $legacyDriftNuGetRoot `
+        -OwnershipManifestPath $legacyDriftManifestPath
+    Set-Content `
+        -LiteralPath (Join-Path $legacyDriftNuGetRoot 'azureauth-credprovider.dll') `
+        -Value 'drifted legacy plugin entrypoint' `
+        -NoNewline
+
+    Assert-InvocationFailure {
+        Invoke-Installer `
+            -BundleRoot $bundleRoot `
+            -InstallRoot $legacyDriftInstallRoot `
+            -LegacyNuGetOwnershipManifestPath $legacyDriftManifestPath
+    } 'Expected legacy NuGet payload drift to block deployment replacement.'
+    $driftedReceipt = Get-Content -LiteralPath (
+        Join-Path $legacyDriftInstallRoot 'installation.json'
+    ) -Raw | ConvertFrom-Json
+    Assert-Equal `
+        -Expected 'azureauth-credprovider-deployment-validation-install-v1' `
+        -Actual $driftedReceipt.schemaVersion `
+        -Message 'Drifted legacy replacement changed the existing receipt.'
+    Assert-Equal `
+        -Expected 'drifted legacy plugin entrypoint' `
+        -Actual (Get-Content -LiteralPath (
+            Join-Path $legacyDriftNuGetRoot 'azureauth-credprovider.dll'
+        ) -Raw) `
+        -Message 'Drifted legacy replacement mutated the NuGet payload.'
+
+    $legacyUninstallRoot = Join-Path $testRoot 'legacy-uninstall'
+    $legacyUninstallInstallRoot = Join-Path $legacyUninstallRoot 'install'
+    $legacyUninstallNuGetRoot = Join-Path $legacyUninstallRoot 'nuget'
+    $legacyUninstallManifestPath = Join-Path $legacyUninstallRoot 'state/ownership.json'
+    New-F1LegacyInstallation `
+        -InstallRoot $legacyUninstallInstallRoot `
+        -NuGetPluginRoot $legacyUninstallNuGetRoot `
+        -OwnershipManifestPath $legacyUninstallManifestPath
+
+    & (Join-Path $bundleRoot 'uninstall.ps1') `
+        -InstallRoot $legacyUninstallInstallRoot `
+        -LegacyNuGetOwnershipManifestPath $legacyUninstallManifestPath `
+        -SkipConfigurationCleanup |
+        Out-Null
+
+    Assert-True (
+        -not (Test-Path -LiteralPath $legacyUninstallInstallRoot)
+    ) 'SkipConfigurationCleanup uninstall left the legacy product payload.'
+    foreach ($relativePath in @(
+            $productExecutableName,
+            'azureauth-credprovider.dll',
+            'nested/dependency.dll',
+            '.azureauth-credprovider.nuget-plugin-layout'
+        )) {
+        Assert-True (
+            -not (Test-Path -LiteralPath (Join-Path $legacyUninstallNuGetRoot $relativePath))
+        ) "SkipConfigurationCleanup uninstall left legacy NuGet content '$relativePath'."
+    }
+    Assert-Equal `
+        -Expected 'unrelated legacy-root content' `
+        -Actual (Get-Content -LiteralPath (
+            Join-Path $legacyUninstallNuGetRoot 'preserve.txt'
+        ) -Raw) `
+        -Message 'SkipConfigurationCleanup uninstall removed unrelated NuGet content.'
+    Assert-True (
+        -not (Test-Path -LiteralPath $legacyUninstallManifestPath)
+    ) 'SkipConfigurationCleanup uninstall left the exact f1bf00d4 ownership manifest.'
 
     $receiptFailureRoot = Join-Path $testRoot 'receipt-failure'
     $receiptFailureInstallRoot = Join-Path $receiptFailureRoot 'install'

--- a/tests/private/app/azureauth-credprovider/Install-DeploymentValidationBundle.Tests.ps1
+++ b/tests/private/app/azureauth-credprovider/Install-DeploymentValidationBundle.Tests.ps1
@@ -532,9 +532,34 @@ function Invoke-ActualUninstallRegression {
     $installRoot = Join-Path $actualRoot 'install'
     $isolatedHome = Join-Path $actualRoot 'home'
     $pluginRoot = Join-Path $isolatedHome '.nuget/plugins/netcore/azureauth-credprovider'
+    $isolatedNuGetState = Join-Path $actualRoot 'nuget-state'
+    $nugetOwnershipManifestPath = Join-Path (
+        Join-Path $isolatedNuGetState 'manifests'
+    ) 'nuget-plugin-layout-ownership-manifest.json'
     $isolatedLocalAppData = Join-Path $actualRoot 'local-app-data'
     $isolatedTemp = Join-Path $actualRoot 'temp'
     $npmConfigPath = Join-Path $actualRoot 'npm/userconfig.npmrc'
+    $processHelperNonce = [System.Guid]::NewGuid().ToString('N')
+    $testApphostPath = $null
+    $realNuGetPaths = @()
+    if ($runningOnWindows) {
+        $testApphostPath = Join-Path $repoRoot (
+            'tests/private/app/azureauth-credprovider/' +
+            'Hcoona.AzureAuth.CredProvider.Platform.Tests/bin/Release/net10.0/' +
+            'Hcoona.AzureAuth.CredProvider.Platform.Tests.exe'
+        )
+        $realUserProfile = [Environment]::GetFolderPath(
+            [Environment+SpecialFolder]::UserProfile
+        )
+        $realLocalAppData = [Environment]::GetFolderPath(
+            [Environment+SpecialFolder]::LocalApplicationData
+        )
+        $realNuGetPaths = @(
+            Join-Path $realUserProfile '.nuget/plugins/netcore/azureauth-credprovider'
+            Join-Path $realUserProfile '.azureauth-credprovider/phase10'
+            Join-Path $realLocalAppData 'azureauth-credprovider/phase10'
+        )
+    }
     New-Item -ItemType Directory -Path $extractedBundleRoot -Force | Out-Null
     New-Item -ItemType Directory -Path $isolatedHome -Force | Out-Null
     New-Item -ItemType Directory -Path $isolatedLocalAppData -Force | Out-Null
@@ -563,6 +588,10 @@ function Invoke-ActualUninstallRegression {
     $environment['SYSTEM_ACCESSTOKEN'] = $token
     $environment['SYSTEM_JOBID'] = $jobId
     $environment['TF_BUILD'] = 'True'
+    if ($runningOnWindows) {
+        $environment['AZUREAUTH_PROCESS_HELPER'] = '1'
+        $environment['AZUREAUTH_PROCESS_HELPER_NONCE'] = $processHelperNonce
+    }
     $savedEnvironment = [System.Collections.Generic.Dictionary[string, string]]::new(
         [System.StringComparer]::Ordinal
     )
@@ -576,13 +605,47 @@ function Invoke-ActualUninstallRegression {
     $heldGitMarkerPath = Join-Path $repoRoot '.git.deployment-validation-test'
 
     try {
+        if ($runningOnWindows) {
+            & dotnet build (
+                Join-Path $repoRoot (
+                    'tests/private/app/azureauth-credprovider/' +
+                    'Hcoona.AzureAuth.CredProvider.Platform.Tests/' +
+                    'Hcoona.AzureAuth.CredProvider.Platform.Tests.csproj'
+                )
+            ) `
+                --configuration Release `
+                -p:RestoreLockedMode=true `
+                --nologo `
+                --verbosity quiet
+            Assert-Equal `
+                -Expected 0 `
+                -Actual $LASTEXITCODE `
+                -Message 'The Windows deployment validation test host build failed.'
+            Assert-True (
+                Test-Path -LiteralPath $testApphostPath -PathType Leaf
+            ) 'The Windows deployment validation test host was not built in Release.'
+            foreach ($realNuGetPath in $realNuGetPaths) {
+                Assert-True (
+                    -not (Test-Path -LiteralPath $realNuGetPath)
+                ) "The Windows runner already contains product NuGet state '$realNuGetPath'."
+            }
+        }
+
         & (Join-Path $extractedBundleRoot 'install.ps1') -InstallRoot $installRoot | Out-Null
 
         Assert-True (
             -not (Test-Path -LiteralPath $pluginRoot)
         ) 'Physical installation unexpectedly activated the NuGet plugin.'
 
-        & (Join-Path $extractedBundleRoot 'uninstall.ps1') -InstallRoot $installRoot | Out-Null
+        if ($runningOnWindows) {
+            & (Join-Path $extractedBundleRoot 'uninstall.ps1') `
+                -InstallRoot $installRoot `
+                -SkipConfigurationCleanup | Out-Null
+        }
+        else {
+            & (Join-Path $extractedBundleRoot 'uninstall.ps1') -InstallRoot $installRoot |
+                Out-Null
+        }
         Assert-True (
             -not (Test-Path -LiteralPath $installRoot)
         ) 'Uninstall before NuGet configuration left the product payload.'
@@ -593,16 +656,61 @@ function Invoke-ActualUninstallRegression {
         & (Join-Path $extractedBundleRoot 'install.ps1') -InstallRoot $installRoot | Out-Null
 
         $productExecutablePath = Join-Path $installRoot "app/$productExecutableName"
-        & $productExecutablePath configure nuget | Out-Null
-        Assert-Equal `
-            -Expected 0 `
-            -Actual $LASTEXITCODE `
-            -Message 'Actual NuGet configuration failed.'
+        if ($runningOnWindows) {
+            $harnessArguments = @(
+                '--process-helper'
+                '--process-helper-nonce'
+                $processHelperNonce
+                'deployment-validation-nuget-lifecycle'
+                'configure'
+                $isolatedNuGetState
+                (Join-Path $installRoot 'app')
+                $isolatedHome
+            )
+            $harnessOutput = @(& $testApphostPath @harnessArguments)
+            Assert-Equal `
+                -Expected 0 `
+                -Actual $LASTEXITCODE `
+                -Message 'The isolated Windows NuGet configure harness failed.'
+            Assert-Equal `
+                -Expected 'configure' `
+                -Actual (($harnessOutput -join "`n").Trim()) `
+                -Message 'The isolated Windows NuGet configure harness returned unexpected output.'
+        }
+        else {
+            & $productExecutablePath configure nuget | Out-Null
+            Assert-Equal `
+                -Expected 0 `
+                -Actual $LASTEXITCODE `
+                -Message 'Actual NuGet configuration failed.'
+        }
         Assert-True (
             Test-Path -LiteralPath (
                 Join-Path $pluginRoot 'azureauth-credprovider.dll'
             ) -PathType Leaf
         ) 'NuGet configuration did not create a discoverable plugin activation.'
+        if ($runningOnWindows) {
+            Assert-True (
+                Test-Path -LiteralPath $nugetOwnershipManifestPath -PathType Leaf
+            ) 'The isolated Windows NuGet state root does not contain its ownership manifest.'
+            Assert-Equal `
+                -Expected (
+                Get-FileHash `
+                    -LiteralPath (Join-Path $installRoot 'app/azureauth-credprovider.dll') `
+                    -Algorithm SHA256
+            ).Hash `
+                -Actual (
+                Get-FileHash `
+                    -LiteralPath (Join-Path $pluginRoot 'azureauth-credprovider.dll') `
+                    -Algorithm SHA256
+            ).Hash `
+                -Message 'The isolated activation did not use the installed application payload.'
+            foreach ($realNuGetPath in $realNuGetPaths) {
+                Assert-True (
+                    -not (Test-Path -LiteralPath $realNuGetPath)
+                ) "Isolated Windows NuGet configure wrote real-profile state '$realNuGetPath'."
+            }
+        }
         Set-Content `
             -LiteralPath (Join-Path $pluginRoot 'preserve.txt') `
             -Value 'unrelated activation-root content' `
@@ -694,7 +802,41 @@ function Invoke-ActualUninstallRegression {
             -Value 'another job remains' `
             -NoNewline
 
-        & (Join-Path $extractedBundleRoot 'uninstall.ps1') -InstallRoot $installRoot | Out-Null
+        if ($runningOnWindows) {
+            $harnessArguments[4] = 'unconfigure'
+            $harnessOutput = @(& $testApphostPath @harnessArguments)
+            Assert-Equal `
+                -Expected 0 `
+                -Actual $LASTEXITCODE `
+                -Message 'The isolated Windows NuGet unconfigure harness failed.'
+            Assert-Equal `
+                -Expected 'unconfigure' `
+                -Actual (($harnessOutput -join "`n").Trim()) `
+                -Message 'The Windows NuGet unconfigure harness returned unexpected output.'
+            Assert-True (
+                -not (Test-Path -LiteralPath (
+                        Join-Path $pluginRoot 'azureauth-credprovider.dll'
+                    )) -and
+                -not (Test-Path -LiteralPath $nugetOwnershipManifestPath)
+            ) 'The isolated Windows NuGet harness left owned activation state.'
+            foreach ($realNuGetPath in $realNuGetPaths) {
+                Assert-True (
+                    -not (Test-Path -LiteralPath $realNuGetPath)
+                ) "Isolated Windows NuGet cleanup wrote real-profile state '$realNuGetPath'."
+            }
+            & $productExecutablePath cleanup --ci azure-pipelines | Out-Null
+            Assert-Equal `
+                -Expected 0 `
+                -Actual $LASTEXITCODE `
+                -Message 'Windows Azure Pipelines configuration cleanup failed.'
+            & (Join-Path $extractedBundleRoot 'uninstall.ps1') `
+                -InstallRoot $installRoot `
+                -SkipConfigurationCleanup | Out-Null
+        }
+        else {
+            & (Join-Path $extractedBundleRoot 'uninstall.ps1') -InstallRoot $installRoot |
+                Out-Null
+        }
 
         Assert-True (
             -not (Test-Path -LiteralPath $installRoot)


### PR DESCRIPTION
## Summary

- Keep physical deployment payload-only and move conventional NuGet plugin activation into `configure nuget` and `unconfigure nuget`.
- Track copied activation through verified inventory, write-free no-op detection, refresh classification, retry-safe catchable failures, and unrelated-content preservation.
- Support only the exact previous-main legacy state with authoritative validation while keeping unknown, drifted, or conflicting state fail-closed.

## Validation

- NuGet and ConfigurationManager scenarios: 69 passed
- Platform: 1,423 passed, 2 skipped
- CLI: 341 passed
- Contracts: 790 passed
- Deployment installer and fresh-bundle lifecycle scenarios passed
- PowerShell formatting and ScriptAnalyzer passed
- Branch-range HK small/medium/large passed
- Three terminal OCR reviewers reported no findings