### PR TITLE
fix(azureauth): Report Effective NuGet Plugin Discovery

### DIFF
--- a/src/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Cli/CliApplication.cs
+++ b/src/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Cli/CliApplication.cs
@@ -3263,6 +3263,26 @@ internal static class CliApplication
                 + GetCheckStatusText(doctorResult.InteractivePolicyGuidanceSuccess),
             "nuget-environment-overrides: "
                 + (doctorResult.OptionalEnvironmentOverridesAbsent ? "absent" : "present"),
+            "nuget-plugin-discovery-source: "
+                + GetNuGetPluginDiscoverySourceText(doctorResult.EffectivePlugin.Source),
+            "nuget-product-plugin-discovery: "
+                + GetNuGetProductPluginDiscoveryText(
+                    doctorResult.EffectivePlugin.ProductDiscovery
+                ),
+            "nuget-operational-plugin-selection: "
+                + GetNuGetOperationalPluginSelectionText(
+                    doctorResult.EffectivePlugin.OperationalSelection
+                ),
+            "nuget-override-product-inclusion: "
+                + GetNuGetOverrideProductInclusionText(
+                    doctorResult.EffectivePlugin.OverrideProductInclusion
+                ),
+            "nuget-plugin-override-truncated: "
+                + GetYesNo(doctorResult.EffectivePlugin.OverrideEntriesTruncated),
+            "nuget-product-plugin-remediation: "
+                + GetNuGetProductPluginRemediationText(
+                    doctorResult.EffectivePlugin.Remediation
+                ),
         ];
         if (doctorResult.ConfigurationState == NuGetConfigurationState.Refreshable)
         {
@@ -3695,6 +3715,84 @@ internal static class CliApplication
             _ => throw new ArgumentOutOfRangeException(nameof(state), state, null),
         };
 
+    private static string GetNuGetPluginDiscoverySourceText(
+        NuGetPluginDiscoverySource source
+    ) =>
+        source switch
+        {
+            NuGetPluginDiscoverySource.Conventional => "conventional",
+            NuGetPluginDiscoverySource.NuGetPluginPaths => "NUGET_PLUGIN_PATHS",
+            NuGetPluginDiscoverySource.NuGetNetCorePluginPaths =>
+                "NUGET_NETCORE_PLUGIN_PATHS",
+            _ => throw new ArgumentOutOfRangeException(nameof(source), source, null),
+        };
+
+    private static string GetNuGetProductPluginDiscoveryText(
+        NuGetProductPluginDiscoveryState discovery
+    ) =>
+        discovery switch
+        {
+            NuGetProductPluginDiscoveryState.NotFound => "not-found",
+            NuGetProductPluginDiscoveryState.DiscoverableCandidate =>
+                "discoverable-candidate",
+            NuGetProductPluginDiscoveryState.OverrideExcludesProduct =>
+                "override-excludes-product",
+            NuGetProductPluginDiscoveryState.IncludedPathMissing =>
+                "included-path-missing",
+            NuGetProductPluginDiscoveryState.InspectionIncomplete =>
+                "inspection-incomplete",
+            _ => throw new ArgumentOutOfRangeException(nameof(discovery), discovery, null),
+        };
+
+    private static string GetNuGetOperationalPluginSelectionText(
+        NuGetOperationalPluginSelectionState selection
+    ) =>
+        selection switch
+        {
+            NuGetOperationalPluginSelectionState.DeferredNotProbed =>
+                "deferred-not-probed",
+            _ => throw new ArgumentOutOfRangeException(nameof(selection), selection, null),
+        };
+
+    private static string GetNuGetOverrideProductInclusionText(
+        NuGetOverrideProductInclusionState inclusion
+    ) =>
+        inclusion switch
+        {
+            NuGetOverrideProductInclusionState.NotApplicable => "not-applicable",
+            NuGetOverrideProductInclusionState.IncludesProduct => "includes-product",
+            NuGetOverrideProductInclusionState.ExcludesProduct => "excludes-product",
+            NuGetOverrideProductInclusionState.InspectionIncomplete =>
+                "inspection-incomplete",
+            _ => throw new ArgumentOutOfRangeException(nameof(inclusion), inclusion, null),
+        };
+
+    private static string GetNuGetProductPluginRemediationText(
+        NuGetProductPluginRemediation remediation
+    ) =>
+        remediation switch
+        {
+            NuGetProductPluginRemediation.None => "none",
+            NuGetProductPluginRemediation.InstallConventionalPlugin =>
+                "install the product plugin under the conventional netcore plugin path",
+            NuGetProductPluginRemediation.ClearOrIncludeProductInNuGetPluginPaths =>
+                "clear NUGET_PLUGIN_PATHS or include the product plugin entrypoint",
+            NuGetProductPluginRemediation.ClearOrIncludeProductInNuGetNetCorePluginPaths =>
+                "clear NUGET_NETCORE_PLUGIN_PATHS or include the product plugin entrypoint",
+            NuGetProductPluginRemediation.RestoreIncludedProductPath =>
+                "restore the product plugin entrypoint included by the effective override",
+            NuGetProductPluginRemediation.ShortenOverrideAndRerunDoctor =>
+                "shorten the effective NuGet plugin path override and rerun doctor",
+            NuGetProductPluginRemediation.SelectionDeferredNotProbed =>
+                "candidate discovered; operational selection is determined by NuGet at runtime "
+                + "and was not probed",
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(remediation),
+                remediation,
+                null
+            ),
+        };
+
     private static string[] GetPlannedActions(
         CliCommand command,
         CredentialEcosystem ecosystem,
@@ -3970,19 +4068,26 @@ internal static class CliApplication
     {
         ArgumentNullException.ThrowIfNull(doctorResult);
 
-        return doctorResult.ConfigurationPlanValid
+        bool commonChecksPass =
+            doctorResult.ConfigurationPlanValid
             && doctorResult.AzureArtifactsSourceCanonicalizationSuccess
-            && doctorResult.InteractivePolicyGuidanceSuccess
-            && doctorResult.OptionalEnvironmentOverridesAbsent
-            && (
-                NuGetDoctorStateAbsent(doctorResult)
-                || (
-                    doctorResult.PluginLayoutMarkerPresent
-                    && doctorResult.OwnershipManifestPresent
-                    && doctorResult.NetCorePluginEntrypointPresent
-                    && doctorResult.PluginModeEntrypointResolvable
-                )
-            );
+            && doctorResult.InteractivePolicyGuidanceSuccess;
+        bool neutralAbsence =
+            NuGetDoctorStateAbsent(doctorResult)
+            && doctorResult.EffectivePlugin.Source
+                == NuGetPluginDiscoverySource.Conventional;
+        bool structurallyReadyCandidate =
+            doctorResult.PluginLayoutMarkerPresent
+            && doctorResult.OwnershipManifestPresent
+            && doctorResult.NetCorePluginEntrypointPresent
+            && doctorResult.PluginModeEntrypointResolvable
+            && doctorResult.EffectivePlugin.ProductDiscovery
+                == NuGetProductPluginDiscoveryState.DiscoverableCandidate
+            && !doctorResult.EffectivePlugin.OverrideEntriesTruncated
+            && doctorResult.EffectivePlugin.OverrideProductInclusion
+                is NuGetOverrideProductInclusionState.NotApplicable
+                    or NuGetOverrideProductInclusionState.IncludesProduct;
+        return commonChecksPass && (neutralAbsence || structurallyReadyCandidate);
     }
 
     private static bool NuGetDoctorStateAbsent(NuGetPhase10DoctorResult doctorResult) =>

--- a/src/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform/VerticalSlice/NuGetPhase10VerticalSliceService.cs
+++ b/src/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform/VerticalSlice/NuGetPhase10VerticalSliceService.cs
@@ -73,11 +73,74 @@ public sealed record NuGetPhase10UnconfigureResult
     public required bool OwnershipManifestPresent { get; init; }
 }
 
+public enum NuGetPluginDiscoverySource
+{
+    Conventional = 1,
+    NuGetPluginPaths = 2,
+    NuGetNetCorePluginPaths = 3,
+}
+
+public enum NuGetProductPluginDiscoveryState
+{
+    NotFound = 1,
+    DiscoverableCandidate = 2,
+    OverrideExcludesProduct = 3,
+    IncludedPathMissing = 4,
+    InspectionIncomplete = 5,
+}
+
+public enum NuGetOperationalPluginSelectionState
+{
+    DeferredNotProbed = 1,
+}
+
+public enum NuGetOverrideProductInclusionState
+{
+    NotApplicable = 1,
+    IncludesProduct = 2,
+    ExcludesProduct = 3,
+    InspectionIncomplete = 4,
+}
+
+public enum NuGetProductPluginRemediation
+{
+    None = 0,
+    InstallConventionalPlugin = 1,
+    ClearOrIncludeProductInNuGetPluginPaths = 2,
+    ClearOrIncludeProductInNuGetNetCorePluginPaths = 3,
+    RestoreIncludedProductPath = 4,
+    ShortenOverrideAndRerunDoctor = 5,
+    SelectionDeferredNotProbed = 6,
+}
+
 public enum NuGetConfigurationState
 {
     Valid = 1,
     Refreshable = 2,
     Unrecognized = 3,
+}
+
+public sealed record NuGetEffectivePluginDiagnostics
+{
+    public required NuGetPluginDiscoverySource Source { get; init; }
+
+    public required NuGetProductPluginDiscoveryState ProductDiscovery { get; init; }
+
+    public required NuGetOperationalPluginSelectionState OperationalSelection { get; init; }
+
+    public required NuGetOverrideProductInclusionState OverrideProductInclusion
+    {
+        get;
+        init;
+    }
+
+    public required NuGetProductPluginRemediation Remediation { get; init; }
+
+    public required bool NuGetPluginPathsOverridePresent { get; init; }
+
+    public required bool NuGetNetCorePluginPathsOverridePresent { get; init; }
+
+    public required bool OverrideEntriesTruncated { get; init; }
 }
 
 public sealed record NuGetPhase10DoctorResult
@@ -101,6 +164,8 @@ public sealed record NuGetPhase10DoctorResult
     public required bool InteractivePolicyGuidanceSuccess { get; init; }
 
     public required bool OptionalEnvironmentOverridesAbsent { get; init; }
+
+    public required NuGetEffectivePluginDiagnostics EffectivePlugin { get; init; }
 }
 
 public sealed class NuGetPhase10UnrecognizedStateException : InvalidOperationException
@@ -122,6 +187,8 @@ public sealed class NuGetPhase10VerticalSliceService
     private const string PhysicalTargetKey = "physical-target";
     private const string NuGetPluginPathsEnvironmentVariable = "NUGET_PLUGIN_PATHS";
     private const string NuGetNetCorePluginPathsEnvironmentVariable = "NUGET_NETCORE_PLUGIN_PATHS";
+    private const int MaximumOverrideValueLength = 64 * 1024;
+    private const int MaximumOverrideEntries = 128;
 
     private static readonly Uri OrganizationScopedSource = new(
         "https://pkgs.dev.azure.com/org/_packaging/feed/nuget/v3/index.json"
@@ -317,6 +384,9 @@ public sealed class NuGetPhase10VerticalSliceService
         bool netCorePluginEntrypointPresent = TryPluginEntrypointExists();
         bool pluginModeEntrypointResolvable =
             netCorePluginEntrypointPresent && TryResolvePluginModeEntrypoint();
+        NuGetEffectivePluginDiagnostics effectivePlugin = InspectEffectivePluginDiscovery(
+            netCorePluginEntrypointPresent
+        );
 
         return new NuGetPhase10DoctorResult
         {
@@ -330,7 +400,10 @@ public sealed class NuGetPhase10VerticalSliceService
             AzureArtifactsSourceCanonicalizationSuccess =
                 TryValidateAzureArtifactsSourceCanonicalization(),
             InteractivePolicyGuidanceSuccess = TryValidateInteractivePolicyGuidance(),
-            OptionalEnvironmentOverridesAbsent = OptionalEnvironmentOverridesAreAbsent(),
+            OptionalEnvironmentOverridesAbsent =
+                !effectivePlugin.NuGetPluginPathsOverridePresent
+                && !effectivePlugin.NuGetNetCorePluginPathsOverridePresent,
+            EffectivePlugin = effectivePlugin,
         };
     }
 
@@ -742,14 +815,189 @@ public sealed class NuGetPhase10VerticalSliceService
         return parseResult.Status == expectedStatus && parseResult.Resource is null;
     }
 
-    private bool OptionalEnvironmentOverridesAreAbsent()
+    private NuGetEffectivePluginDiagnostics InspectEffectivePluginDiscovery(
+        bool productEntrypointPresent
+    )
     {
-        return string.IsNullOrWhiteSpace(
-                environmentVariableReader(NuGetPluginPathsEnvironmentVariable)
-            )
-            && string.IsNullOrWhiteSpace(
-                environmentVariableReader(NuGetNetCorePluginPathsEnvironmentVariable)
+        NuGetPluginOverrideInspection nuGetPluginPaths = InspectPluginOverride(
+            environmentVariableReader(NuGetPluginPathsEnvironmentVariable)
+        );
+        NuGetPluginOverrideInspection nuGetNetCorePluginPaths = InspectPluginOverride(
+            environmentVariableReader(NuGetNetCorePluginPathsEnvironmentVariable)
+        );
+        NuGetPluginDiscoverySource source =
+            nuGetNetCorePluginPaths.Present
+                ? NuGetPluginDiscoverySource.NuGetNetCorePluginPaths
+            : nuGetPluginPaths.Present
+                ? NuGetPluginDiscoverySource.NuGetPluginPaths
+                : NuGetPluginDiscoverySource.Conventional;
+        NuGetPluginOverrideInspection effectiveOverride =
+            source == NuGetPluginDiscoverySource.NuGetNetCorePluginPaths
+                ? nuGetNetCorePluginPaths
+                : nuGetPluginPaths;
+
+        NuGetOverrideProductInclusionState overrideProductInclusion =
+            source == NuGetPluginDiscoverySource.Conventional
+                ? NuGetOverrideProductInclusionState.NotApplicable
+            : effectiveOverride.IncludesProductEntrypoint is null
+                ? NuGetOverrideProductInclusionState.InspectionIncomplete
+            : effectiveOverride.IncludesProductEntrypoint.Value
+                ? NuGetOverrideProductInclusionState.IncludesProduct
+                : NuGetOverrideProductInclusionState.ExcludesProduct;
+        NuGetProductPluginDiscoveryState productDiscovery =
+            overrideProductInclusion == NuGetOverrideProductInclusionState.InspectionIncomplete
+                ? NuGetProductPluginDiscoveryState.InspectionIncomplete
+            : source == NuGetPluginDiscoverySource.Conventional
+                ? productEntrypointPresent
+                    ? NuGetProductPluginDiscoveryState.DiscoverableCandidate
+                    : NuGetProductPluginDiscoveryState.NotFound
+            : overrideProductInclusion == NuGetOverrideProductInclusionState.ExcludesProduct
+                ? NuGetProductPluginDiscoveryState.OverrideExcludesProduct
+            : productEntrypointPresent
+                ? NuGetProductPluginDiscoveryState.DiscoverableCandidate
+                : NuGetProductPluginDiscoveryState.IncludedPathMissing;
+        return new NuGetEffectivePluginDiagnostics
+        {
+            Source = source,
+            ProductDiscovery = productDiscovery,
+            OperationalSelection = NuGetOperationalPluginSelectionState.DeferredNotProbed,
+            OverrideProductInclusion = overrideProductInclusion,
+            Remediation = GetPluginRemediation(source, productDiscovery),
+            NuGetPluginPathsOverridePresent = nuGetPluginPaths.Present,
+            NuGetNetCorePluginPathsOverridePresent = nuGetNetCorePluginPaths.Present,
+            OverrideEntriesTruncated =
+                effectiveOverride.ValueTooLarge || effectiveOverride.EntryCountExceeded,
+        };
+    }
+
+    private NuGetPluginOverrideInspection InspectPluginOverride(string? value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return NuGetPluginOverrideInspection.Absent;
+        }
+
+        if (value.Length > MaximumOverrideValueLength)
+        {
+            return new NuGetPluginOverrideInspection(
+                Present: true,
+                IncludesProductEntrypoint: null,
+                ValueTooLarge: true,
+                EntryCountExceeded: false
             );
+        }
+
+        string[] entries = value.Split(
+            GetOverridePathSeparator(),
+            StringSplitOptions.RemoveEmptyEntries
+        );
+        if (entries.Length > MaximumOverrideEntries)
+        {
+            return new NuGetPluginOverrideInspection(
+                Present: true,
+                IncludesProductEntrypoint: null,
+                ValueTooLarge: false,
+                EntryCountExceeded: true
+            );
+        }
+
+        bool includesProductEntrypoint = entries.Any(IsProductPluginEntrypointPath);
+        return new NuGetPluginOverrideInspection(
+            Present: true,
+            IncludesProductEntrypoint: includesProductEntrypoint,
+            ValueTooLarge: false,
+            EntryCountExceeded: false
+        );
+    }
+
+    private bool IsProductPluginEntrypointPath(string candidate)
+    {
+        try
+        {
+            if (!IsNuGetAbsolutePluginPath(candidate))
+            {
+                return false;
+            }
+
+            return string.Equals(
+                NormalizeComparablePath(candidate),
+                NormalizeComparablePath(paths.PluginEntrypointPath),
+                FileSystemPathSemantics.GetComparison(fileSystem)
+            );
+        }
+        catch (Exception exception) when (
+            exception is ArgumentException or IOException or NotSupportedException
+        )
+        {
+            return false;
+        }
+    }
+
+    private static NuGetProductPluginRemediation GetPluginRemediation(
+        NuGetPluginDiscoverySource source,
+        NuGetProductPluginDiscoveryState discovery
+    ) =>
+        discovery switch
+        {
+            NuGetProductPluginDiscoveryState.DiscoverableCandidate =>
+                NuGetProductPluginRemediation.SelectionDeferredNotProbed,
+            NuGetProductPluginDiscoveryState.NotFound =>
+                NuGetProductPluginRemediation.InstallConventionalPlugin,
+            NuGetProductPluginDiscoveryState.IncludedPathMissing =>
+                NuGetProductPluginRemediation.RestoreIncludedProductPath,
+            NuGetProductPluginDiscoveryState.OverrideExcludesProduct =>
+                source == NuGetPluginDiscoverySource.NuGetNetCorePluginPaths
+                    ? NuGetProductPluginRemediation
+                        .ClearOrIncludeProductInNuGetNetCorePluginPaths
+                    : NuGetProductPluginRemediation.ClearOrIncludeProductInNuGetPluginPaths,
+            NuGetProductPluginDiscoveryState.InspectionIncomplete =>
+                NuGetProductPluginRemediation.ShortenOverrideAndRerunDoctor,
+            _ => throw new ArgumentOutOfRangeException(nameof(discovery), discovery, null),
+        };
+
+    private char GetOverridePathSeparator() =>
+        FileSystemPathSemantics.UsesWindowsPaths(fileSystem) ? ';' : ':';
+
+    private bool IsNuGetAbsolutePluginPath(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return false;
+        }
+
+        if (FileSystemPathSemantics.UsesWindowsPaths(fileSystem))
+        {
+            bool drivePath =
+                path.Length >= 3
+                && char.IsAsciiLetter(path[0])
+                && path[1] == ':'
+                && path[2] == '\\';
+            bool uncPath = HasWindowsUncRoot(path);
+            return (drivePath || uncPath)
+                && fileSystem.IsPathFullyQualified(path);
+        }
+
+        return path.StartsWith('/')
+            && fileSystem.IsPathFullyQualified(path);
+    }
+
+    private static bool HasWindowsUncRoot(string path)
+    {
+        if (!path.StartsWith(@"\\", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        int serverEnd = path.IndexOfAny(['\\', '/'], 2);
+        if (serverEnd <= 2)
+        {
+            return false;
+        }
+
+        int shareEnd = path.IndexOfAny(['\\', '/'], serverEnd + 1);
+        return shareEnd < 0
+            ? serverEnd + 1 < path.Length
+            : shareEnd > serverEnd + 1;
     }
 
     private static bool HasExpectedManifestMetadata(ConfigurationOwnershipManifest manifest) =>
@@ -790,7 +1038,7 @@ public sealed class NuGetPhase10VerticalSliceService
 
     private string NormalizeComparablePath(string path)
     {
-        return Path.TrimEndingDirectorySeparator(fileSystem.GetFullPath(path)).Replace('\\', '/');
+        return fileSystem.GetFullPath(path);
     }
 
     private static NuGetPhase10VerticalSliceResolvedPaths ResolvePaths(
@@ -955,3 +1203,19 @@ internal sealed record NuGetPhase10OwnedState(
     bool PluginLayoutMarkerPresent,
     bool OwnershipManifestPresent
 );
+
+internal sealed record NuGetPluginOverrideInspection(
+    bool Present,
+    bool? IncludesProductEntrypoint,
+    bool ValueTooLarge,
+    bool EntryCountExceeded
+)
+{
+    public static NuGetPluginOverrideInspection Absent { get; } =
+        new(
+            Present: false,
+            IncludesProductEntrypoint: null,
+            ValueTooLarge: false,
+            EntryCountExceeded: false
+        );
+}

--- a/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Cli.Tests/CliApplicationTests.cs
+++ b/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Cli.Tests/CliApplicationTests.cs
@@ -82,6 +82,115 @@ public sealed class CliApplicationTests
         Assert.Equal(string.Empty, result.StdErr);
     }
 
+    [Fact]
+    public void DoctorPassesStructurallyReadyNuGetCandidateWithoutClaimingSelection()
+    {
+        using var pythonFixture = new PythonDoctorFixture(PythonDoctorFixtureMode.Healthy);
+        var nuGetOptions = new NuGetPhase10VerticalSliceOptions
+        {
+            StateDirectoryPath = Path.Combine(pythonFixture.RootPath, "nuget-state"),
+            UserHomeDirectoryPath = Path.Combine(pythonFixture.RootPath, "nuget-home"),
+            EnvironmentVariableReader = _ => null,
+        };
+        CliRuntimeOptions runtime = CreateHealthyDoctorRuntimeOptions(pythonFixture) with
+        {
+            NuGetPhase10Options = nuGetOptions,
+        };
+
+        Assert.Equal(0, InvokeWithRuntime(runtime, "configure", "git").ExitCode);
+        Assert.Equal(0, InvokeWithRuntime(runtime, "configure", "nuget").ExitCode);
+
+        CommandResult doctor = InvokeWithRuntime(runtime, "doctor");
+
+        Assert.Equal(0, doctor.ExitCode);
+        AssertDoctorCheck(
+            doctor.StdOut,
+            "nuget-product-plugin-discovery",
+            "discoverable-candidate"
+        );
+        AssertDoctorCheck(
+            doctor.StdOut,
+            "nuget-operational-plugin-selection",
+            "deferred-not-probed"
+        );
+        AssertDoctorCheck(doctor.StdOut, "doctor-aggregation", "pass");
+    }
+
+    [Theory]
+    [InlineData("included", "discoverable-candidate", "includes-product", true)]
+    [InlineData("excluded", "override-excludes-product", "excludes-product", false)]
+    [InlineData("missing", "included-path-missing", "includes-product", false)]
+    [InlineData("incomplete", "inspection-incomplete", "inspection-incomplete", false)]
+    public void DoctorAggregatesNuGetOverrideStructure(
+        string mode,
+        string expectedDiscovery,
+        string expectedInclusion,
+        bool expectedSuccess
+    )
+    {
+        using var pythonFixture = new PythonDoctorFixture(PythonDoctorFixtureMode.Healthy);
+        string? overrideValue = null;
+        var nuGetOptions = new NuGetPhase10VerticalSliceOptions
+        {
+            StateDirectoryPath = Path.Combine(pythonFixture.RootPath, "nuget-state"),
+            UserHomeDirectoryPath = Path.Combine(pythonFixture.RootPath, "nuget-home"),
+            EnvironmentVariableReader = name =>
+                string.Equals(
+                    name,
+                    "NUGET_NETCORE_PLUGIN_PATHS",
+                    StringComparison.Ordinal
+                )
+                    ? overrideValue
+                    : null,
+        };
+        CliRuntimeOptions runtime = CreateHealthyDoctorRuntimeOptions(pythonFixture) with
+        {
+            NuGetPhase10Options = nuGetOptions,
+        };
+
+        Assert.Equal(0, InvokeWithRuntime(runtime, "configure", "git").ExitCode);
+        Assert.Equal(0, InvokeWithRuntime(runtime, "configure", "nuget").ExitCode);
+        var nuGetService = new NuGetPhase10VerticalSliceService(nuGetOptions);
+        if (string.Equals(mode, "missing", StringComparison.Ordinal))
+        {
+            File.Delete(nuGetService.Paths.PluginEntrypointPath);
+        }
+        overrideValue = mode switch
+        {
+            "included" or "missing" => nuGetService.Paths.PluginEntrypointPath,
+            "excluded" => Path.Combine(pythonFixture.RootPath, "third-party.dll"),
+            "incomplete" =>
+                nuGetService.Paths.PluginEntrypointPath
+                + Path.PathSeparator
+                + new string('x', 64 * 1024),
+            _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, null),
+        };
+
+        CommandResult doctor = InvokeWithRuntime(runtime, "doctor");
+
+        Assert.Equal(expectedSuccess ? 0 : 1, doctor.ExitCode);
+        AssertDoctorCheck(
+            doctor.StdOut,
+            "nuget-product-plugin-discovery",
+            expectedDiscovery
+        );
+        AssertDoctorCheck(
+            doctor.StdOut,
+            "nuget-override-product-inclusion",
+            expectedInclusion
+        );
+        AssertDoctorCheck(
+            doctor.StdOut,
+            "nuget-operational-plugin-selection",
+            "deferred-not-probed"
+        );
+        AssertDoctorCheck(
+            doctor.StdOut,
+            "doctor-aggregation",
+            expectedSuccess ? "pass" : "fail"
+        );
+    }
+
     [Theory]
     [InlineData("status")]
     [InlineData("configure")]
@@ -4976,6 +5085,13 @@ public sealed class CliApplicationTests
                     "nuget-azure-artifacts-source: pass",
                     "nuget-interactive-policy: pass",
                     "nuget-environment-overrides: absent",
+                    "nuget-plugin-discovery-source: conventional",
+                    "nuget-product-plugin-discovery: not-found",
+                    "nuget-operational-plugin-selection: deferred-not-probed",
+                    "nuget-override-product-inclusion: not-applicable",
+                    "nuget-plugin-override-truncated: no",
+                    "nuget-product-plugin-remediation: "
+                        + "install the product plugin under the conventional netcore plugin path",
                     "python-keyring-shim-exists: "
                         + (OperatingSystem.IsWindows() ? "N/A" : "fail"),
                     "python-keyring-shim-first-on-path: "
@@ -9436,6 +9552,119 @@ public sealed class CliApplicationTests
             lines
         );
     }
+
+    [Fact]
+    public void DoctorNuGetDamagedEntrypointRequiresManualInspectionAndFailsClosed()
+    {
+        using var fixture = new NuGetDoctorCliFixture();
+        string damagedPath = fixture.Service.Paths.PluginEntrypointPath;
+        byte[] damage = [0xff, 0x00, 0x7b, 0x22];
+        File.WriteAllBytes(damagedPath, damage);
+
+        CommandResult doctor = InvokeWithRuntime(fixture.Runtime, "doctor");
+        CommandResult configure = InvokeWithRuntime(
+            fixture.Runtime,
+            "configure",
+            "nuget"
+        );
+
+        Assert.Equal(1, doctor.ExitCode);
+        AssertDoctorCheck(doctor.StdOut, "nuget-configuration-state", "unrecognized");
+        Assert.Contains(
+            NuGetUnrecognizedManualGuidance,
+            doctor.StdOut,
+            StringComparison.Ordinal
+        );
+        Assert.DoesNotContain(
+            "azureauth-credprovider configure nuget",
+            doctor.StdOut,
+            StringComparison.Ordinal
+        );
+        Assert.Equal(1, configure.ExitCode);
+        Assert.Contains(
+            "configure cannot modify unrecognized Phase 10 NuGet state",
+            configure.StdErr,
+            StringComparison.Ordinal
+        );
+        Assert.Equal(damage, File.ReadAllBytes(damagedPath));
+    }
+
+    [Fact]
+    public void Run_DoctorNuGet_OwnershiplessTargetRootFileRequiresManualInspection()
+    {
+        using var fixture = new NuGetDoctorCliFixture();
+        fixture.ReplaceOwnedNuGetLayoutWithTargetRootFile();
+
+        CommandResult doctor = InvokeWithRuntime(fixture.Runtime, "doctor");
+
+        Assert.NotEqual(0, doctor.ExitCode);
+        AssertDoctorCheck(doctor.StdOut, "nuget-configuration-state", "unrecognized");
+        Assert.Contains(
+            NuGetUnrecognizedManualGuidance,
+            doctor.StdOut,
+            StringComparison.Ordinal
+        );
+        Assert.DoesNotContain(
+            "azureauth-credprovider configure nuget",
+            doctor.StdOut,
+            StringComparison.Ordinal
+        );
+    }
+
+    private const string NuGetUnrecognizedManualGuidance =
+        "nuget-configuration-plan-remediation: manually inspect and restore "
+        + "the product-owned NuGet plugin layout";
+
+    private sealed class NuGetDoctorCliFixture : IDisposable
+    {
+        private readonly PythonDoctorFixture _pythonFixture;
+
+        public NuGetDoctorCliFixture()
+        {
+            _pythonFixture = new PythonDoctorFixture(PythonDoctorFixtureMode.Healthy);
+            string applicationRoot = Path.Combine(
+                _pythonFixture.RootPath,
+                "nuget-application"
+            );
+            Directory.CreateDirectory(applicationRoot);
+            File.WriteAllText(
+                Path.Combine(applicationRoot, "azureauth-credprovider.dll"),
+                "source-a"
+            );
+            File.WriteAllText(
+                Path.Combine(applicationRoot, "dependency.dll"),
+                "dependency"
+            );
+            var options = new NuGetPhase10VerticalSliceOptions
+            {
+                StateDirectoryPath = Path.Combine(_pythonFixture.RootPath, "nuget-state"),
+                ApplicationPayloadRootPath = applicationRoot,
+                UserHomeDirectoryPath = Path.Combine(_pythonFixture.RootPath, "nuget-home"),
+                EnvironmentVariableReader = _ => null,
+            };
+            Runtime = CreateHealthyDoctorRuntimeOptions(_pythonFixture) with
+            {
+                NuGetPhase10Options = options,
+            };
+            Service = new NuGetPhase10VerticalSliceService(options);
+            Assert.Equal(0, InvokeWithRuntime(Runtime, "configure", "git").ExitCode);
+            Assert.Equal(0, InvokeWithRuntime(Runtime, "configure", "nuget").ExitCode);
+        }
+
+        public CliRuntimeOptions Runtime { get; }
+
+        public NuGetPhase10VerticalSliceService Service { get; }
+
+        public void Dispose() => _pythonFixture.Dispose();
+
+        public void ReplaceOwnedNuGetLayoutWithTargetRootFile()
+        {
+            File.Delete(Service.Paths.OwnershipManifestPath);
+            Directory.Delete(Service.Paths.PluginTargetRootPath, recursive: true);
+            File.WriteAllText(Service.Paths.PluginTargetRootPath, "foreign");
+        }
+    }
+
 #pragma warning restore CA1707, CA1861
 
 }

--- a/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform.Tests/InMemoryFileSystemTests.cs
+++ b/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform.Tests/InMemoryFileSystemTests.cs
@@ -44,6 +44,38 @@ public sealed class InMemoryFileSystemTests
     }
 
     [Fact]
+    public void PosixSemanticsNormalizeBackslashesAsSeparators()
+    {
+        var fileSystem = new InMemoryFileSystem(InMemoryPathSemantics.Posix);
+
+        fileSystem.CreateDirectory(@"/root\cache");
+        fileSystem.WriteAllText(@"/root\cache\keep.txt", "value");
+
+        Assert.True(fileSystem.DirectoryExists("/root/cache"));
+        Assert.True(fileSystem.FileExists("/root/cache/keep.txt"));
+        Assert.Equal(
+            ["/root/cache/keep.txt"],
+            fileSystem.EnumerateFiles(@"/root\cache", "*.txt")
+        );
+    }
+
+    [Fact]
+    public void LiteralBackslashPosixSemanticsDoNotTreatSiblingAsDescendant()
+    {
+        var fileSystem = new InMemoryFileSystem(
+            InMemoryPathSemantics.PosixLiteralBackslash
+        );
+        fileSystem.CreateDirectory(@"/root/cache\");
+        fileSystem.WriteAllText(@"/root/cache\keep.txt", "sibling");
+
+        Assert.Empty(fileSystem.EnumerateFiles(@"/root/cache\", "*"));
+        Assert.Equal(
+            [@"/root/cache\keep.txt"],
+            fileSystem.EnumerateFiles("/root", "*.txt")
+        );
+    }
+
+    [Fact]
     public void OwnerOnlyAtomicWriteAppliesRequestedMode()
     {
         var fileSystem = new InMemoryFileSystem(InMemoryPathSemantics.Posix);

--- a/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform.Tests/NuGetPhase10VerticalSliceServiceTests.cs
+++ b/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform.Tests/NuGetPhase10VerticalSliceServiceTests.cs
@@ -788,7 +788,8 @@ public sealed class NuGetPhase10VerticalSliceServiceTests
                                 service!.Paths.PluginEntrypointPath,
                             ]
                     )
-                    : null
+                    : null,
+            userHomeDirectoryPath: "/home/user"
         );
         fileSystem.AtomicWriteAllText(service.Paths.PluginEntrypointPath, "fake-assembly");
 

--- a/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform.Tests/NuGetPhase10VerticalSliceServiceTests.cs
+++ b/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform.Tests/NuGetPhase10VerticalSliceServiceTests.cs
@@ -1011,7 +1011,9 @@ public sealed class NuGetPhase10VerticalSliceServiceTests
     [Fact]
     public async Task DoctorTreatsPosixBackslashAsLiteralPathCharacter()
     {
-        var fileSystem = new InMemoryFileSystem(InMemoryPathSemantics.Posix);
+        var fileSystem = new InMemoryFileSystem(
+            InMemoryPathSemantics.PosixLiteralBackslash
+        );
         NuGetPhase10VerticalSliceService? service = null;
         service = CreateService(
             fileSystem,

--- a/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform.Tests/NuGetPhase10VerticalSliceServiceTests.cs
+++ b/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform.Tests/NuGetPhase10VerticalSliceServiceTests.cs
@@ -283,6 +283,22 @@ public sealed class NuGetPhase10VerticalSliceServiceTests
         Assert.True(doctorResult.AzureArtifactsSourceCanonicalizationSuccess);
         Assert.True(doctorResult.InteractivePolicyGuidanceSuccess);
         Assert.True(doctorResult.OptionalEnvironmentOverridesAbsent);
+        Assert.Equal(
+            NuGetPluginDiscoverySource.Conventional,
+            doctorResult.EffectivePlugin.Source
+        );
+        Assert.Equal(
+            NuGetProductPluginDiscoveryState.DiscoverableCandidate,
+            doctorResult.EffectivePlugin.ProductDiscovery
+        );
+        Assert.Equal(
+            NuGetOperationalPluginSelectionState.DeferredNotProbed,
+            doctorResult.EffectivePlugin.OperationalSelection
+        );
+        Assert.Equal(
+            NuGetProductPluginRemediation.SelectionDeferredNotProbed,
+            doctorResult.EffectivePlugin.Remediation
+        );
     }
 
     [Fact]
@@ -674,7 +690,7 @@ public sealed class NuGetPhase10VerticalSliceServiceTests
             fileSystem,
             name =>
                 string.Equals(name, "NUGET_NETCORE_PLUGIN_PATHS", StringComparison.Ordinal)
-                    ? "/tmp/plugin.dll"
+                    ? Path.Combine(GetIsolatedHomePath(), "third-party-plugin.dll")
                     : null
         );
         await service.ConfigureAsync(TestContext.Current.CancellationToken);
@@ -686,6 +702,448 @@ public sealed class NuGetPhase10VerticalSliceServiceTests
         Assert.False(result.OptionalEnvironmentOverridesAbsent);
         Assert.True(result.PluginLayoutMarkerPresent);
         Assert.True(result.OwnershipManifestPresent);
+        Assert.Equal(
+            NuGetPluginDiscoverySource.NuGetNetCorePluginPaths,
+            result.EffectivePlugin.Source
+        );
+        Assert.Equal(
+            NuGetProductPluginDiscoveryState.OverrideExcludesProduct,
+            result.EffectivePlugin.ProductDiscovery
+        );
+        Assert.Equal(
+            NuGetOverrideProductInclusionState.ExcludesProduct,
+            result.EffectivePlugin.OverrideProductInclusion
+        );
+        Assert.Equal(
+            NuGetProductPluginRemediation.ClearOrIncludeProductInNuGetNetCorePluginPaths,
+            result.EffectivePlugin.Remediation
+        );
+    }
+
+    [Theory]
+    [InlineData("NUGET_PLUGIN_PATHS", NuGetPluginDiscoverySource.NuGetPluginPaths)]
+    [InlineData(
+        "NUGET_NETCORE_PLUGIN_PATHS",
+        NuGetPluginDiscoverySource.NuGetNetCorePluginPaths
+    )]
+    public async Task DoctorReportsProductAsIncludedCandidateByExplicitOverride(
+        string variableName,
+        NuGetPluginDiscoverySource expectedSource
+    )
+    {
+        var fileSystem = new InMemoryFileSystem(InMemoryPathSemantics.Host);
+        NuGetPhase10VerticalSliceService? service = null;
+        service = CreateService(
+            fileSystem,
+            name =>
+                string.Equals(name, variableName, StringComparison.Ordinal)
+                    ? service!.Paths.PluginEntrypointPath
+                    : null
+        );
+        await service.ConfigureAsync(TestContext.Current.CancellationToken);
+
+        NuGetPhase10DoctorResult result = await service.DoctorAsync(
+            TestContext.Current.CancellationToken
+        );
+
+        Assert.Equal(expectedSource, result.EffectivePlugin.Source);
+        Assert.Equal(
+            NuGetProductPluginDiscoveryState.DiscoverableCandidate,
+            result.EffectivePlugin.ProductDiscovery
+        );
+        Assert.Equal(
+            NuGetOverrideProductInclusionState.IncludesProduct,
+            result.EffectivePlugin.OverrideProductInclusion
+        );
+        Assert.Equal(
+            NuGetProductPluginRemediation.SelectionDeferredNotProbed,
+            result.EffectivePlugin.Remediation
+        );
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task DoctorKeepsProductAsCandidateRegardlessOfCompetingProviderOrder(
+        bool competingProviderAfterProduct
+    )
+    {
+        var fileSystem = new InMemoryFileSystem(InMemoryPathSemantics.Posix);
+        NuGetPhase10VerticalSliceService? service = null;
+        service = CreateService(
+            fileSystem,
+            name =>
+                string.Equals(name, "NUGET_NETCORE_PLUGIN_PATHS", StringComparison.Ordinal)
+                    ? string.Join(
+                        ':',
+                        competingProviderAfterProduct
+                            ?
+                            [
+                                service!.Paths.PluginEntrypointPath,
+                                "/plugins/competing.dll",
+                            ]
+                            :
+                            [
+                                "/plugins/competing.dll",
+                                service!.Paths.PluginEntrypointPath,
+                            ]
+                    )
+                    : null
+        );
+        fileSystem.AtomicWriteAllText(service.Paths.PluginEntrypointPath, "fake-assembly");
+
+        NuGetPhase10DoctorResult result = await service.DoctorAsync(
+            TestContext.Current.CancellationToken
+        );
+
+        Assert.Equal(
+            NuGetProductPluginDiscoveryState.DiscoverableCandidate,
+            result.EffectivePlugin.ProductDiscovery
+        );
+        Assert.Equal(
+            NuGetOperationalPluginSelectionState.DeferredNotProbed,
+            result.EffectivePlugin.OperationalSelection
+        );
+    }
+
+    [Fact]
+    public async Task DoctorTreatsWhitespaceOverrideAsExplicit()
+    {
+        var fileSystem = new InMemoryFileSystem(InMemoryPathSemantics.Host);
+        NuGetPhase10VerticalSliceService service = CreateService(
+            fileSystem,
+            name =>
+                string.Equals(name, "NUGET_NETCORE_PLUGIN_PATHS", StringComparison.Ordinal)
+                    ? " "
+                    : null
+        );
+        await service.ConfigureAsync(TestContext.Current.CancellationToken);
+
+        NuGetPhase10DoctorResult result = await service.DoctorAsync(
+            TestContext.Current.CancellationToken
+        );
+
+        Assert.False(result.OptionalEnvironmentOverridesAbsent);
+        Assert.Equal(
+            NuGetPluginDiscoverySource.NuGetNetCorePluginPaths,
+            result.EffectivePlugin.Source
+        );
+        Assert.Equal(
+            NuGetProductPluginDiscoveryState.OverrideExcludesProduct,
+            result.EffectivePlugin.ProductDiscovery
+        );
+    }
+
+    [Fact]
+    public async Task DoctorUsesNetCoreOverrideBeforeGenericOverride()
+    {
+        var fileSystem = new InMemoryFileSystem(InMemoryPathSemantics.Host);
+        NuGetPhase10VerticalSliceService? service = null;
+        service = CreateService(
+            fileSystem,
+            name =>
+                name switch
+                {
+                    "NUGET_PLUGIN_PATHS" => service!.Paths.PluginEntrypointPath,
+                    "NUGET_NETCORE_PLUGIN_PATHS" => Path.Combine(
+                        GetIsolatedHomePath(),
+                        "third-party-plugin.dll"
+                    ),
+                    _ => null,
+                }
+        );
+        await service.ConfigureAsync(TestContext.Current.CancellationToken);
+
+        NuGetPhase10DoctorResult result = await service.DoctorAsync(
+            TestContext.Current.CancellationToken
+        );
+
+        Assert.True(result.EffectivePlugin.NuGetPluginPathsOverridePresent);
+        Assert.True(result.EffectivePlugin.NuGetNetCorePluginPathsOverridePresent);
+        Assert.Equal(
+            NuGetPluginDiscoverySource.NuGetNetCorePluginPaths,
+            result.EffectivePlugin.Source
+        );
+        Assert.Equal(
+            NuGetProductPluginDiscoveryState.OverrideExcludesProduct,
+            result.EffectivePlugin.ProductDiscovery
+        );
+    }
+
+    [Fact]
+    public async Task DoctorReportsMissingProductPathIncludedByOverride()
+    {
+        var fileSystem = new InMemoryFileSystem(InMemoryPathSemantics.Host);
+        NuGetPhase10VerticalSliceService? service = null;
+        service = CreateService(
+            fileSystem,
+            name =>
+                string.Equals(name, "NUGET_NETCORE_PLUGIN_PATHS", StringComparison.Ordinal)
+                    ? service!.Paths.PluginEntrypointPath
+                    : null
+        );
+        await service.ConfigureAsync(TestContext.Current.CancellationToken);
+        fileSystem.DeleteFile(service.Paths.PluginEntrypointPath);
+
+        NuGetPhase10DoctorResult result = await service.DoctorAsync(
+            TestContext.Current.CancellationToken
+        );
+
+        Assert.Equal(
+            NuGetProductPluginDiscoveryState.IncludedPathMissing,
+            result.EffectivePlugin.ProductDiscovery
+        );
+        Assert.Equal(
+            NuGetProductPluginRemediation.RestoreIncludedProductPath,
+            result.EffectivePlugin.Remediation
+        );
+    }
+
+    [Fact]
+    public async Task DoctorBoundsOversizedOverrideEntryLists()
+    {
+        var fileSystem = new InMemoryFileSystem(InMemoryPathSemantics.Host);
+        NuGetPhase10VerticalSliceService? service = null;
+        string overrideValue = string.Join(
+            Path.PathSeparator,
+            new[] { string.Empty }
+                .Concat(
+                    Enumerable
+                        .Range(0, 128)
+                        .Select(index =>
+                            Path.Combine(GetIsolatedHomePath(), $"third-party-{index}.dll")
+                        )
+                )
+        );
+        service = CreateService(
+            fileSystem,
+            name =>
+                string.Equals(name, "NUGET_PLUGIN_PATHS", StringComparison.Ordinal)
+                    ? service!.Paths.PluginEntrypointPath
+                        + Path.PathSeparator
+                        + overrideValue
+                    : null
+        );
+        await service.ConfigureAsync(TestContext.Current.CancellationToken);
+
+        NuGetPhase10DoctorResult result = await service.DoctorAsync(
+            TestContext.Current.CancellationToken
+        );
+
+        Assert.True(result.EffectivePlugin.OverrideEntriesTruncated);
+        Assert.Equal(
+            NuGetProductPluginDiscoveryState.InspectionIncomplete,
+            result.EffectivePlugin.ProductDiscovery
+        );
+        Assert.Equal(
+            NuGetOverrideProductInclusionState.InspectionIncomplete,
+            result.EffectivePlugin.OverrideProductInclusion
+        );
+        Assert.Equal(
+            NuGetProductPluginRemediation.ShortenOverrideAndRerunDoctor,
+            result.EffectivePlugin.Remediation
+        );
+    }
+
+    [Fact]
+    public async Task DoctorTreatsOversizedOverrideWithProductFirstAsInspectionIncomplete()
+    {
+        var fileSystem = new InMemoryFileSystem(InMemoryPathSemantics.Posix);
+        NuGetPhase10VerticalSliceService? service = null;
+        service = CreateService(
+            fileSystem,
+            name =>
+                string.Equals(name, "NUGET_PLUGIN_PATHS", StringComparison.Ordinal)
+                    ? service!.Paths.PluginEntrypointPath
+                        + ":/"
+                        + new string('x', 64 * 1024)
+                    : null
+        );
+        fileSystem.AtomicWriteAllText(service.Paths.PluginEntrypointPath, "fake-assembly");
+
+        NuGetPhase10DoctorResult result = await service.DoctorAsync(
+            TestContext.Current.CancellationToken
+        );
+
+        Assert.True(result.EffectivePlugin.OverrideEntriesTruncated);
+        Assert.Equal(
+            NuGetProductPluginDiscoveryState.InspectionIncomplete,
+            result.EffectivePlugin.ProductDiscovery
+        );
+        Assert.Equal(
+            NuGetOverrideProductInclusionState.InspectionIncomplete,
+            result.EffectivePlugin.OverrideProductInclusion
+        );
+    }
+
+    [Theory]
+    [InlineData("relative")]
+    [InlineData("all-backslash")]
+    public async Task DoctorRejectsNonNuGetPosixPluginPathForms(string form)
+    {
+        var fileSystem = new InMemoryFileSystem(InMemoryPathSemantics.Posix);
+        NuGetPhase10VerticalSliceService? service = null;
+        service = CreateService(
+            fileSystem,
+            name =>
+                string.Equals(name, "NUGET_NETCORE_PLUGIN_PATHS", StringComparison.Ordinal)
+                    ? form == "relative"
+                        ? "azureauth-credprovider.dll"
+                        : service!.Paths.PluginEntrypointPath.Replace('/', '\\')
+                    : null
+        );
+        fileSystem.AtomicWriteAllText(service.Paths.PluginEntrypointPath, "fake-assembly");
+
+        NuGetPhase10DoctorResult result = await service.DoctorAsync(
+            TestContext.Current.CancellationToken
+        );
+
+        Assert.Equal(
+            NuGetProductPluginDiscoveryState.OverrideExcludesProduct,
+            result.EffectivePlugin.ProductDiscovery
+        );
+        Assert.Equal(
+            NuGetOverrideProductInclusionState.ExcludesProduct,
+            result.EffectivePlugin.OverrideProductInclusion
+        );
+    }
+
+    [Fact]
+    public async Task DoctorTreatsPosixBackslashAsLiteralPathCharacter()
+    {
+        var fileSystem = new InMemoryFileSystem(InMemoryPathSemantics.Posix);
+        NuGetPhase10VerticalSliceService? service = null;
+        service = CreateService(
+            fileSystem,
+            name =>
+                string.Equals(name, "NUGET_NETCORE_PLUGIN_PATHS", StringComparison.Ordinal)
+                    ? service!.Paths.PluginEntrypointPath
+                    : null,
+            userHomeDirectoryPath: "/home/user\\literal"
+        );
+        fileSystem.AtomicWriteAllText(service.Paths.PluginEntrypointPath, "fake-assembly");
+
+        NuGetPhase10DoctorResult result = await service.DoctorAsync(
+            TestContext.Current.CancellationToken
+        );
+
+        Assert.Contains('\\', service.Paths.PluginEntrypointPath);
+        Assert.Equal(
+            NuGetOverrideProductInclusionState.IncludesProduct,
+            result.EffectivePlugin.OverrideProductInclusion
+        );
+    }
+
+    [Fact]
+    public async Task DoctorRejectsWindowsDrivePathUsingForwardSlashes()
+    {
+        var fileSystem = new InMemoryFileSystem(InMemoryPathSemantics.Windows);
+        NuGetPhase10VerticalSliceService? service = null;
+        service = CreateService(
+            fileSystem,
+            name =>
+                string.Equals(name, "NUGET_NETCORE_PLUGIN_PATHS", StringComparison.Ordinal)
+                    ? service!.Paths.PluginEntrypointPath.Replace('\\', '/')
+                    : null
+        );
+        fileSystem.AtomicWriteAllText(service.Paths.PluginEntrypointPath, "fake-assembly");
+
+        NuGetPhase10DoctorResult result = await service.DoctorAsync(
+            TestContext.Current.CancellationToken
+        );
+
+        Assert.Equal(
+            NuGetOverrideProductInclusionState.ExcludesProduct,
+            result.EffectivePlugin.OverrideProductInclusion
+        );
+    }
+
+    [Fact]
+    public async Task DoctorUsesInjectedWindowsPathComparisonAndSeparator()
+    {
+        var fileSystem = new InMemoryFileSystem(InMemoryPathSemantics.Windows);
+        NuGetPhase10VerticalSliceService? service = null;
+        service = CreateService(
+            fileSystem,
+            name =>
+                string.Equals(name, "NUGET_NETCORE_PLUGIN_PATHS", StringComparison.Ordinal)
+                    ? @"C:\plugins\other.dll;"
+                        + service!.Paths.PluginEntrypointPath.ToUpperInvariant()
+                    : null
+        );
+        fileSystem.AtomicWriteAllText(service.Paths.PluginEntrypointPath, "fake-assembly");
+
+        NuGetPhase10DoctorResult result = await service.DoctorAsync(
+            TestContext.Current.CancellationToken
+        );
+
+        Assert.Equal(
+            NuGetOverrideProductInclusionState.IncludesProduct,
+            result.EffectivePlugin.OverrideProductInclusion
+        );
+        Assert.Equal(
+            NuGetProductPluginDiscoveryState.DiscoverableCandidate,
+            result.EffectivePlugin.ProductDiscovery
+        );
+    }
+
+    [Fact]
+    public async Task DoctorAcceptsForwardSlashAfterWindowsDriveRoot()
+    {
+        var fileSystem = new InMemoryFileSystem(InMemoryPathSemantics.Windows);
+        NuGetPhase10VerticalSliceService? service = null;
+        service = CreateService(
+            fileSystem,
+            name =>
+                string.Equals(name, "NUGET_NETCORE_PLUGIN_PATHS", StringComparison.Ordinal)
+                    ? service!.Paths.PluginEntrypointPath[..3]
+                        + service.Paths.PluginEntrypointPath[3..].Replace('\\', '/')
+                    : null
+        );
+        fileSystem.AtomicWriteAllText(service.Paths.PluginEntrypointPath, "fake-assembly");
+
+        NuGetPhase10DoctorResult result = await service.DoctorAsync(
+            TestContext.Current.CancellationToken
+        );
+
+        Assert.Equal(
+            NuGetOverrideProductInclusionState.IncludesProduct,
+            result.EffectivePlugin.OverrideProductInclusion
+        );
+    }
+
+    [Fact]
+    public async Task DoctorAcceptsWindowsUncRootWithLaterForwardSlashes()
+    {
+        var fileSystem = new InMemoryFileSystem(InMemoryPathSemantics.Windows);
+        NuGetPhase10VerticalSliceService? service = null;
+        service = CreateService(
+            fileSystem,
+            name =>
+                string.Equals(name, "NUGET_NETCORE_PLUGIN_PATHS", StringComparison.Ordinal)
+                    ? @"\\server\share/"
+                        + service!
+                            .Paths
+                            .PluginEntrypointPath[@"\\server\share\".Length..]
+                            .Replace('\\', '/')
+                    : null,
+            userHomeDirectoryPath: @"\\server\share\home"
+        );
+        fileSystem.AtomicWriteAllText(service.Paths.PluginEntrypointPath, "fake-assembly");
+
+        NuGetPhase10DoctorResult result = await service.DoctorAsync(
+            TestContext.Current.CancellationToken
+        );
+
+        Assert.StartsWith(
+            @"\\server\share\",
+            service.Paths.PluginEntrypointPath,
+            StringComparison.OrdinalIgnoreCase
+        );
+        Assert.Equal(
+            NuGetOverrideProductInclusionState.IncludesProduct,
+            result.EffectivePlugin.OverrideProductInclusion
+        );
     }
 
     [Fact]
@@ -700,11 +1158,16 @@ public sealed class NuGetPhase10VerticalSliceServiceTests
             TestContext.Current.CancellationToken
         );
 
+        Assert.Equal(NuGetConfigurationState.Unrecognized, result.ConfigurationState);
         Assert.True(result.PluginLayoutMarkerPresent);
         Assert.True(result.OwnershipManifestPresent);
         Assert.False(result.ConfigurationPlanValid);
         Assert.False(result.NetCorePluginEntrypointPresent);
         Assert.False(result.PluginModeEntrypointResolvable);
+        Assert.Equal(
+            NuGetProductPluginDiscoveryState.NotFound,
+            result.EffectivePlugin.ProductDiscovery
+        );
     }
 
     [Theory]
@@ -742,6 +1205,7 @@ public sealed class NuGetPhase10VerticalSliceServiceTests
     private static NuGetPhase10VerticalSliceService CreateService(
         InMemoryFileSystem fileSystem,
         Func<string, string?>? environmentVariableReader = null,
+        string? userHomeDirectoryPath = null,
         string? applicationRootPath = null,
         bool seedPayload = true
     )
@@ -760,6 +1224,8 @@ public sealed class NuGetPhase10VerticalSliceServiceTests
             {
                 StateDirectoryPath = "/state/azureauth-credprovider/phase10",
                 ApplicationPayloadRootPath = applicationRoot,
+                UserHomeDirectoryPath =
+                    userHomeDirectoryPath ?? GetIsolatedHomePath(),
                 FileSystem = fileSystem,
                 EnvironmentVariableReader = environmentVariableReader ?? (_ => null),
             }
@@ -796,17 +1262,20 @@ public sealed class NuGetPhase10VerticalSliceServiceTests
             case "source-contains-target":
                 service = CreateService(
                     fileSystem,
-                    applicationRootPath: "/"
+                    userHomeDirectoryPath: "/home/user",
+                    applicationRootPath: "/home/user"
                 );
                 expectedDiagnostic = "source and activation roots must be disjoint";
                 break;
             case "target-contains-source":
                 NuGetPhase10VerticalSliceService layout = CreateService(
                     fileSystem,
+                    userHomeDirectoryPath: "/home/user",
                     seedPayload: false
                 );
                 service = CreateService(
                     fileSystem,
+                    userHomeDirectoryPath: "/home/user",
                     applicationRootPath: layout.Paths.PluginTargetRootPath + "/application"
                 );
                 expectedDiagnostic = "source and activation roots must be disjoint";
@@ -992,6 +1461,7 @@ public sealed class NuGetPhase10VerticalSliceServiceTests
             {
                 StateDirectoryPath = "/state/azureauth-credprovider/phase10",
                 ApplicationPayloadRootPath = applicationRoot,
+                UserHomeDirectoryPath = GetIsolatedHomePath(),
                 FileSystem = fileSystem,
                 EnvironmentVariableReader = _ => null,
                 CredentialAcquisition =
@@ -1013,6 +1483,24 @@ public sealed class NuGetPhase10VerticalSliceServiceTests
         Assert.True(result.AzureArtifactsSourceCanonicalizationSuccess);
         Assert.True(result.InteractivePolicyGuidanceSuccess);
         Assert.True(result.OptionalEnvironmentOverridesAbsent);
+    }
+
+    private sealed class ThrowingNuGetDoctorCredentialAcquisitionService
+        : Hcoona.AzureAuth.CredProvider.Platform.Composition.ICredentialAcquisitionService
+    {
+        public int InvocationCount { get; private set; }
+
+        public ValueTask<CredentialResult> AcquireAsync(
+            CredentialRequestV2 request,
+            CancellationToken cancellationToken = default
+        )
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            InvocationCount++;
+            throw new InvalidOperationException(
+                "NuGet doctor must classify sources without acquiring credentials."
+            );
+        }
     }
 
     [Fact]
@@ -1212,24 +1700,6 @@ public sealed class NuGetPhase10VerticalSliceServiceTests
                 break;
             default:
                 throw new ArgumentOutOfRangeException(nameof(scenario), scenario, null);
-        }
-    }
-
-    private sealed class ThrowingNuGetDoctorCredentialAcquisitionService
-        : Hcoona.AzureAuth.CredProvider.Platform.Composition.ICredentialAcquisitionService
-    {
-        public int InvocationCount { get; private set; }
-
-        public ValueTask<CredentialResult> AcquireAsync(
-            CredentialRequestV2 request,
-            CancellationToken cancellationToken = default
-        )
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            InvocationCount++;
-            throw new InvalidOperationException(
-                "NuGet doctor must classify sources without acquiring credentials."
-            );
         }
     }
 }

--- a/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform.Tests/TestDoubles/InMemoryFileSystem.cs
+++ b/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform.Tests/TestDoubles/InMemoryFileSystem.cs
@@ -140,10 +140,12 @@ public sealed class InMemoryFileSystem
         bool result =
             pathSemantics == InMemoryPathSemantics.Posix ? path.StartsWith('/')
             : pathSemantics == InMemoryPathSemantics.Windows
-                ? path.Length >= 3
+                ? (
+                    path.Length >= 3
                     && char.IsAsciiLetter(path[0])
                     && path[1] == ':'
                     && IsSeparator(path[2])
+                ) || HasWindowsUncShareRoot(path)
             : Path.IsPathFullyQualified(path);
         Record(nameof(IsPathFullyQualified), path, result.ToString());
         return result;
@@ -521,18 +523,31 @@ public sealed class InMemoryFileSystem
         }
 
         char separator = pathSemantics == InMemoryPathSemantics.Windows ? '\\' : '/';
-        string replaced = path.Replace('\\', separator).Replace('/', separator);
+        string replaced =
+            pathSemantics == InMemoryPathSemantics.Windows
+                ? path.Replace('/', separator)
+                : path;
         string prefix;
         string remainder;
         if (pathSemantics == InMemoryPathSemantics.Windows)
         {
+            string[] uncComponents = replaced.StartsWith(@"\\", StringComparison.Ordinal)
+                ? replaced[2..].Split('\\', StringSplitOptions.RemoveEmptyEntries)
+                : [];
+            bool uncRooted = uncComponents.Length >= 2;
             bool rooted =
                 replaced.Length >= 3
                 && char.IsAsciiLetter(replaced[0])
                 && replaced[1] == ':'
                 && replaced[2] == separator;
-            prefix = rooted ? char.ToUpperInvariant(replaced[0]) + @":\" : rootPath;
-            remainder = rooted ? replaced[3..] : replaced;
+            prefix =
+                uncRooted ? @"\\" + uncComponents[0] + @"\" + uncComponents[1]
+                : rooted ? char.ToUpperInvariant(replaced[0]) + @":\"
+                : rootPath;
+            remainder =
+                uncRooted ? string.Join('\\', uncComponents.Skip(2))
+                : rooted ? replaced[3..]
+                : replaced;
         }
         else
         {
@@ -562,12 +577,29 @@ public sealed class InMemoryFileSystem
             components.Add(component);
         }
 
-        return components.Count == 0 ? prefix : prefix + string.Join(separator, components);
+        return components.Count == 0
+            ? prefix
+            : prefix
+                + (
+                    prefix.EndsWith(separator)
+                        ? string.Empty
+                        : separator.ToString()
+                )
+                + string.Join(separator, components);
     }
 
     private string GetParentPath(string path)
     {
-        int separatorIndex = path.LastIndexOfAny(['/', '\\']);
+        if (
+            pathSemantics == InMemoryPathSemantics.Windows
+            && HasWindowsUncShareRoot(path)
+            && path.Count(character => character == '\\') == 3
+        )
+        {
+            return path;
+        }
+
+        int separatorIndex = LastSeparatorIndex(path);
         if (separatorIndex <= 0)
         {
             return rootPath;
@@ -581,13 +613,37 @@ public sealed class InMemoryFileSystem
         return path[..separatorIndex];
     }
 
-    private static string GetFileName(string path)
+    private string GetFileName(string path)
     {
-        int separatorIndex = path.LastIndexOfAny(['/', '\\']);
+        int separatorIndex = LastSeparatorIndex(path);
         return separatorIndex < 0 ? path : path[(separatorIndex + 1)..];
     }
 
-    private static bool IsSeparator(char character) => character is '/' or '\\';
+    private int LastSeparatorIndex(string path) =>
+        UsesWindowsSeparatorSemantics()
+            ? path.LastIndexOfAny(['/', '\\'])
+            : path.LastIndexOf('/');
+
+    private bool IsSeparator(char character) =>
+        character == '/' || (UsesWindowsSeparatorSemantics() && character == '\\');
+
+    private bool UsesWindowsSeparatorSemantics() =>
+        pathSemantics == InMemoryPathSemantics.Windows
+        || (pathSemantics == InMemoryPathSemantics.Host && OperatingSystem.IsWindows());
+
+    private static bool HasWindowsUncShareRoot(string path)
+    {
+        if (!path.StartsWith(@"\\", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        string[] components = path[2..].Split(
+            ['\\', '/'],
+            StringSplitOptions.RemoveEmptyEntries
+        );
+        return components.Length >= 2;
+    }
 
     private string AppendSeparator(string path)
     {

--- a/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform.Tests/TestDoubles/InMemoryFileSystem.cs
+++ b/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform.Tests/TestDoubles/InMemoryFileSystem.cs
@@ -36,7 +36,7 @@ public sealed class InMemoryFileSystem
         heldLocks = new HashSet<string>(pathComparer);
         unixFileModes = new Dictionary<string, UnixFileMode>(pathComparer);
         rootPath =
-            pathSemantics == InMemoryPathSemantics.Posix ? "/"
+            UsesPosixPathSemantics() ? "/"
             : pathSemantics == InMemoryPathSemantics.Windows ? @"C:\"
             : Path.GetPathRoot(Path.GetFullPath("."))!;
         directories.Add(rootPath);
@@ -138,7 +138,7 @@ public sealed class InMemoryFileSystem
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(path);
         bool result =
-            pathSemantics == InMemoryPathSemantics.Posix ? path.StartsWith('/')
+            UsesPosixPathSemantics() ? path.StartsWith('/')
             : pathSemantics == InMemoryPathSemantics.Windows
                 ? (
                     path.Length >= 3
@@ -523,10 +523,12 @@ public sealed class InMemoryFileSystem
         }
 
         char separator = pathSemantics == InMemoryPathSemantics.Windows ? '\\' : '/';
-        string replaced =
-            pathSemantics == InMemoryPathSemantics.Windows
-                ? path.Replace('/', separator)
-                : path;
+        string replaced = pathSemantics switch
+        {
+            InMemoryPathSemantics.Windows => path.Replace('/', separator),
+            InMemoryPathSemantics.Posix => path.Replace('\\', separator),
+            _ => path,
+        };
         string prefix;
         string remainder;
         if (pathSemantics == InMemoryPathSemantics.Windows)
@@ -620,16 +622,21 @@ public sealed class InMemoryFileSystem
     }
 
     private int LastSeparatorIndex(string path) =>
-        UsesWindowsSeparatorSemantics()
+        TreatsBackslashAsSeparator()
             ? path.LastIndexOfAny(['/', '\\'])
             : path.LastIndexOf('/');
 
     private bool IsSeparator(char character) =>
-        character == '/' || (UsesWindowsSeparatorSemantics() && character == '\\');
+        character == '/' || (TreatsBackslashAsSeparator() && character == '\\');
 
-    private bool UsesWindowsSeparatorSemantics() =>
-        pathSemantics == InMemoryPathSemantics.Windows
+    private bool TreatsBackslashAsSeparator() =>
+        pathSemantics is InMemoryPathSemantics.Windows or InMemoryPathSemantics.Posix
         || (pathSemantics == InMemoryPathSemantics.Host && OperatingSystem.IsWindows());
+
+    private bool UsesPosixPathSemantics() =>
+        pathSemantics
+            is InMemoryPathSemantics.Posix
+                or InMemoryPathSemantics.PosixLiteralBackslash;
 
     private static bool HasWindowsUncShareRoot(string path)
     {
@@ -647,14 +654,14 @@ public sealed class InMemoryFileSystem
 
     private string AppendSeparator(string path)
     {
-        if (path.EndsWith('/') || path.EndsWith('\\'))
+        if (path.Length > 0 && IsSeparator(path[^1]))
         {
             return path;
         }
 
         char separator =
             pathSemantics == InMemoryPathSemantics.Windows ? '\\'
-            : pathSemantics == InMemoryPathSemantics.Posix ? '/'
+            : UsesPosixPathSemantics() ? '/'
             : Path.DirectorySeparatorChar;
         return path + separator;
     }

--- a/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform.Tests/TestDoubles/InMemoryPathSemantics.cs
+++ b/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform.Tests/TestDoubles/InMemoryPathSemantics.cs
@@ -4,5 +4,6 @@ public enum InMemoryPathSemantics
 {
     Host,
     Posix,
+    PosixLiteralBackslash,
     Windows,
 }


### PR DESCRIPTION
## Summary

- Report effective NuGet plugin candidate discovery across conventional paths, `NUGET_PLUGIN_PATHS`, and `NUGET_NETCORE_PLUGIN_PATHS` with correct precedence.
- Keep operational provider selection explicitly deferred and avoid invoking providers, feeds, or authentication during doctor.
- Bound and sanitize override inspection, returning incomplete evidence and focused remediation instead of false exclusion claims.
- Preserve the shared cross-platform in-memory filesystem contract while isolating strict POSIX literal-backslash scenarios.

## Validation

- Targeted NuGet discovery scenarios: 72 passed
- Platform: 1,439 passed, 2 skipped
- Isolated CLI: 344 passed
- Windows Platform comparison introduced no new failures
- Formatting and branch-range HK small/medium/large passed
- Three terminal OCR reviewers reported no findings