### PR TITLE
fix(azureauth): Validate Deployment Bundle Identity and Packaging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,6 +237,10 @@ jobs:
             src/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform/packages.lock.json
             tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform.Tests/packages.lock.json
 
+      - name: Restore dotnet tools for deployment validation
+        if: matrix.run-deployment-validation
+        run: dotnet tool restore
+
       - name: Test AzureAuth host OS behavior
         if: matrix.run-host-tests
         timeout-minutes: 15
@@ -292,9 +296,7 @@ jobs:
           ./eng/scripts/azureauth-credprovider/New-DeploymentValidationBundle.ps1 `
             -BuildOs '${{ matrix.build-os }}' `
             -TargetRid '${{ matrix.target-rid }}' `
-            -Configuration Release `
-            -ProductVersion '0.0.0-internal' `
-            -SourceRevision '${{ github.sha }}'
+            -Configuration Release
 
       - name: Test deployment validation lifecycle
         if: matrix.run-deployment-validation

--- a/eng/scripts/azureauth-credprovider/Install-DeploymentValidationBundle.ps1
+++ b/eng/scripts/azureauth-credprovider/Install-DeploymentValidationBundle.ps1
@@ -25,6 +25,11 @@ if ($manifest.schemaVersion -ne 'azureauth-credprovider-deployment-validation-v1
     $manifest.isRelease) {
     throw 'The bundle is not an internal deployment validation artifact.'
 }
+if ([string]::IsNullOrWhiteSpace([string]$manifest.productVersion) -or
+    [string]::IsNullOrWhiteSpace([string]$manifest.pythonPackageVersion) -or
+    [string]::IsNullOrWhiteSpace([string]$manifest.sourceRevision)) {
+    throw 'The bundle version identity is incomplete.'
+}
 $runningOnWindows = $IsWindows
 $expectedBuildOs = if ($runningOnWindows) {
     'Windows'
@@ -355,12 +360,13 @@ try {
     }
 
     $receipt = [ordered]@{
-        schemaVersion   = 'azureauth-credprovider-deployment-validation-install-v2'
-        productVersion  = $manifest.productVersion
-        sourceRevision  = $manifest.sourceRevision
-        targetRid       = $manifest.targetRid
-        installRoot     = $InstallRoot
-        applicationRoot = $applicationRoot
+        schemaVersion        = 'azureauth-credprovider-deployment-validation-install-v2'
+        productVersion       = $manifest.productVersion
+        pythonPackageVersion = $manifest.pythonPackageVersion
+        sourceRevision       = $manifest.sourceRevision
+        targetRid            = $manifest.targetRid
+        installRoot          = $InstallRoot
+        applicationRoot      = $applicationRoot
     }
     $receipt | ConvertTo-Json -Depth 5 |
         Set-Content `

--- a/eng/scripts/azureauth-credprovider/New-DeploymentValidationBundle.ps1
+++ b/eng/scripts/azureauth-credprovider/New-DeploymentValidationBundle.ps1
@@ -63,27 +63,33 @@ $projectPath = Join-Path $repoRoot (
     'Hcoona.AzureAuth.CredProvider.Cli/Hcoona.AzureAuth.CredProvider.Cli.csproj'
 )
 $projectRoot = Split-Path -Parent $projectPath
-$versionOutput = dotnet tool run nbgv get-version -f json -p $projectRoot
-if ($LASTEXITCODE -ne 0) {
-    exit $LASTEXITCODE
+Push-Location -LiteralPath $repoRoot
+try {
+    $versionOutput = dotnet tool run nbgv get-version -f json -p $projectRoot
+    if ($LASTEXITCODE -ne 0) {
+        exit $LASTEXITCODE
+    }
+    $versionInfo = ($versionOutput -join [System.Environment]::NewLine) | ConvertFrom-Json
+    $productVersion = [string]$versionInfo.AssemblyInformationalVersion
+    $sourceRevision = [string]$versionInfo.GitCommitId
+    $semVer2 = [string]$versionInfo.SemVer2
+    if ([string]::IsNullOrWhiteSpace($productVersion) -or
+        [string]::IsNullOrWhiteSpace($sourceRevision) -or
+        [string]::IsNullOrWhiteSpace($semVer2)) {
+        throw 'NBGV did not resolve the required AzureAuth component version fields.'
+    }
+    $pythonPackageVersion = uv run `
+        --package nbgv-python `
+        python -c (
+        'from nbgv_python.versioning import normalize_version_field; ' +
+        'import sys; print(normalize_version_field(sys.argv[1], field="SemVer2"))'
+    ) $semVer2
+    if ($LASTEXITCODE -ne 0) {
+        exit $LASTEXITCODE
+    }
 }
-$versionInfo = ($versionOutput -join [System.Environment]::NewLine) | ConvertFrom-Json
-$productVersion = [string]$versionInfo.AssemblyInformationalVersion
-$sourceRevision = [string]$versionInfo.GitCommitId
-$semVer2 = [string]$versionInfo.SemVer2
-if ([string]::IsNullOrWhiteSpace($productVersion) -or
-    [string]::IsNullOrWhiteSpace($sourceRevision) -or
-    [string]::IsNullOrWhiteSpace($semVer2)) {
-    throw 'NBGV did not resolve the required AzureAuth component version fields.'
-}
-$pythonPackageVersion = uv run `
-    --package nbgv-python `
-    python -c (
-    'from nbgv_python.versioning import normalize_version_field; ' +
-    'import sys; print(normalize_version_field(sys.argv[1], field="SemVer2"))'
-) $semVer2
-if ($LASTEXITCODE -ne 0) {
-    exit $LASTEXITCODE
+finally {
+    Pop-Location
 }
 $pythonPackageVersion = ([string]$pythonPackageVersion).Trim()
 if ([string]::IsNullOrWhiteSpace($pythonPackageVersion)) {
@@ -277,13 +283,13 @@ function Assert-DeploymentPayloadMatchesBuildIdentity {
     $normalizedEntryPoints = (
         $entryPoints -replace "`r`n", "`n"
     ).TrimEnd("`n")
-    $expectedEntryPoints = @'
-[console_scripts]
-azureauth-keyring = azureauth_credprovider_keyring.shim:main
-
-[keyring.backends]
-azureauth = azureauth_credprovider_keyring.backend:AzureAuthKeyringBackend
-'@
+    $expectedEntryPoints = @(
+        '[console_scripts]'
+        'azureauth-keyring = azureauth_credprovider_keyring.shim:main'
+        ''
+        '[keyring.backends]'
+        'azureauth = azureauth_credprovider_keyring.backend:AzureAuthKeyringBackend'
+    ) -join "`n"
     if ($normalizedEntryPoints -cne $expectedEntryPoints) {
         throw 'The Python wheel entry points do not match the AzureAuth package contract.'
     }

--- a/eng/scripts/azureauth-credprovider/New-DeploymentValidationBundle.ps1
+++ b/eng/scripts/azureauth-credprovider/New-DeploymentValidationBundle.ps1
@@ -13,12 +13,6 @@ param(
     [string]$Configuration = 'Release',
 
     [ValidateNotNullOrEmpty()]
-    [string]$ProductVersion = '0.0.0-internal',
-
-    [ValidateNotNullOrEmpty()]
-    [string]$SourceRevision = 'unknown',
-
-    [ValidateNotNullOrEmpty()]
     [string]$OutputRoot = 'artifacts/azureauth-credprovider/deployment-validation',
 
     [switch]$NoBuild,
@@ -68,16 +62,120 @@ $projectPath = Join-Path $repoRoot (
     'src/private/app/azureauth-credprovider/' +
     'Hcoona.AzureAuth.CredProvider.Cli/Hcoona.AzureAuth.CredProvider.Cli.csproj'
 )
+$projectRoot = Split-Path -Parent $projectPath
+$versionOutput = dotnet tool run nbgv get-version -f json -p $projectRoot
+if ($LASTEXITCODE -ne 0) {
+    exit $LASTEXITCODE
+}
+$versionInfo = ($versionOutput -join [System.Environment]::NewLine) | ConvertFrom-Json
+$productVersion = [string]$versionInfo.AssemblyInformationalVersion
+$sourceRevision = [string]$versionInfo.GitCommitId
+$semVer2 = [string]$versionInfo.SemVer2
+if ([string]::IsNullOrWhiteSpace($productVersion) -or
+    [string]::IsNullOrWhiteSpace($sourceRevision) -or
+    [string]::IsNullOrWhiteSpace($semVer2)) {
+    throw 'NBGV did not resolve the required AzureAuth component version fields.'
+}
+$pythonPackageVersion = uv run `
+    --package nbgv-python `
+    python -c (
+    'from nbgv_python.versioning import normalize_version_field; ' +
+    'import sys; print(normalize_version_field(sys.argv[1], field="SemVer2"))'
+) $semVer2
+if ($LASTEXITCODE -ne 0) {
+    exit $LASTEXITCODE
+}
+$pythonPackageVersion = ([string]$pythonPackageVersion).Trim()
+if ([string]::IsNullOrWhiteSpace($pythonPackageVersion)) {
+    throw 'The nbgv-python version normalizer returned an empty Python package version.'
+}
+
 $stagingRoot = Join-Path $outputRootPath "staging/$BuildOs/$TargetRid"
 $appRoot = Join-Path $stagingRoot 'app'
 $launcherRoot = Join-Path $stagingRoot 'launchers'
 $pythonRoot = Join-Path $stagingRoot 'python'
+$buildIdentityPath = Join-Path $stagingRoot '.build-identity.json'
+$productExecutableName = if ($BuildOs -eq 'Windows') {
+    'azureauth-credprovider.exe'
+}
+else {
+    'azureauth-credprovider'
+}
+$productExecutablePath = Join-Path $appRoot $productExecutableName
 $packagePath = Join-Path $outputRootPath (
     "azureauth-credprovider-deployment-validation-internal-$BuildOs-$TargetRid.zip"
 )
 $temporaryPackagePath = "$packagePath.$([System.Guid]::NewGuid().ToString('N')).tmp"
 
+function Assert-DeploymentPayloadMatchesBuildIdentity {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ApplicationRoot,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ProductExecutablePath,
+
+        [Parameter(Mandatory = $true)]
+        [string]$PythonRoot,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ExpectedProductVersion,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ExpectedPythonPackageVersion
+    )
+
+    $nugetEntrypointPath = Join-Path $ApplicationRoot 'azureauth-credprovider.dll'
+    if (-not (Test-Path -LiteralPath $ProductExecutablePath -PathType Leaf) -or
+        -not (Test-Path -LiteralPath $nugetEntrypointPath -PathType Leaf)) {
+        throw 'The published application payload is incomplete.'
+    }
+
+    $componentVersionOutput = & $ProductExecutablePath --version
+    if ($LASTEXITCODE -ne 0 -or
+        ([string]$componentVersionOutput).Trim() -cne
+        "azureauth-credprovider $ExpectedProductVersion") {
+        throw 'The published application version does not match the NBGV build identity.'
+    }
+
+    $wheel = @(Get-ChildItem -LiteralPath $PythonRoot -Filter '*.whl' -File)
+    if ($wheel.Count -ne 1) {
+        throw 'The deployment validation bundle requires exactly one Python wheel.'
+    }
+    $wheelArchive = [System.IO.Compression.ZipFile]::OpenRead($wheel[0].FullName)
+    try {
+        $metadataEntries = @(
+            $wheelArchive.Entries |
+                Where-Object FullName -Like '*.dist-info/METADATA'
+        )
+        if ($metadataEntries.Count -ne 1) {
+            throw 'The Python wheel contains an invalid metadata inventory.'
+        }
+        $metadataReader = [System.IO.StreamReader]::new($metadataEntries[0].Open())
+        try {
+            $wheelMetadata = $metadataReader.ReadToEnd()
+        }
+        finally {
+            $metadataReader.Dispose()
+        }
+    }
+    finally {
+        $wheelArchive.Dispose()
+    }
+    $wheelVersionMatch = [System.Text.RegularExpressions.Regex]::Match(
+        $wheelMetadata,
+        '(?m)^Version: (?<version>[^\r\n]+)\r?$'
+    )
+    if (-not $wheelVersionMatch.Success -or
+        $wheelVersionMatch.Groups['version'].Value -cne $ExpectedPythonPackageVersion) {
+        throw 'The Python wheel version does not match the NBGV build identity.'
+    }
+
+    return $wheel[0]
+}
+
 New-Item -ItemType Directory -Path $outputRootPath -Force | Out-Null
+$generationSucceeded = $false
 
 try {
     if (-not $NoBuild) {
@@ -112,30 +210,38 @@ try {
         finally {
             Pop-Location
         }
+
+        [ordered]@{
+            schemaVersion        = 'azureauth-credprovider-build-identity-v1'
+            productVersion       = $productVersion
+            pythonPackageVersion = $pythonPackageVersion
+            sourceRevision       = $sourceRevision
+        } | ConvertTo-Json -Compress |
+            Set-Content -LiteralPath $buildIdentityPath -Encoding utf8
     }
     elseif (-not (Test-Path -LiteralPath $stagingRoot -PathType Container)) {
         throw "Canonical staging directory '$stagingRoot' does not exist. Run without -NoBuild first."
     }
+    elseif (-not (Test-Path -LiteralPath $buildIdentityPath -PathType Leaf)) {
+        throw "Canonical staging build identity '$buildIdentityPath' does not exist."
+    }
+
+    $buildIdentity = Get-Content -LiteralPath $buildIdentityPath -Raw | ConvertFrom-Json
+    if ($buildIdentity.schemaVersion -ne 'azureauth-credprovider-build-identity-v1' -or
+        $buildIdentity.productVersion -cne $productVersion -or
+        $buildIdentity.pythonPackageVersion -cne $pythonPackageVersion -or
+        $buildIdentity.sourceRevision -cne $sourceRevision) {
+        throw 'The canonical staging payload does not match the current NBGV build identity.'
+    }
+
+    $wheel = Assert-DeploymentPayloadMatchesBuildIdentity `
+        -ApplicationRoot $appRoot `
+        -ProductExecutablePath $productExecutablePath `
+        -PythonRoot $pythonRoot `
+        -ExpectedProductVersion $productVersion `
+        -ExpectedPythonPackageVersion $pythonPackageVersion
 
     New-Item -ItemType Directory -Path $launcherRoot -Force | Out-Null
-
-    $productExecutableName = if ($BuildOs -eq 'Windows') {
-        'azureauth-credprovider.exe'
-    }
-    else {
-        'azureauth-credprovider'
-    }
-    $productExecutablePath = Join-Path $appRoot $productExecutableName
-    $nugetEntrypointPath = Join-Path $appRoot 'azureauth-credprovider.dll'
-    if (-not (Test-Path -LiteralPath $productExecutablePath -PathType Leaf) -or
-        -not (Test-Path -LiteralPath $nugetEntrypointPath -PathType Leaf)) {
-        throw 'The published application payload is incomplete.'
-    }
-
-    $wheel = @(Get-ChildItem -LiteralPath $pythonRoot -Filter '*.whl' -File)
-    if ($wheel.Count -ne 1) {
-        throw 'The deployment validation bundle requires exactly one Python wheel.'
-    }
 
     if ($BuildOs -eq 'Windows') {
         @"
@@ -202,19 +308,20 @@ exec "$script_dir/../app/azureauth-credprovider" git credential-helper "$@"
     )
 
     $manifest = [ordered]@{
-        schemaVersion   = 'azureauth-credprovider-deployment-validation-v1'
-        artifactName    = 'azureauth-credprovider-deployment-validation'
-        buildOs         = $BuildOs
-        targetRid       = $TargetRid
-        productVersion  = $ProductVersion
-        sourceRevision  = $SourceRevision
-        producedBy      = 'eng/scripts/azureauth-credprovider/New-DeploymentValidationBundle.ps1'
-        releaseStatus   = 'internal-non-release'
-        signatureStatus = 'unsigned'
-        isInternal      = $true
-        isRelease       = $false
-        isSigned        = $false
-        entrypoints     = [ordered]@{
+        schemaVersion        = 'azureauth-credprovider-deployment-validation-v1'
+        artifactName         = 'azureauth-credprovider-deployment-validation'
+        buildOs              = $BuildOs
+        targetRid            = $TargetRid
+        productVersion       = $productVersion
+        pythonPackageVersion = $pythonPackageVersion
+        sourceRevision       = $sourceRevision
+        producedBy           = 'eng/scripts/azureauth-credprovider/New-DeploymentValidationBundle.ps1'
+        releaseStatus        = 'internal-non-release'
+        signatureStatus      = 'unsigned'
+        isInternal           = $true
+        isRelease            = $false
+        isSigned             = $false
+        entrypoints          = [ordered]@{
             cli         = "app/$productExecutableName"
             cliLauncher = $cliLauncherPath
             gitLauncher = $gitLauncherPath
@@ -223,7 +330,7 @@ exec "$script_dir/../app/azureauth-credprovider" git credential-helper "$@"
             installer   = 'install.ps1'
             uninstaller = 'uninstall.ps1'
         }
-        files           = $files
+        files                = $files
     }
     $manifest | ConvertTo-Json -Depth 10 -Compress |
         Set-Content -LiteralPath $manifestPath -Encoding utf8
@@ -306,12 +413,15 @@ exec "$script_dir/../app/azureauth-credprovider" git credential-helper "$@"
     }
 
     [System.IO.File]::Move($temporaryPackagePath, $packagePath, $true)
+    $generationSucceeded = $true
 }
 finally {
     if (Test-Path -LiteralPath $temporaryPackagePath) {
         Remove-Item -LiteralPath $temporaryPackagePath -Force
     }
-    if (-not $NoBuild -and (Test-Path -LiteralPath $stagingRoot)) {
+    if (-not $NoBuild -and
+        -not $generationSucceeded -and
+        (Test-Path -LiteralPath $stagingRoot)) {
         Remove-Item -LiteralPath $stagingRoot -Recurse -Force
     }
 }

--- a/eng/scripts/azureauth-credprovider/New-DeploymentValidationBundle.ps1
+++ b/eng/scripts/azureauth-credprovider/New-DeploymentValidationBundle.ps1
@@ -138,29 +138,103 @@ function Assert-DeploymentPayloadMatchesBuildIdentity {
         throw 'The published application version does not match the NBGV build identity.'
     }
 
+    $distributionName = 'azureauth-credprovider-keyring'
+    $wheelDistributionName = 'azureauth_credprovider_keyring'
+    $expectedWheelName = (
+        "$wheelDistributionName-$ExpectedPythonPackageVersion-py3-none-any.whl"
+    )
+    $expectedDistInfoRoot = (
+        "$wheelDistributionName-$ExpectedPythonPackageVersion.dist-info"
+    )
+    $expectedEntries = @(
+        "$expectedDistInfoRoot/METADATA"
+        "$expectedDistInfoRoot/WHEEL"
+        "$expectedDistInfoRoot/RECORD"
+        "$expectedDistInfoRoot/entry_points.txt"
+        "$wheelDistributionName/backend.py"
+        "$wheelDistributionName/helper.py"
+    )
+
     $wheel = @(Get-ChildItem -LiteralPath $PythonRoot -Filter '*.whl' -File)
     if ($wheel.Count -ne 1) {
         throw 'The deployment validation bundle requires exactly one Python wheel.'
     }
+    if ($wheel[0].Name -cne $expectedWheelName) {
+        throw "The Python wheel filename must be '$expectedWheelName'."
+    }
+
     $wheelArchive = [System.IO.Compression.ZipFile]::OpenRead($wheel[0].FullName)
     try {
-        $metadataEntries = @(
-            $wheelArchive.Entries |
-                Where-Object FullName -Like '*.dist-info/METADATA'
-        )
-        if ($metadataEntries.Count -ne 1) {
-            throw 'The Python wheel contains an invalid metadata inventory.'
+        $archiveEntries = @{}
+        foreach ($entry in $wheelArchive.Entries) {
+            if ($archiveEntries.ContainsKey($entry.FullName)) {
+                throw "The Python wheel contains duplicate entry '$($entry.FullName)'."
+            }
+            $archiveEntries.Add($entry.FullName, $entry)
         }
-        $metadataReader = [System.IO.StreamReader]::new($metadataEntries[0].Open())
+        foreach ($expectedEntry in $expectedEntries) {
+            if (-not $archiveEntries.ContainsKey($expectedEntry)) {
+                throw "The Python wheel is missing required entry '$expectedEntry'."
+            }
+        }
+
+        $distInfoEntries = @(
+            $wheelArchive.Entries |
+                Where-Object FullName -Like '*.dist-info/*'
+        )
+        if ($distInfoEntries.Count -eq 0 -or
+            @(
+                $distInfoEntries |
+                    Where-Object {
+                        -not $_.FullName.StartsWith(
+                            "$expectedDistInfoRoot/",
+                            [System.StringComparison]::Ordinal
+                        )
+                    }
+            ).Count -ne 0) {
+            throw "The Python wheel dist-info identity must be '$expectedDistInfoRoot'."
+        }
+
+        $metadataReader = [System.IO.StreamReader]::new(
+            $archiveEntries["$expectedDistInfoRoot/METADATA"].Open()
+        )
         try {
             $wheelMetadata = $metadataReader.ReadToEnd()
         }
         finally {
             $metadataReader.Dispose()
         }
+
+        $wheelReader = [System.IO.StreamReader]::new(
+            $archiveEntries["$expectedDistInfoRoot/WHEEL"].Open()
+        )
+        try {
+            $wheelDescriptor = $wheelReader.ReadToEnd()
+        }
+        finally {
+            $wheelReader.Dispose()
+        }
+
+        $entryPointsReader = [System.IO.StreamReader]::new(
+            $archiveEntries["$expectedDistInfoRoot/entry_points.txt"].Open()
+        )
+        try {
+            $entryPoints = $entryPointsReader.ReadToEnd()
+        }
+        finally {
+            $entryPointsReader.Dispose()
+        }
     }
     finally {
         $wheelArchive.Dispose()
+    }
+    $wheelNameMatch = [System.Text.RegularExpressions.Regex]::Match(
+        $wheelMetadata,
+        '(?m)^Name: (?<name>[^\r\n]+)\r?$'
+    )
+    if (-not $wheelNameMatch.Success -or
+        $wheelNameMatch.Groups['name'].Value -cne $distributionName) {
+        throw "The Python wheel metadata Name must be '$distributionName'."
     }
     $wheelVersionMatch = [System.Text.RegularExpressions.Regex]::Match(
         $wheelMetadata,
@@ -169,6 +243,24 @@ function Assert-DeploymentPayloadMatchesBuildIdentity {
     if (-not $wheelVersionMatch.Success -or
         $wheelVersionMatch.Groups['version'].Value -cne $ExpectedPythonPackageVersion) {
         throw 'The Python wheel version does not match the NBGV build identity.'
+    }
+    if ($wheelDescriptor -cnotmatch '(?m)^Root-Is-Purelib: true\r?$' -or
+        $wheelDescriptor -cnotmatch '(?m)^Tag: py3-none-any\r?$') {
+        throw 'The Python wheel descriptor must declare a pure Python py3-none-any wheel.'
+    }
+
+    $normalizedEntryPoints = (
+        $entryPoints -replace "`r`n", "`n"
+    ).TrimEnd("`n")
+    $expectedEntryPoints = @'
+[console_scripts]
+azureauth-keyring = azureauth_credprovider_keyring.shim:main
+
+[keyring.backends]
+azureauth = azureauth_credprovider_keyring.backend:AzureAuthKeyringBackend
+'@
+    if ($normalizedEntryPoints -cne $expectedEntryPoints) {
+        throw 'The Python wheel entry points do not match the AzureAuth package contract.'
     }
 
     return $wheel[0]

--- a/eng/scripts/azureauth-credprovider/New-DeploymentValidationBundle.ps1
+++ b/eng/scripts/azureauth-credprovider/New-DeploymentValidationBundle.ps1
@@ -146,14 +146,21 @@ function Assert-DeploymentPayloadMatchesBuildIdentity {
     $expectedDistInfoRoot = (
         "$wheelDistributionName-$ExpectedPythonPackageVersion.dist-info"
     )
+    $expectedPackageModules = @(
+        "$wheelDistributionName/__init__.py"
+        "$wheelDistributionName/backend.py"
+        "$wheelDistributionName/contracts.py"
+        "$wheelDistributionName/endpoint.py"
+        "$wheelDistributionName/helper.py"
+        "$wheelDistributionName/integrity.py"
+        "$wheelDistributionName/shim.py"
+    )
     $expectedEntries = @(
         "$expectedDistInfoRoot/METADATA"
         "$expectedDistInfoRoot/WHEEL"
         "$expectedDistInfoRoot/RECORD"
         "$expectedDistInfoRoot/entry_points.txt"
-        "$wheelDistributionName/backend.py"
-        "$wheelDistributionName/helper.py"
-    )
+    ) + $expectedPackageModules
 
     $wheel = @(Get-ChildItem -LiteralPath $PythonRoot -Filter '*.whl' -File)
     if ($wheel.Count -ne 1) {
@@ -165,7 +172,9 @@ function Assert-DeploymentPayloadMatchesBuildIdentity {
 
     $wheelArchive = [System.IO.Compression.ZipFile]::OpenRead($wheel[0].FullName)
     try {
-        $archiveEntries = @{}
+        $archiveEntries = [System.Collections.Generic.Dictionary[string, object]]::new(
+            [System.StringComparer]::Ordinal
+        )
         foreach ($entry in $wheelArchive.Entries) {
             if ($archiveEntries.ContainsKey($entry.FullName)) {
                 throw "The Python wheel contains duplicate entry '$($entry.FullName)'."
@@ -176,6 +185,22 @@ function Assert-DeploymentPayloadMatchesBuildIdentity {
             if (-not $archiveEntries.ContainsKey($expectedEntry)) {
                 throw "The Python wheel is missing required entry '$expectedEntry'."
             }
+        }
+        $packageModules = @(
+            $wheelArchive.Entries |
+                Where-Object {
+                    $_.FullName.StartsWith(
+                        "$wheelDistributionName/",
+                        [System.StringComparison]::Ordinal
+                    ) -and
+                    $_.FullName.EndsWith('.py', [System.StringComparison]::Ordinal)
+                } |
+                ForEach-Object FullName |
+                Sort-Object
+        )
+        if (($packageModules | ConvertTo-Json -Compress) -cne
+            ($expectedPackageModules | Sort-Object | ConvertTo-Json -Compress)) {
+            throw 'The Python wheel package module inventory is invalid.'
         }
 
         $distInfoEntries = @(

--- a/src/private/app/azureauth-credprovider/docs/phase-wp16-deployment-validation-bundle.md
+++ b/src/private/app/azureauth-credprovider/docs/phase-wp16-deployment-validation-bundle.md
@@ -19,14 +19,15 @@ not create or accept a release installer.
 payload for `win-x64` or `linux-x64` and builds one Python wheel. The ZIP
 contains:
 
-| Path            | Purpose                                                                  |
-| --------------- | ------------------------------------------------------------------------ |
-| `app/`          | Complete published CLI payload and NuGet netcore plugin entrypoint.      |
-| `launchers/`    | CLI and Git credential-helper launchers.                                 |
-| `python/`       | The `azureauth-credprovider-keyring` wheel.                              |
-| `manifest.json` | Artifact identity, boundaries, entrypoints, lengths, and SHA-256 hashes. |
-| `install.ps1`   | Per-user physical installation without ecosystem activation.             |
-| `uninstall.ps1` | Configuration-aware removal of product-owned payloads.                   |
+| Path                   | Purpose                                                                  |
+| ---------------------- | ------------------------------------------------------------------------ |
+| `app/`                 | Complete published CLI payload and NuGet netcore plugin entrypoint.      |
+| `launchers/`           | CLI and Git credential-helper launchers.                                 |
+| `python/`              | The `azureauth-credprovider-keyring` wheel.                              |
+| `.build-identity.json` | NBGV-derived app, wheel, and source identity for safe `-NoBuild` reuse.  |
+| `manifest.json`        | Artifact identity, boundaries, entrypoints, lengths, and SHA-256 hashes. |
+| `install.ps1`          | Per-user physical installation without ecosystem activation.             |
+| `uninstall.ps1`        | Configuration-aware removal of product-owned payloads.                   |
 
 The archive schema is
 `azureauth-credprovider-deployment-validation-v1`. ZIP entry timestamps are
@@ -57,6 +58,17 @@ copies the installed application payload to
 `~/.nuget/plugins/netcore/azureauth-credprovider` and records the product-owned
 activation inventory. `unconfigure nuget` removes only inventory-listed files
 whose hashes still match and preserves unrelated files.
+
+The bundle generator resolves `AssemblyInformationalVersion`, `SemVer2`, and
+`GitCommitId` from the component's existing NBGV `version.json`. It validates
+the published app's `--version` output and the wheel's normalized metadata
+version before writing the manifest, including when `-NoBuild` reuses canonical
+staging. The staging sidecar records source/build identity but cannot substitute
+for payload validation. The install receipt copies those validated app and
+Python package versions; callers cannot supply a separate receipt version.
+Successful normal generation retains only the canonical RID staging tree and
+identity sidecar needed for a direct subsequent `-NoBuild` invocation. Failed
+normal generation removes incomplete staging.
 
 The wheel must be installed into the exact Python environment that imports the
 backend. On Linux, `configure python` then writes the backend manifest and
@@ -109,15 +121,16 @@ failure.
 On 2026-08-11, an isolated `linux-x64` working-tree bundle completed:
 
 1. Archive manifest and file-hash validation.
-2. Physical installation without a NuGet conventional discovery directory.
-3. Uninstallation before NuGet configuration.
-4. `configure nuget` creation of the discoverable owned plugin layout.
-5. Configuration-aware uninstallation after NuGet configuration.
-6. Removal of owned NuGet activation files while preserving an unrelated file.
-7. Refusal to force-replace unrelated or receipt-mismatched product roots.
-8. Cleanup of product roots created by a failed installation.
-9. Installation from an extraction path containing wildcard characters.
-10. Rejection of hidden files absent from the bundle manifest.
+2. NBGV-derived app, wheel, manifest, and receipt version coherence.
+3. Physical installation without a NuGet conventional discovery directory.
+4. Uninstallation before NuGet configuration.
+5. `configure nuget` creation of the discoverable owned plugin layout.
+6. Configuration-aware uninstallation after NuGet configuration.
+7. Removal of owned NuGet activation files while preserving an unrelated file.
+8. Refusal to force-replace unrelated or receipt-mismatched product roots.
+9. Cleanup of product roots created by a failed installation.
+10. Installation from an extraction path containing wildcard characters.
+11. Rejection of hidden files absent from the bundle manifest.
 
 No token acquisition, AzureAuth launch, browser interaction, WAM interaction,
 device code, or private-feed authorization occurred.

--- a/src/private/app/azureauth-credprovider/python/tests/test_package_metadata.py
+++ b/src/private/app/azureauth-credprovider/python/tests/test_package_metadata.py
@@ -11,7 +11,7 @@ import tomllib
 import zipfile
 from email.parser import Parser
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
@@ -338,6 +338,33 @@ def test_bundle_builds_versioned_wheel_from_clean_checkout(
     assert completed.returncode == 0, completed.stderr
 
     _run_git(repository, "switch", "--quiet", "--force-create", "main")
+    cloned_bundle_script = repository / BUNDLE_SCRIPT_RELATIVE_PATH
+    shutil.copy2(BUNDLE_SCRIPT_PATH, cloned_bundle_script)
+    script_diff = subprocess.run(  # noqa: S603
+        [
+            git,
+            "diff",
+            "--quiet",
+            "--",
+            str(BUNDLE_SCRIPT_RELATIVE_PATH),
+        ],
+        cwd=repository,
+        check=False,
+    )
+    assert script_diff.returncode in {0, 1}
+    if script_diff.returncode == 1:
+        _run_git(repository, "add", "--", str(BUNDLE_SCRIPT_RELATIVE_PATH))
+        _run_git(
+            repository,
+            "-c",
+            "user.email=tests@example.invalid",
+            "-c",
+            "user.name=AzureAuth metadata tests",
+            "commit",
+            "--quiet",
+            "--message",
+            "Test current deployment bundle implementation",
+        )
     assert _run_git(repository, "status", "--porcelain") == ""
     assert _run_git(
         repository,
@@ -348,8 +375,11 @@ def test_bundle_builds_versioned_wheel_from_clean_checkout(
 
     project_root = repository / "src/private/app/azureauth-credprovider"
     version_data = _get_version(project_root / "python", repository)
-    product_version = version_data["SemVer2"]
-    source_revision = _run_git(repository, "rev-parse", "HEAD")
+    product_version = version_data["AssemblyInformationalVersion"]
+    semver2 = version_data["SemVer2"]
+    python_package_version = _wheel_version(semver2)
+    source_revision = version_data["GitCommitId"]
+    cloned_head = _run_git(repository, "rev-parse", "HEAD")
     output_root = tmp_path / "deployment-validation"
     pwsh = _required_executable("pwsh")
     completed = subprocess.run(  # noqa: S603
@@ -364,10 +394,6 @@ def test_bundle_builds_versioned_wheel_from_clean_checkout(
             "linux-x64",
             "-Configuration",
             "Release",
-            "-ProductVersion",
-            product_version,
-            "-SourceRevision",
-            source_revision,
             "-OutputRoot",
             str(output_root),
         ],
@@ -380,13 +406,12 @@ def test_bundle_builds_versioned_wheel_from_clean_checkout(
     assert completed.returncode == 0, (
         f"stdout:\n{completed.stdout}\nstderr:\n{completed.stderr}"
     )
-
     bundle_paths = list(output_root.glob("*.zip"))
     assert len(bundle_paths) == 1
-    expected_wheel_version = _wheel_version(product_version)
+    assert len(bundle_paths) == 1
     expected_wheel_name = (
         "azureauth_credprovider_keyring-"
-        f"{expected_wheel_version}-py3-none-any.whl"
+        f"{python_package_version}-py3-none-any.whl"
     )
 
     with zipfile.ZipFile(bundle_paths[0]) as bundle:
@@ -402,8 +427,10 @@ def test_bundle_builds_versioned_wheel_from_clean_checkout(
     metadata = _read_wheel_metadata(nested_wheel_path)
 
     assert metadata["Name"] == "azureauth-credprovider-keyring"
-    assert metadata["Version"] == expected_wheel_version
+    assert metadata["Version"] == python_package_version
+    assert source_revision == cloned_head
     assert manifest["productVersion"] == product_version
+    assert manifest["pythonPackageVersion"] == python_package_version
     assert manifest["sourceRevision"] == source_revision
     assert manifest["entrypoints"]["pythonWheel"] == wheel_entries[0]
 
@@ -460,7 +487,7 @@ def _commit_path(repository: Path, relative_path: str) -> None:
 def _get_version(
     project_root: Path,
     command_root: Path = WORKSPACE_ROOT,
-) -> dict[str, object]:
+) -> dict[str, Any]:
     completed = subprocess.run(  # noqa: S603
         [
             _required_executable("dotnet"),

--- a/src/private/app/azureauth-credprovider/python/tests/test_package_metadata.py
+++ b/src/private/app/azureauth-credprovider/python/tests/test_package_metadata.py
@@ -408,7 +408,6 @@ def test_bundle_builds_versioned_wheel_from_clean_checkout(
     )
     bundle_paths = list(output_root.glob("*.zip"))
     assert len(bundle_paths) == 1
-    assert len(bundle_paths) == 1
     expected_wheel_name = (
         "azureauth_credprovider_keyring-"
         f"{python_package_version}-py3-none-any.whl"

--- a/tests/private/app/azureauth-credprovider/Install-DeploymentValidationBundle.Tests.ps1
+++ b/tests/private/app/azureauth-credprovider/Install-DeploymentValidationBundle.Tests.ps1
@@ -1308,10 +1308,16 @@ print("controlled-supported-host-failure")
 
 try {
     $normalReuseOutput = Join-Path $testRoot 'normal-then-no-build'
-    & $bundleGeneratorSource `
-        -BuildOs $buildOs `
-        -TargetRid $targetRid `
-        -OutputRoot $normalReuseOutput | Out-Null
+    Push-Location -LiteralPath (Split-Path -Parent $repoRoot)
+    try {
+        & $bundleGeneratorSource `
+            -BuildOs $buildOs `
+            -TargetRid $targetRid `
+            -OutputRoot $normalReuseOutput | Out-Null
+    }
+    finally {
+        Pop-Location
+    }
     $normalReuseStaging = Join-Path $normalReuseOutput "staging/$buildOs/$targetRid"
     $normalReuseIdentity = Join-Path $normalReuseStaging '.build-identity.json'
     $normalReusePackage = Join-Path $normalReuseOutput $deploymentPackageName

--- a/tests/private/app/azureauth-credprovider/Install-DeploymentValidationBundle.Tests.ps1
+++ b/tests/private/app/azureauth-credprovider/Install-DeploymentValidationBundle.Tests.ps1
@@ -32,6 +32,25 @@ else {
 $deploymentPackageName = (
     "azureauth-credprovider-deployment-validation-internal-$buildOs-$targetRid.zip"
 )
+$versionOutput = dotnet tool run nbgv get-version -f json -p (
+    Join-Path $repoRoot 'src/private/app/azureauth-credprovider'
+)
+if ($LASTEXITCODE -ne 0) {
+    exit $LASTEXITCODE
+}
+$versionInfo = ($versionOutput -join [System.Environment]::NewLine) | ConvertFrom-Json
+$expectedProductVersion = [string]$versionInfo.AssemblyInformationalVersion
+$expectedSourceRevision = [string]$versionInfo.GitCommitId
+$expectedPythonPackageVersion = uv run `
+    --package nbgv-python `
+    python -c (
+    'from nbgv_python.versioning import normalize_version_field; ' +
+    'import sys; print(normalize_version_field(sys.argv[1], field="SemVer2"))'
+) ([string]$versionInfo.SemVer2)
+if ($LASTEXITCODE -ne 0) {
+    exit $LASTEXITCODE
+}
+$expectedPythonPackageVersion = ([string]$expectedPythonPackageVersion).Trim()
 
 function Assert-True {
     param(
@@ -152,6 +171,116 @@ function Assert-InvocationFailure {
     throw $Message
 }
 
+function New-ValidDeploymentGeneratorBundleRoot {
+    [CmdletBinding(SupportsShouldProcess)]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Destination,
+
+        [Parameter(Mandatory = $true)]
+        [string]$PackagePath
+    )
+
+    if (-not $PSCmdlet.ShouldProcess($Destination, 'Create valid generator bundle root')) {
+        return
+    }
+
+    New-Item -ItemType Directory -Path $Destination -Force | Out-Null
+    [System.IO.Compression.ZipFile]::ExtractToDirectory(
+        (Resolve-Path -LiteralPath $PackagePath).Path,
+        $Destination
+    )
+    return $Destination
+}
+
+function Set-TestWheelVersion {
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$WheelPath,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Version
+    )
+
+    if (-not $PSCmdlet.ShouldProcess($WheelPath, 'Set test wheel version metadata')) {
+        return
+    }
+
+    if (Test-Path -LiteralPath $WheelPath) {
+        Remove-Item -LiteralPath $WheelPath -Force
+    }
+    $wheelArchive = [System.IO.Compression.ZipFile]::Open(
+        $WheelPath,
+        [System.IO.Compression.ZipArchiveMode]::Create
+    )
+    try {
+        $metadataEntry = $wheelArchive.CreateEntry(
+            "azureauth_credprovider_keyring-$Version.dist-info/METADATA"
+        )
+        $metadataWriter = [System.IO.StreamWriter]::new($metadataEntry.Open())
+        try {
+            $metadataWriter.Write(
+                "Metadata-Version: 2.3`n" +
+                "Name: azureauth-credprovider-keyring`n" +
+                "Version: $Version`n"
+            )
+        }
+        finally {
+            $metadataWriter.Dispose()
+        }
+    }
+    finally {
+        $wheelArchive.Dispose()
+    }
+}
+
+function New-WrongVersionApplication {
+    [CmdletBinding(SupportsShouldProcess)]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Destination
+    )
+
+    if (-not $PSCmdlet.ShouldProcess($Destination, 'Create wrong-version test application')) {
+        return
+    }
+
+    $projectRoot = Join-Path $testRoot 'wrong-version-application-project'
+    New-Item -ItemType Directory -Path $projectRoot -Force | Out-Null
+    @'
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <AssemblyName>azureauth-credprovider</AssemblyName>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>
+'@ | Set-Content -LiteralPath (Join-Path $projectRoot 'WrongVersion.csproj') -Encoding utf8
+    @'
+if (args is ["--version"])
+{
+    Console.WriteLine("azureauth-credprovider 0.0.0-stale");
+    return;
+}
+
+Environment.ExitCode = 1;
+'@ | Set-Content -LiteralPath (Join-Path $projectRoot 'Program.cs') -Encoding utf8
+
+    $publishOutput = dotnet publish (Join-Path $projectRoot 'WrongVersion.csproj') `
+        --configuration Release `
+        --runtime $targetRid `
+        --self-contained false `
+        --output $Destination 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "Wrong-version test application publish failed:`n$($publishOutput -join "`n")"
+    }
+    return $Destination
+}
+
 function New-TestBundle {
     [CmdletBinding(SupportsShouldProcess)]
     param(
@@ -212,8 +341,9 @@ function New-TestBundle {
         schemaVersion  = 'azureauth-credprovider-deployment-validation-v1'
         buildOs        = $buildOs
         targetRid      = $targetRid
-        productVersion = '2.0.0-test'
-        sourceRevision = 'new-revision'
+        productVersion       = '2.0.0-test'
+        pythonPackageVersion = '2.0.0'
+        sourceRevision       = 'new-revision'
         releaseStatus  = 'internal-non-release'
         isInternal     = $true
         isRelease      = $false
@@ -240,20 +370,36 @@ function New-DeploymentGeneratorStaging {
     $stagingRoot = Join-Path $OutputRoot "staging/$buildOs/$targetRid"
     $appRoot = Join-Path $stagingRoot 'app'
     $pythonRoot = Join-Path $stagingRoot 'python'
-    New-Item -ItemType Directory -Path $appRoot -Force | Out-Null
-    New-Item -ItemType Directory -Path $pythonRoot -Force | Out-Null
-    Set-Content `
-        -LiteralPath (Join-Path $appRoot $productExecutableName) `
-        -Value 'deployment generator executable' `
-        -NoNewline
-    Set-Content `
-        -LiteralPath (Join-Path $appRoot 'azureauth-credprovider.dll') `
-        -Value 'deployment generator plugin' `
-        -NoNewline
-    Set-Content `
-        -LiteralPath (Join-Path $pythonRoot 'azureauth_credprovider-1.0.0-py3-none-any.whl') `
-        -Value 'deployment generator wheel' `
-        -NoNewline
+    New-Item -ItemType Directory -Path $stagingRoot -Force | Out-Null
+    Copy-Item `
+        -LiteralPath (Join-Path $validDeploymentBundleRoot 'app') `
+        -Destination $appRoot `
+        -Recurse
+    Copy-Item `
+        -LiteralPath (Join-Path $validDeploymentBundleRoot 'python') `
+        -Destination $pythonRoot `
+        -Recurse
+    if (-not $runningOnWindows) {
+        [System.IO.File]::SetUnixFileMode(
+            (Join-Path $appRoot $productExecutableName),
+            [System.IO.UnixFileMode]::UserRead -bor
+            [System.IO.UnixFileMode]::UserWrite -bor
+            [System.IO.UnixFileMode]::UserExecute -bor
+            [System.IO.UnixFileMode]::GroupRead -bor
+            [System.IO.UnixFileMode]::GroupExecute -bor
+            [System.IO.UnixFileMode]::OtherRead -bor
+            [System.IO.UnixFileMode]::OtherExecute
+        )
+    }
+    [ordered]@{
+        schemaVersion        = 'azureauth-credprovider-build-identity-v1'
+        productVersion       = $expectedProductVersion
+        pythonPackageVersion = $expectedPythonPackageVersion
+        sourceRevision       = $expectedSourceRevision
+    } | ConvertTo-Json -Compress |
+        Set-Content `
+            -LiteralPath (Join-Path $stagingRoot '.build-identity.json') `
+            -Encoding utf8
 }
 
 function Invoke-DeploymentGenerator {
@@ -267,12 +413,10 @@ function Invoke-DeploymentGenerator {
     )
 
     $parameters = @{
-        BuildOs        = $buildOs
-        TargetRid      = $targetRid
-        OutputRoot     = $OutputRoot
-        ProductVersion = '2.0.0-test'
-        SourceRevision = 'generator-test'
-        NoBuild        = $true
+        BuildOs    = $buildOs
+        TargetRid  = $targetRid
+        OutputRoot = $OutputRoot
+        NoBuild    = $true
     }
     if ($null -ne $BeforeArchiveEntry) {
         $parameters.BeforeArchiveEntry = $BeforeArchiveEntry
@@ -755,6 +899,21 @@ function Invoke-ActualUninstallRegression {
                 -Message 'The installed keyring shim did not return no-credential for an unrelated host.'
         }
 
+        & $productExecutablePath configure nuget | Out-Null
+        Assert-Equal `
+            -Expected 0 `
+            -Actual $LASTEXITCODE `
+            -Message 'Actual NuGet configuration failed.'
+        Assert-True (
+            Test-Path -LiteralPath (
+                Join-Path $pluginRoot 'azureauth-credprovider.dll'
+            ) -PathType Leaf
+        ) 'NuGet configuration did not create a discoverable plugin activation.'
+        Set-Content `
+            -LiteralPath (Join-Path $pluginRoot 'preserve.txt') `
+            -Value 'unrelated activation-root content' `
+            -NoNewline
+
         $registryUrl = 'https://pkgs.dev.azure.com/example/project/_packaging/feed/npm/registry/'
         Move-Item -LiteralPath $gitMarkerPath -Destination $heldGitMarkerPath
         try {
@@ -869,6 +1028,24 @@ function Invoke-ActualUninstallRegression {
         Assert-True (
             Test-Path -LiteralPath (Join-Path $otherJobRoot 'preserve.txt') -PathType Leaf
         ) 'Actual uninstall removed another Azure Pipelines job state.'
+
+        & (Join-Path $extractedBundleRoot 'install.ps1') -InstallRoot $installRoot | Out-Null
+        Remove-Item -LiteralPath (
+            Join-Path $installRoot "app/$productExecutableName"
+        ) -Force
+        Assert-InvocationFailure {
+            & (Join-Path $extractedBundleRoot 'uninstall.ps1') -InstallRoot $installRoot |
+                Out-Null
+        } 'Damaged installation unexpectedly allowed normal uninstall.'
+        Assert-True (
+            Test-Path -LiteralPath $installRoot -PathType Container
+        ) 'Damaged-install refusal removed the product root.'
+        & (Join-Path $extractedBundleRoot 'uninstall.ps1') `
+            -InstallRoot $installRoot `
+            -SkipConfigurationCleanup | Out-Null
+        Assert-True (
+            -not (Test-Path -LiteralPath $installRoot)
+        ) 'Explicit damaged-install cleanup did not remove the product root.'
     }
     finally {
         if (Test-Path -LiteralPath $heldGitMarkerPath) {
@@ -882,6 +1059,67 @@ function Invoke-ActualUninstallRegression {
 }
 
 try {
+    $normalReuseOutput = Join-Path $testRoot 'normal-then-no-build'
+    & $bundleGeneratorSource `
+        -BuildOs $buildOs `
+        -TargetRid $targetRid `
+        -OutputRoot $normalReuseOutput | Out-Null
+    $normalReuseStaging = Join-Path $normalReuseOutput "staging/$buildOs/$targetRid"
+    $normalReuseIdentity = Join-Path $normalReuseStaging '.build-identity.json'
+    $normalReusePackage = Join-Path $normalReuseOutput $deploymentPackageName
+    Assert-True (
+        Test-Path -LiteralPath $normalReuseStaging -PathType Container
+    ) 'Normal generation did not retain canonical staging for -NoBuild reuse.'
+    Assert-True (
+        Test-Path -LiteralPath $normalReuseIdentity -PathType Leaf
+    ) 'Normal generation did not retain its canonical build identity.'
+    Assert-True (
+        Test-Path -LiteralPath $normalReusePackage -PathType Leaf
+    ) 'Normal generation did not create the deployment package.'
+
+    Invoke-DeploymentGenerator -OutputRoot $normalReuseOutput
+
+    Assert-True (
+        Test-Path -LiteralPath $normalReuseStaging -PathType Container
+    ) '-NoBuild removed canonical staging retained by normal generation.'
+    Assert-True (
+        Test-Path -LiteralPath $normalReuseIdentity -PathType Leaf
+    ) '-NoBuild removed the canonical build identity.'
+    Assert-True (
+        Test-Path -LiteralPath $normalReusePackage -PathType Leaf
+    ) '-NoBuild did not recreate the deployment package from retained staging.'
+    Assert-NoTemporaryDeploymentPackage `
+        -OutputRoot $normalReuseOutput `
+        -Context 'normal generation followed by direct -NoBuild reuse'
+
+    $validDeploymentBundleRoot = New-ValidDeploymentGeneratorBundleRoot `
+        -Destination (Join-Path $testRoot 'valid-generator-bundle') `
+        -PackagePath $normalReusePackage
+    $normalReusePackageBytes = [System.IO.File]::ReadAllBytes($normalReusePackage)
+    Assert-InvocationFailure {
+        & $bundleGeneratorSource `
+            -BuildOs $buildOs `
+            -TargetRid $targetRid `
+            -OutputRoot $normalReuseOutput `
+            -BeforeArchiveEntry {
+            param([string]$EntryName)
+            throw "Injected normal-generation packaging failure before '$EntryName'."
+        } | Out-Null
+    } 'Expected injected normal-generation packaging failure.'
+    Assert-True (
+        -not (Test-Path -LiteralPath $normalReuseStaging)
+    ) 'Failed normal generation retained incomplete canonical staging.'
+    Assert-BytesEqual `
+        -Expected $normalReusePackageBytes `
+        -Actual ([System.IO.File]::ReadAllBytes($normalReusePackage)) `
+        -Message 'Failed normal generation changed the previous deployment package.'
+    Assert-NoTemporaryDeploymentPackage `
+        -OutputRoot $normalReuseOutput `
+        -Context 'failed normal generation cleanup'
+
+    $wrongVersionApplicationRoot = New-WrongVersionApplication `
+        -Destination (Join-Path $testRoot 'wrong-version-application')
+
     $generatorSuccessOutput = Join-Path $testRoot 'generator-success'
     New-DeploymentGeneratorStaging -OutputRoot $generatorSuccessOutput
     $generatorSuccessPackage = Join-Path $generatorSuccessOutput $deploymentPackageName
@@ -925,9 +1163,17 @@ try {
         Join-Path $twiceNoBuildInstallRoot 'installation.json'
     ) -Raw | ConvertFrom-Json
     Assert-Equal `
-        -Expected 'generator-test' `
+        -Expected $expectedSourceRevision `
         -Actual $twiceNoBuildReceipt.sourceRevision `
         -Message 'The twice-NoBuild bundle installed an unexpected receipt.'
+    Assert-Equal `
+        -Expected $expectedProductVersion `
+        -Actual $twiceNoBuildReceipt.productVersion `
+        -Message 'The installed receipt does not match the NBGV application version.'
+    Assert-Equal `
+        -Expected $expectedPythonPackageVersion `
+        -Actual $twiceNoBuildReceipt.pythonPackageVersion `
+        -Message 'The installed receipt does not match the NBGV Python package version.'
 
     Assert-NoTemporaryDeploymentPackage `
         -OutputRoot $generatorSuccessOutput `
@@ -954,6 +1200,67 @@ try {
     Assert-NoTemporaryDeploymentPackage `
         -OutputRoot $generatorFailureOutput `
         -Context 'injected packaging failure'
+
+    $identityFailureOutput = Join-Path $testRoot 'identity-failure'
+    New-DeploymentGeneratorStaging -OutputRoot $identityFailureOutput
+    $identityPath = Join-Path (
+        Join-Path $identityFailureOutput "staging/$buildOs/$targetRid"
+    ) '.build-identity.json'
+    $staleIdentity = Get-Content -LiteralPath $identityPath -Raw | ConvertFrom-Json
+    $staleIdentity.productVersion = '1.0.0-beta.252'
+    $staleIdentity | ConvertTo-Json -Compress |
+        Set-Content -LiteralPath $identityPath -Encoding utf8
+    Assert-InvocationFailure {
+        Invoke-DeploymentGenerator -OutputRoot $identityFailureOutput
+    } 'Expected stale staging version identity rejection.'
+    Assert-NoTemporaryDeploymentPackage `
+        -OutputRoot $identityFailureOutput `
+        -Context 'stale staging identity rejection'
+
+    $applicationFailureOutput = Join-Path $testRoot 'application-payload-failure'
+    New-DeploymentGeneratorStaging -OutputRoot $applicationFailureOutput
+    Copy-Item `
+        -Path (Join-Path $wrongVersionApplicationRoot '*') `
+        -Destination (
+        Join-Path $applicationFailureOutput "staging/$buildOs/$targetRid/app"
+    ) `
+        -Force
+    Assert-InvocationFailure {
+        Invoke-DeploymentGenerator -OutputRoot $applicationFailureOutput
+    } 'Expected wrong staged application version rejection.'
+    Assert-NoTemporaryDeploymentPackage `
+        -OutputRoot $applicationFailureOutput `
+        -Context 'wrong staged application version rejection'
+
+    $malformedWheelOutput = Join-Path $testRoot 'malformed-wheel-failure'
+    New-DeploymentGeneratorStaging -OutputRoot $malformedWheelOutput
+    $malformedWheelPath = @(
+        Get-ChildItem -LiteralPath (
+            Join-Path $malformedWheelOutput "staging/$buildOs/$targetRid/python"
+        ) -Filter '*.whl' -File
+    )[0].FullName
+    [System.IO.File]::WriteAllText($malformedWheelPath, 'not a wheel archive')
+    Assert-InvocationFailure {
+        Invoke-DeploymentGenerator -OutputRoot $malformedWheelOutput
+    } 'Expected malformed staged wheel rejection.'
+    Assert-NoTemporaryDeploymentPackage `
+        -OutputRoot $malformedWheelOutput `
+        -Context 'malformed staged wheel rejection'
+
+    $wrongWheelOutput = Join-Path $testRoot 'wrong-wheel-failure'
+    New-DeploymentGeneratorStaging -OutputRoot $wrongWheelOutput
+    $wrongWheelPath = @(
+        Get-ChildItem -LiteralPath (
+            Join-Path $wrongWheelOutput "staging/$buildOs/$targetRid/python"
+        ) -Filter '*.whl' -File
+    )[0].FullName
+    Set-TestWheelVersion -WheelPath $wrongWheelPath -Version '0.0.0'
+    Assert-InvocationFailure {
+        Invoke-DeploymentGenerator -OutputRoot $wrongWheelOutput
+    } 'Expected wrong staged wheel version rejection.'
+    Assert-NoTemporaryDeploymentPackage `
+        -OutputRoot $wrongWheelOutput `
+        -Context 'wrong staged wheel version rejection'
 
     $bundleRoot = Join-Path $testRoot 'bundle'
     New-TestBundle -BundleRoot $bundleRoot

--- a/tests/private/app/azureauth-credprovider/Install-DeploymentValidationBundle.Tests.ps1
+++ b/tests/private/app/azureauth-credprovider/Install-DeploymentValidationBundle.Tests.ps1
@@ -236,6 +236,90 @@ function Set-TestWheelVersion {
     }
 }
 
+function Set-TestWheelContent {
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$WheelPath,
+
+        [string]$MetadataName,
+
+        [string[]]$OmitEntryName = @(),
+
+        [string]$EntryPointsContent
+    )
+
+    if (-not $PSCmdlet.ShouldProcess($WheelPath, 'Mutate test wheel content')) {
+        return
+    }
+
+    $temporaryWheelPath = "$WheelPath.mutated"
+    $sourceArchive = [System.IO.Compression.ZipFile]::OpenRead($WheelPath)
+    try {
+        $destinationArchive = [System.IO.Compression.ZipFile]::Open(
+            $temporaryWheelPath,
+            [System.IO.Compression.ZipArchiveMode]::Create
+        )
+        try {
+            foreach ($sourceEntry in $sourceArchive.Entries) {
+                if ([System.Linq.Enumerable]::Contains(
+                        $OmitEntryName,
+                        $sourceEntry.FullName,
+                        [System.StringComparer]::Ordinal
+                    )) {
+                    continue
+                }
+
+                $destinationEntry = $destinationArchive.CreateEntry(
+                    $sourceEntry.FullName,
+                    [System.IO.Compression.CompressionLevel]::NoCompression
+                )
+                $sourceStream = $sourceEntry.Open()
+                $destinationStream = $destinationEntry.Open()
+                try {
+                    if (-not [string]::IsNullOrWhiteSpace($MetadataName) -and
+                        $sourceEntry.FullName -like '*.dist-info/METADATA') {
+                        $reader = [System.IO.StreamReader]::new($sourceStream)
+                        $content = $reader.ReadToEnd()
+                        $reader.Dispose()
+                        $writer = [System.IO.StreamWriter]::new($destinationStream)
+                        $writer.Write(
+                            [System.Text.RegularExpressions.Regex]::Replace(
+                                $content,
+                                '(?m)^Name: [^\r\n]+\r?$',
+                                "Name: $MetadataName"
+                            )
+                        )
+                        $writer.Dispose()
+                    }
+                    elseif ($null -ne $EntryPointsContent -and
+                        $sourceEntry.FullName -like '*.dist-info/entry_points.txt') {
+                        $writer = [System.IO.StreamWriter]::new($destinationStream)
+                        $writer.Write($EntryPointsContent)
+                        $writer.Dispose()
+                    }
+                    else {
+                        $sourceStream.CopyTo($destinationStream)
+                    }
+                }
+                finally {
+                    $sourceStream.Dispose()
+                    $destinationStream.Dispose()
+                }
+            }
+        }
+        finally {
+            $destinationArchive.Dispose()
+        }
+    }
+    finally {
+        $sourceArchive.Dispose()
+    }
+
+    Remove-Item -LiteralPath $WheelPath -Force
+    Move-Item -LiteralPath $temporaryWheelPath -Destination $WheelPath
+}
+
 function New-WrongVersionApplication {
     [CmdletBinding(SupportsShouldProcess)]
     [OutputType([string])]
@@ -426,6 +510,28 @@ function Invoke-DeploymentGenerator {
     }
 
     & $bundleGeneratorSource @parameters | Out-Null
+}
+
+function Assert-InvalidStagedWheelRejected {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Name,
+
+        [Parameter(Mandatory = $true)]
+        [scriptblock]$Mutation
+    )
+
+    $outputRoot = Join-Path $testRoot "wheel-$Name"
+    New-DeploymentGeneratorStaging -OutputRoot $outputRoot
+    $wheelPath = @(
+        Get-ChildItem -LiteralPath (
+            Join-Path $outputRoot "staging/$buildOs/$targetRid/python"
+        ) -Filter '*.whl' -File
+    )[0].FullName
+    & $Mutation $wheelPath
+    Assert-InvocationFailure {
+        Invoke-DeploymentGenerator -OutputRoot $outputRoot
+    } "Expected '$Name' staged wheel rejection."
 }
 
 function Assert-NoTemporaryDeploymentPackage {
@@ -800,6 +906,13 @@ function Invoke-ActualUninstallRegression {
         & (Join-Path $extractedBundleRoot 'install.ps1') -InstallRoot $installRoot | Out-Null
 
         $productExecutablePath = Join-Path $installRoot "app/$productExecutableName"
+        $versionOutput = @(& $productExecutablePath --version)
+        Assert-Equal -Expected 0 -Actual $LASTEXITCODE -Message 'The apphost version smoke failed.'
+        Assert-Equal `
+            -Expected "azureauth-credprovider $expectedProductVersion" `
+            -Actual (($versionOutput -join "`n").Trim()) `
+            -Message 'The installed packaged apphost version is incorrect.'
+
         if ($runningOnWindows) {
             $harnessArguments = @(
                 '--process-helper'
@@ -897,22 +1010,120 @@ function Invoke-ActualUninstallRegression {
                 -Expected 1 `
                 -Actual $LASTEXITCODE `
                 -Message 'The installed keyring shim did not return no-credential for an unrelated host.'
-        }
 
-        & $productExecutablePath configure nuget | Out-Null
-        Assert-Equal `
-            -Expected 0 `
-            -Actual $LASTEXITCODE `
-            -Message 'Actual NuGet configuration failed.'
-        Assert-True (
-            Test-Path -LiteralPath (
-                Join-Path $pluginRoot 'azureauth-credprovider.dll'
-            ) -PathType Leaf
-        ) 'NuGet configuration did not create a discoverable plugin activation.'
-        Set-Content `
-            -LiteralPath (Join-Path $pluginRoot 'preserve.txt') `
-            -Value 'unrelated activation-root content' `
-            -NoNewline
+            $deploymentManifest = Get-Content -LiteralPath (
+                Join-Path $extractedBundleRoot 'manifest.json'
+            ) -Raw | ConvertFrom-Json
+            $wheelRelativePath = [string]$deploymentManifest.entrypoints.pythonWheel
+            $bundleWheelPath = Join-Path $extractedBundleRoot $wheelRelativePath
+            $installedWheelPath = Join-Path $installRoot $wheelRelativePath
+            Assert-Equal `
+                -Expected (
+                Get-FileHash -LiteralPath $bundleWheelPath -Algorithm SHA256
+            ).Hash `
+                -Actual (
+                Get-FileHash -LiteralPath $installedWheelPath -Algorithm SHA256
+            ).Hash `
+                -Message 'Physical installation changed the exact bundled wheel.'
+
+            $venvRoot = Join-Path $actualRoot 'wheel-venv'
+            uv venv `
+                --no-project `
+                --no-config `
+                --offline `
+                --no-python-downloads `
+                $venvRoot | Out-Null
+            Assert-Equal `
+                -Expected 0 `
+                -Actual $LASTEXITCODE `
+                -Message 'uv failed to create the isolated bundled-wheel venv.'
+            $venvPython = Join-Path $venvRoot 'bin/python'
+            uv pip install `
+                --python $venvPython `
+                --no-deps `
+                --no-index `
+                --offline `
+                --no-config `
+                $installedWheelPath | Out-Null
+            Assert-Equal `
+                -Expected 0 `
+                -Actual $LASTEXITCODE `
+                -Message 'uv failed to install the exact bundled wheel.'
+
+            $credentialEnvironmentNames = @(
+                'SYSTEM_ACCESSTOKEN'
+                'AZURE_DEVOPS_EXT_PAT'
+                'VSS_NUGET_EXTERNAL_FEED_ENDPOINTS'
+                'ARTIFACTS_CREDENTIALPROVIDER_FEED_ENDPOINTS'
+                'ARTIFACTS_KEYRING_NONINTERACTIVE_MODE'
+            )
+            $savedCredentialEnvironment = @{}
+            foreach ($name in $credentialEnvironmentNames) {
+                $savedCredentialEnvironment[$name] = [Environment]::GetEnvironmentVariable($name)
+                [Environment]::SetEnvironmentVariable($name, $null)
+            }
+            [Environment]::SetEnvironmentVariable(
+                'ARTIFACTS_KEYRING_NONINTERACTIVE_MODE',
+                'true'
+            )
+            $credentialConfigRoot = $environment['AZUREAUTH_CREDPROVIDER_CONFIG_ROOT']
+            New-Item -ItemType Directory -Path $credentialConfigRoot -Force | Out-Null
+            Assert-Equal `
+                -Expected 0 `
+                -Actual @(Get-ChildItem -LiteralPath $credentialConfigRoot -Force).Count `
+                -Message 'The isolated provider configuration was not empty.'
+            try {
+                $probeScript = @'
+import importlib.metadata
+import pathlib
+import sys
+
+from azureauth_credprovider_keyring.contracts import HelperExecutionError
+
+distribution = importlib.metadata.distribution("azureauth-credprovider-keyring")
+entry_points = [
+    entry_point
+    for entry_point in distribution.entry_points
+    if entry_point.group == "keyring.backends"
+    and entry_point.name == "azureauth"
+]
+if len(entry_points) != 1:
+    raise SystemExit(20)
+backend_type = entry_points[0].load()
+module_path = pathlib.Path(sys.modules[backend_type.__module__].__file__).resolve()
+if not module_path.is_relative_to(pathlib.Path(sys.argv[1]).resolve()):
+    raise SystemExit(21)
+try:
+    backend_type().get_credential(
+        "https://pkgs.dev.azure.com/example/project/_packaging/feed/pypi/simple/",
+        None,
+    )
+except HelperExecutionError as error:
+    if error.exit_code != 64 or "ProviderNotConfigured" not in error.safe_message:
+        raise SystemExit(22) from error
+else:
+    raise SystemExit(23)
+print("controlled-supported-host-failure")
+'@
+                $probeOutput = @(& $venvPython -I -c $probeScript $venvRoot)
+                Assert-Equal `
+                    -Expected 0 `
+                    -Actual $LASTEXITCODE `
+                    -Message 'The exact bundled-wheel entry-point probe failed.'
+                Assert-Equal `
+                    -Expected 'controlled-supported-host-failure' `
+                    -Actual (($probeOutput -join "`n").Trim()) `
+                    -Message 'The supported-host helper failure was not controlled.'
+            }
+            finally {
+                foreach ($name in $credentialEnvironmentNames) {
+                    [Environment]::SetEnvironmentVariable(
+                        $name,
+                        $savedCredentialEnvironment[$name]
+                    )
+                }
+            }
+        }
 
         $registryUrl = 'https://pkgs.dev.azure.com/example/project/_packaging/feed/npm/registry/'
         Move-Item -LiteralPath $gitMarkerPath -Destination $heldGitMarkerPath
@@ -1046,6 +1257,13 @@ function Invoke-ActualUninstallRegression {
         Assert-True (
             -not (Test-Path -LiteralPath $installRoot)
         ) 'Explicit damaged-install cleanup did not remove the product root.'
+        if ($runningOnWindows) {
+            foreach ($realNuGetPath in $realNuGetPaths) {
+                Assert-True (
+                    -not (Test-Path -LiteralPath $realNuGetPath)
+                ) "Windows lifecycle cleanup wrote real-profile state '$realNuGetPath'."
+            }
+        }
     }
     finally {
         if (Test-Path -LiteralPath $heldGitMarkerPath) {
@@ -1247,20 +1465,46 @@ try {
         -OutputRoot $malformedWheelOutput `
         -Context 'malformed staged wheel rejection'
 
-    $wrongWheelOutput = Join-Path $testRoot 'wrong-wheel-failure'
-    New-DeploymentGeneratorStaging -OutputRoot $wrongWheelOutput
-    $wrongWheelPath = @(
-        Get-ChildItem -LiteralPath (
-            Join-Path $wrongWheelOutput "staging/$buildOs/$targetRid/python"
-        ) -Filter '*.whl' -File
-    )[0].FullName
-    Set-TestWheelVersion -WheelPath $wrongWheelPath -Version '0.0.0'
-    Assert-InvocationFailure {
-        Invoke-DeploymentGenerator -OutputRoot $wrongWheelOutput
-    } 'Expected wrong staged wheel version rejection.'
-    Assert-NoTemporaryDeploymentPackage `
-        -OutputRoot $wrongWheelOutput `
-        -Context 'wrong staged wheel version rejection'
+    Assert-InvalidStagedWheelRejected -Name 'wrong-name' -Mutation {
+        param($WheelPath)
+        Set-TestWheelContent -WheelPath $WheelPath -MetadataName 'other-project'
+    }
+    Assert-InvalidStagedWheelRejected -Name 'metadata-only' -Mutation {
+        param($WheelPath)
+        Set-TestWheelVersion `
+            -WheelPath $WheelPath `
+            -Version $expectedPythonPackageVersion
+    }
+    Assert-InvalidStagedWheelRejected -Name 'missing-backend-module' -Mutation {
+        param($WheelPath)
+        Set-TestWheelContent `
+            -WheelPath $WheelPath `
+            -OmitEntryName @('azureauth_credprovider_keyring/backend.py')
+    }
+    Assert-InvalidStagedWheelRejected -Name 'missing-helper-module' -Mutation {
+        param($WheelPath)
+        Set-TestWheelContent `
+            -WheelPath $WheelPath `
+            -OmitEntryName @('azureauth_credprovider_keyring/helper.py')
+    }
+    Assert-InvalidStagedWheelRejected -Name 'missing-entry-points' -Mutation {
+        param($WheelPath)
+        Set-TestWheelContent `
+            -WheelPath $WheelPath `
+            -OmitEntryName @(
+            "azureauth_credprovider_keyring-$expectedPythonPackageVersion.dist-info/entry_points.txt"
+        )
+    }
+    Assert-InvalidStagedWheelRejected -Name 'wrong-entry-points' -Mutation {
+        param($WheelPath)
+        Set-TestWheelContent -WheelPath $WheelPath -EntryPointsContent @'
+[console_scripts]
+azureauth-keyring = azureauth_credprovider_keyring.helper:main
+
+[keyring.backends]
+azureauth = azureauth_credprovider_keyring.backend:WrongBackend
+'@
+    }
 
     $bundleRoot = Join-Path $testRoot 'bundle'
     New-TestBundle -BundleRoot $bundleRoot

--- a/tests/private/app/azureauth-credprovider/Install-DeploymentValidationBundle.Tests.ps1
+++ b/tests/private/app/azureauth-credprovider/Install-DeploymentValidationBundle.Tests.ps1
@@ -422,16 +422,16 @@ function New-TestBundle {
             Sort-Object path
     )
     $manifest = [ordered]@{
-        schemaVersion  = 'azureauth-credprovider-deployment-validation-v1'
-        buildOs        = $buildOs
-        targetRid      = $targetRid
+        schemaVersion        = 'azureauth-credprovider-deployment-validation-v1'
+        buildOs              = $buildOs
+        targetRid            = $targetRid
         productVersion       = '2.0.0-test'
         pythonPackageVersion = '2.0.0'
         sourceRevision       = 'new-revision'
-        releaseStatus  = 'internal-non-release'
-        isInternal     = $true
-        isRelease      = $false
-        files          = $files
+        releaseStatus        = 'internal-non-release'
+        isInternal           = $true
+        isRelease            = $false
+        files                = $files
     }
     $manifest | ConvertTo-Json -Depth 10 |
         Set-Content -LiteralPath (Join-Path $BundleRoot 'manifest.json') -Encoding utf8
@@ -1073,6 +1073,34 @@ function Invoke-ActualUninstallRegression {
                 -Actual @(Get-ChildItem -LiteralPath $credentialConfigRoot -Force).Count `
                 -Message 'The isolated provider configuration was not empty.'
             try {
+                $pythonFeedUrl = (
+                    'https://pkgs.dev.azure.com/example/project/' +
+                    '_packaging/feed/pypi/simple/'
+                )
+                $consoleScriptPath = Join-Path $venvRoot 'bin/azureauth-keyring'
+                Assert-True (
+                    Test-Path -LiteralPath $consoleScriptPath -PathType Leaf
+                ) 'The installed wheel did not generate the azureauth-keyring console script.'
+                $consoleScriptOutput = @(
+                    & $consoleScriptPath get $pythonFeedUrl 2>&1
+                )
+                $consoleScriptExitCode = $LASTEXITCODE
+                $consoleScriptText = ($consoleScriptOutput | ForEach-Object ToString) -join "`n"
+                Assert-Equal `
+                    -Expected 64 `
+                    -Actual $consoleScriptExitCode `
+                    -Message 'The azureauth-keyring console script returned an unexpected exit code.'
+                Assert-True (
+                    $consoleScriptText.Contains(
+                        'ProviderNotConfigured',
+                        [System.StringComparison]::Ordinal
+                    ) -and
+                    -not $consoleScriptText.Contains(
+                        'Traceback',
+                        [System.StringComparison]::OrdinalIgnoreCase
+                    )
+                ) 'The azureauth-keyring console script failure was not controlled.'
+
                 $probeScript = @'
 import importlib.metadata
 import pathlib
@@ -1095,7 +1123,7 @@ if not module_path.is_relative_to(pathlib.Path(sys.argv[1]).resolve()):
     raise SystemExit(21)
 try:
     backend_type().get_credential(
-        "https://pkgs.dev.azure.com/example/project/_packaging/feed/pypi/simple/",
+        sys.argv[2],
         None,
     )
 except HelperExecutionError as error:
@@ -1105,7 +1133,9 @@ else:
     raise SystemExit(23)
 print("controlled-supported-host-failure")
 '@
-                $probeOutput = @(& $venvPython -I -c $probeScript $venvRoot)
+                $probeOutput = @(
+                    & $venvPython -I -c $probeScript $venvRoot $pythonFeedUrl
+                )
                 Assert-Equal `
                     -Expected 0 `
                     -Actual $LASTEXITCODE `
@@ -1475,17 +1505,21 @@ try {
             -WheelPath $WheelPath `
             -Version $expectedPythonPackageVersion
     }
-    Assert-InvalidStagedWheelRejected -Name 'missing-backend-module' -Mutation {
-        param($WheelPath)
-        Set-TestWheelContent `
-            -WheelPath $WheelPath `
-            -OmitEntryName @('azureauth_credprovider_keyring/backend.py')
-    }
-    Assert-InvalidStagedWheelRejected -Name 'missing-helper-module' -Mutation {
-        param($WheelPath)
-        Set-TestWheelContent `
-            -WheelPath $WheelPath `
-            -OmitEntryName @('azureauth_credprovider_keyring/helper.py')
+    foreach ($moduleName in @(
+            '__init__.py'
+            'backend.py'
+            'contracts.py'
+            'endpoint.py'
+            'helper.py'
+            'integrity.py'
+            'shim.py'
+        )) {
+        Assert-InvalidStagedWheelRejected -Name "missing-$moduleName" -Mutation {
+            param($WheelPath)
+            Set-TestWheelContent `
+                -WheelPath $WheelPath `
+                -OmitEntryName @("azureauth_credprovider_keyring/$moduleName")
+        }
     }
     Assert-InvalidStagedWheelRejected -Name 'missing-entry-points' -Mutation {
         param($WheelPath)


### PR DESCRIPTION
## Summary

- derive deployment application, source, and Python wheel identity from the AzureAuth component NBGV configuration
- validate reusable staging and the complete keyring wheel module, metadata, and entry-point contract before packaging
- exercise the exact bundled wheel through installation, backend discovery, and console entry points
- restore repository-local .NET tools in deployment-validation CI

## Validation

- NBGV package metadata scenario
- fresh and repeated `-NoBuild` bundle generation
- deployment installation and exact bundled-wheel lifecycle
- Python, contracts, platform, and isolated CLI test suites
- HK formatting, ScriptAnalyzer, and branch-range gates
- three-angle delegated OCR with independent TP/FP adjudication and clean original-reviewer re-review