### PR TITLE
fix(azureauth): Report Evidence-Based Ecosystem Capabilities

### DIFF
--- a/src/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Cli/CliApplication.cs
+++ b/src/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Cli/CliApplication.cs
@@ -29,14 +29,14 @@ internal static class CliApplication
         "credential.https://dev.azure.com.useHttpPath";
     private const string NuGetPluginLayoutConfigurationKey = "physical-target";
 
-    private static readonly string[] SupportedEcosystems =
+    private static readonly CredentialEcosystem[] CapabilityEcosystems =
     [
-        "git",
-        "nuget",
-        "python",
-        "npm",
-        "pnpm",
-        "yarn",
+        CredentialEcosystem.Git,
+        CredentialEcosystem.NuGet,
+        CredentialEcosystem.Python,
+        CredentialEcosystem.Npm,
+        CredentialEcosystem.Pnpm,
+        CredentialEcosystem.Yarn,
     ];
     private static readonly HashSet<string> SecretLikeOptionNames = new(StringComparer.Ordinal)
     {
@@ -54,6 +54,12 @@ internal static class CliApplication
         "--help",
         "--dry-run",
     };
+
+    private sealed record EcosystemCapabilityAssessment(
+        CredentialEcosystem Ecosystem,
+        string Configurable,
+        string CurrentlyUsable
+    );
 
     public static int Run(IReadOnlyList<string> args, TextWriter stdout, TextWriter stderr)
     {
@@ -283,6 +289,9 @@ internal static class CliApplication
         WriteText(
             stdout,
             BuildStatusOutput(invocation.CiMode, root, readiness)
+                + BuildEcosystemCapabilityOutput(
+                    CreateStatusEcosystemCapabilities(configuration, invocation.CiMode)
+                )
                 + BuildConfigurationLifecycleStatusOutput(configuration)
         );
         return SuccessExitCode;
@@ -301,6 +310,319 @@ internal static class CliApplication
                     + $"{GetLifecycleStateText(result.LifecycleState)}\n"
                 )
         );
+
+    private static EcosystemCapabilityAssessment[] CreateStatusEcosystemCapabilities(
+        ConfigurationPhase14DoctorResult configurationDoctor,
+        CliCiMode ciMode
+    )
+    {
+        ArgumentNullException.ThrowIfNull(configurationDoctor);
+        return CapabilityEcosystems
+            .Select(ecosystem =>
+            {
+                if (ciMode == CliCiMode.AzurePipelines)
+                {
+                    if (!IsPackageRegistryEcosystem(ecosystem))
+                    {
+                        return new EcosystemCapabilityAssessment(
+                            ecosystem,
+                            "no",
+                            "not-assessed"
+                        );
+                    }
+
+                    ConfigurationPhase14EcosystemDoctorResult? ciConfiguration =
+                        configurationDoctor.Ecosystems.SingleOrDefault(result =>
+                            result.Ecosystem == ecosystem
+                            && result.Scope == ConfigurationPhase14Scope.CiTemporary
+                        );
+                    return ciConfiguration is null
+                        ? new EcosystemCapabilityAssessment(
+                            ecosystem,
+                            "not-assessed",
+                            "not-configured"
+                        )
+                        : new EcosystemCapabilityAssessment(
+                            ecosystem,
+                            GetStatusConfigurableState(ciConfiguration),
+                            GetPhase14CurrentlyUsableState(
+                                ciConfiguration,
+                                additionalEvidenceReady:
+                                    !EcosystemRequiresAdditionalStatusAssessment(ecosystem),
+                                configuredButNotProbed:
+                                    EcosystemRequiresAdditionalStatusAssessment(ecosystem)
+                            )
+                        );
+                }
+
+                if (!IsPhase14ConfigurationEcosystem(ecosystem))
+                {
+                    return new EcosystemCapabilityAssessment(
+                        ecosystem,
+                        "not-assessed",
+                        "not-assessed"
+                    );
+                }
+
+                ConfigurationPhase14EcosystemDoctorResult configuration =
+                    GetUserConfigurationDoctorResult(configurationDoctor, ecosystem);
+                return new EcosystemCapabilityAssessment(
+                    ecosystem,
+                    GetStatusConfigurableState(configuration),
+                    GetPhase14CurrentlyUsableState(
+                        configuration,
+                        additionalEvidenceReady: false,
+                        configuredButNotProbed: true
+                    )
+                );
+            })
+            .ToArray();
+    }
+
+    private static EcosystemCapabilityAssessment[] CreateDoctorEcosystemCapabilities(
+        GitPhase8DoctorResult gitDoctor,
+        NuGetPhase10DoctorResult nuGetDoctor,
+        PythonPhase11DoctorResult pythonDoctor,
+        NpmPhase12DoctorResult npmDoctor,
+        YarnPhase13DoctorResult yarnDoctor,
+        ConfigurationPhase14DoctorResult configurationDoctor
+    )
+    {
+        ArgumentNullException.ThrowIfNull(gitDoctor);
+        ArgumentNullException.ThrowIfNull(nuGetDoctor);
+        ArgumentNullException.ThrowIfNull(pythonDoctor);
+        ArgumentNullException.ThrowIfNull(npmDoctor);
+        ArgumentNullException.ThrowIfNull(yarnDoctor);
+        ArgumentNullException.ThrowIfNull(configurationDoctor);
+
+        ConfigurationPhase14EcosystemDoctorResult pythonConfiguration =
+            GetUserConfigurationDoctorResult(configurationDoctor, CredentialEcosystem.Python);
+        ConfigurationPhase14EcosystemDoctorResult npmConfiguration =
+            GetUserConfigurationDoctorResult(configurationDoctor, CredentialEcosystem.Npm);
+        ConfigurationPhase14EcosystemDoctorResult pnpmConfiguration =
+            GetUserConfigurationDoctorResult(configurationDoctor, CredentialEcosystem.Pnpm);
+        ConfigurationPhase14EcosystemDoctorResult yarnConfiguration =
+            GetUserConfigurationDoctorResult(configurationDoctor, CredentialEcosystem.Yarn);
+
+        bool gitAbsent =
+            !gitDoctor.OwnedGitEntriesPresent
+            && !gitDoctor.OwnershipManifestPresent
+            && gitDoctor.EffectiveCredentialHelper.State
+                == GitEffectiveCredentialHelperState.NotConfigured
+            && gitDoctor.DevAzureUseHttpPath.State
+                == GitUseHttpPathInspectionState.Absent;
+        bool gitStructurallyReady =
+            gitDoctor.ConfigurationPlanValid
+            && gitDoctor.OwnedGitEntriesPresent
+            && gitDoctor.OwnershipManifestPresent
+            && gitDoctor.LocalShellHelperShorthandSuccess
+            && gitDoctor.EffectiveCredentialHelper.State
+                == GitEffectiveCredentialHelperState.Active
+            && gitDoctor.DevAzureUseHttpPath.State
+                == GitUseHttpPathInspectionState.Present;
+
+        bool nuGetStructurallyReady =
+            nuGetDoctor.ConfigurationPlanValid
+            && nuGetDoctor.PluginLayoutMarkerPresent
+            && nuGetDoctor.OwnershipManifestPresent
+            && nuGetDoctor.NetCorePluginEntrypointPresent
+            && nuGetDoctor.PluginModeEntrypointResolvable
+            && nuGetDoctor.EffectivePlugin.ProductDiscovery
+                == NuGetProductPluginDiscoveryState.DiscoverableCandidate
+            && !nuGetDoctor.EffectivePlugin.OverrideEntriesTruncated
+            && nuGetDoctor.EffectivePlugin.OverrideProductInclusion
+                is NuGetOverrideProductInclusionState.NotApplicable
+                    or NuGetOverrideProductInclusionState.IncludesProduct;
+
+        bool npmEvidenceReady =
+            npmDoctor.WorkspaceResolutionSucceeded
+            && npmDoctor.EffectiveUserNpmrcExists
+            && npmDoctor.AzureArtifactsNpmEndpointCanonicalizationSuccess
+            && (
+                !npmDoctor.RegistryDeclarationDiscovered
+                || npmDoctor.NpmUserCredentialPlanValid
+            );
+        bool pnpmEvidenceReady =
+            npmDoctor.EffectiveUserNpmrcExists
+            && npmDoctor.AzureArtifactsNpmEndpointCanonicalizationSuccess
+            && (
+                !npmDoctor.RegistryDeclarationDiscovered
+                || npmDoctor.PnpmUserCredentialPlanValid
+            );
+        bool yarnEvidenceReady =
+            yarnDoctor.EffectiveUserYarnrcExists
+            && yarnDoctor.AzureArtifactsYarnEndpointCanonicalizationSuccess
+            && yarnDoctor.WritesSupported
+            && !yarnDoctor.ForbiddenAuthIdentConflictDetected;
+        bool yarnConfigurable =
+            yarnDoctor.AzureArtifactsYarnEndpointCanonicalizationSuccess
+            && yarnDoctor.WritesSupported
+            && !yarnDoctor.ForbiddenAuthIdentConflictDetected;
+
+        return
+        [
+            new(
+                CredentialEcosystem.Git,
+                gitDoctor.ConfigurationPlanValid ? "yes" : "no",
+                gitAbsent
+                    ? "not-configured"
+                    : gitStructurallyReady
+                        ? "ready-local-evidence"
+                        : "blocked"
+            ),
+            new(
+                CredentialEcosystem.NuGet,
+                nuGetDoctor.ConfigurationState == NuGetConfigurationState.Unrecognized
+                    ? "no"
+                    : "yes",
+                NuGetDoctorStateAbsent(nuGetDoctor)
+                    ? "not-configured"
+                    : nuGetStructurallyReady
+                        ? "selection-deferred-not-probed"
+                        : "blocked"
+            ),
+            new(
+                CredentialEcosystem.Python,
+                pythonConfiguration.ConfigurationPlanValid
+                    && pythonConfiguration.ConfigureOperationValid
+                    && pythonDoctor.IsConfigurationPreflightReady
+                        ? "yes"
+                        : "no",
+                GetPhase14CurrentlyUsableState(
+                    pythonConfiguration,
+                    pythonDoctor.IsReady,
+                    configuredButNotProbed: false
+                )
+            ),
+            new(
+                CredentialEcosystem.Npm,
+                npmConfiguration.ConfigurationPlanValid
+                    && npmConfiguration.ConfigureOperationValid
+                    && npmDoctor.WorkspaceResolutionSucceeded
+                    && npmDoctor.AzureArtifactsNpmEndpointCanonicalizationSuccess
+                        ? "yes"
+                        : "no",
+                GetPhase14CurrentlyUsableState(
+                    npmConfiguration,
+                    npmEvidenceReady,
+                    configuredButNotProbed: false
+                )
+            ),
+            new(
+                CredentialEcosystem.Pnpm,
+                pnpmConfiguration.ConfigurationPlanValid
+                    && pnpmConfiguration.ConfigureOperationValid
+                    && npmDoctor.AzureArtifactsNpmEndpointCanonicalizationSuccess
+                        ? "yes"
+                        : "no",
+                GetPhase14CurrentlyUsableState(
+                    pnpmConfiguration,
+                    pnpmEvidenceReady,
+                    configuredButNotProbed: false
+                )
+            ),
+            new(
+                CredentialEcosystem.Yarn,
+                yarnConfiguration.ConfigurationPlanValid
+                    && yarnConfiguration.ConfigureOperationValid
+                    && yarnConfigurable
+                        ? "yes"
+                        : "no",
+                GetPhase14CurrentlyUsableState(
+                    yarnConfiguration,
+                    yarnEvidenceReady,
+                    configuredButNotProbed: false
+                )
+            ),
+        ];
+    }
+
+    private static string GetStatusConfigurableState(
+        ConfigurationPhase14EcosystemDoctorResult configuration
+    )
+    {
+        if (!configuration.ConfigurationPlanValid || !configuration.ConfigureOperationValid)
+        {
+            return "no";
+        }
+
+        return EcosystemRequiresAdditionalStatusAssessment(configuration.Ecosystem)
+            ? "not-assessed"
+            : "yes";
+    }
+
+    private static bool EcosystemRequiresAdditionalStatusAssessment(
+        CredentialEcosystem ecosystem
+    ) =>
+        ecosystem is CredentialEcosystem.Npm or CredentialEcosystem.Pnpm;
+
+    private static string BuildEcosystemCapabilityOutput(
+        IReadOnlyList<EcosystemCapabilityAssessment> capabilities
+    ) => JoinLines(BuildEcosystemCapabilityLines(capabilities));
+
+    private static IEnumerable<string> BuildEcosystemCapabilityLines(
+        IReadOnlyList<EcosystemCapabilityAssessment> capabilities
+    )
+    {
+        ArgumentNullException.ThrowIfNull(capabilities);
+        foreach (
+            EcosystemCapabilityAssessment capability in capabilities.OrderBy(static capability =>
+                capability.Ecosystem
+            )
+        )
+        {
+            string prefix = $"ecosystem-{GetEcosystemText(capability.Ecosystem)}";
+            yield return $"{prefix}-configurable: {capability.Configurable}";
+            yield return $"{prefix}-currently-usable: {capability.CurrentlyUsable}";
+        }
+    }
+
+    private static ConfigurationPhase14EcosystemDoctorResult
+        GetUserConfigurationDoctorResult(
+            ConfigurationPhase14DoctorResult doctor,
+            CredentialEcosystem ecosystem
+        ) =>
+        doctor.Ecosystems.Single(result =>
+            result.Ecosystem == ecosystem
+            && result.Scope == ConfigurationPhase14Scope.User
+        );
+
+    private static string GetPhase14CurrentlyUsableState(
+        ConfigurationPhase14EcosystemDoctorResult configuration,
+        bool additionalEvidenceReady,
+        bool configuredButNotProbed
+    )
+    {
+        if (!configuration.ConfigurationPlanValid || !configuration.ConfigureOperationValid)
+        {
+            return "blocked";
+        }
+
+        if (ConfigurationPhase14DoctorStateAbsent(configuration))
+        {
+            return "not-configured";
+        }
+
+        if (
+            !configuration.OwnershipManifestPresent
+            || !configuration.OwnedTargetPresent
+            || !configuration.OwnedTargetMatchesResolvedPath
+            || (
+                IsPackageRegistryEcosystem(configuration.Ecosystem)
+                && !IsAcceptableLifecycleState(configuration.LifecycleState)
+            )
+        )
+        {
+            return "blocked";
+        }
+
+        if (configuredButNotProbed)
+        {
+            return "not-assessed";
+        }
+
+        return additionalEvidenceReady ? "ready-local-evidence" : "blocked";
+    }
 
     private static int HandleConfigure(
         CliInvocation invocation,
@@ -2304,6 +2626,7 @@ internal static class CliApplication
             "command: status",
             $"product: {CommandName}",
             $"phase: {PhaseName}",
+            "capability-schema: azureauth-credprovider-capabilities-v1",
             $"ci-mode: {GetCiModeText(ciMode)}",
             $"composition-mode: {root.Mode}",
             $"provider: {root.ProviderConfig.Selection}",
@@ -2317,14 +2640,18 @@ internal static class CliApplication
         }
 
         lines.AddRange([
-            "silent-readiness: "
+            "silent-only-readiness: "
                 + (readiness.Silent.IsReady ? "silent-ready" : "silent-unavailable"),
-            $"silent-readiness-code: {readiness.Silent.Code}",
-            $"silent-remediation: {readiness.Silent.SafeMessage}",
+            $"silent-only-readiness-code: {readiness.Silent.Code}",
+            $"silent-only-remediation: {readiness.Silent.SafeMessage}",
+            $"interactive-mechanism: {GetInteractiveMechanismText(root.Installation.HostPlatform)}",
+            $"silent-only-mechanism: {GetSilentOnlyMechanismText(root.Installation.HostPlatform)}",
             "status-shell: ready",
-            "environment-probing: disabled",
-            "persistent-cache: disabled",
-            "persistent-derived-credentials: disabled",
+            "live-auth-probing: disabled",
+            "live-feed-probing: disabled",
+            "provider-cache: provider-managed-not-probed",
+            "product-token-cache: disabled",
+            "registry-derived-credentials: lifecycle-reported-per-ecosystem",
             "accepted-identity-flows: "
                 + (
                     deviceCodeReady
@@ -2337,7 +2664,6 @@ internal static class CliApplication
             "pat-compatibility: deferred-disabled",
             "dry-run-rendering: enabled",
             "mutating-commands: identity-configuration, host-tool-configuration, auth, cleanup",
-            $"supported-ecosystems: {string.Join(", ", SupportedEcosystems)}",
         ]);
         return JoinLines(lines);
     }
@@ -3155,15 +3481,20 @@ internal static class CliApplication
         [
             $"command: {invocation.CommandName}",
             $"phase: {PhaseName}",
+            "capability-schema: azureauth-credprovider-capabilities-v1",
             $"composition-mode: {root.Mode}",
             $"provider: {root.ProviderConfig.Selection}",
             "interactive-readiness: "
                 + (readiness.Interactive.IsReady ? "interactive-ready" : "unavailable"),
             $"interactive-readiness-code: {readiness.Interactive.Code}",
-            "silent-readiness: "
+            "silent-only-readiness: "
                 + (readiness.Silent.IsReady ? "silent-ready" : "silent-unavailable"),
-            $"silent-readiness-code: {readiness.Silent.Code}",
-            $"silent-remediation: {readiness.Silent.SafeMessage}",
+            $"silent-only-readiness-code: {readiness.Silent.Code}",
+            $"silent-only-remediation: {readiness.Silent.SafeMessage}",
+            $"interactive-mechanism: {GetInteractiveMechanismText(root.Installation.HostPlatform)}",
+            $"silent-only-mechanism: {GetSilentOnlyMechanismText(root.Installation.HostPlatform)}",
+            "live-auth-probing: git-doctor-silent-only",
+            "live-feed-probing: disabled",
             "azureauth-version-probe: "
                 + GetAzureAuthHealthProbeStatusText(azureAuthHealthProbe),
             $"azureauth-version-probe-code: {azureAuthHealthProbe.Code}",
@@ -3219,9 +3550,21 @@ internal static class CliApplication
         ];
         if (!readiness.Interactive.IsReady)
         {
-            lines.Insert(6, $"interactive-blocker: {readiness.Interactive.SafeMessage}");
+            lines.Insert(7, $"interactive-blocker: {readiness.Interactive.SafeMessage}");
         }
 
+        lines.AddRange(
+            BuildEcosystemCapabilityLines(
+                CreateDoctorEcosystemCapabilities(
+                    doctorResult,
+                    nuGetDoctorResult,
+                    pythonDoctorResult,
+                    npmDoctorResult,
+                    yarnDoctorResult,
+                    configurationDoctorResult
+                )
+            )
+        );
         lines.AddRange(BuildNuGetDoctorLines(nuGetDoctorResult));
         lines.AddRange(BuildPythonDoctorLines(pythonDoctorResult));
         lines.AddRange(BuildNpmDoctorLines(npmDoctorResult));
@@ -3241,6 +3584,19 @@ internal static class CliApplication
         readiness.Interactive.IsReady
         && root.Installation.HostPlatform == AzureAuthHostPlatform.NativeLinux
         && root.ProductionOptions.DeviceCodePromptWriter is not null;
+
+    private static string GetInteractiveMechanismText(AzureAuthHostPlatform hostPlatform) =>
+        hostPlatform switch
+        {
+            AzureAuthHostPlatform.Windows or AzureAuthHostPlatform.Wsl => "windows-wam-then-web",
+            AzureAuthHostPlatform.NativeLinux => "native-linux-web",
+            _ => "unavailable",
+        };
+
+    private static string GetSilentOnlyMechanismText(AzureAuthHostPlatform hostPlatform) =>
+        hostPlatform == AzureAuthHostPlatform.NativeLinux
+            ? "native-linux-cache-only"
+            : "unavailable";
 
     private static List<string> BuildNuGetDoctorLines(NuGetPhase10DoctorResult doctorResult)
     {
@@ -3556,7 +3912,15 @@ internal static class CliApplication
                     + GetCheckStatusText(ecosystemResult.ConfigurationPlanValid)
             );
             lines.Add(
+                $"{prefix}-configure-operation: "
+                    + GetCheckStatusText(ecosystemResult.ConfigureOperationValid)
+            );
+            lines.Add(
                 $"{prefix}-owned-targets: " + GetPresenceText(ecosystemResult.OwnedTargetPresent)
+            );
+            lines.Add(
+                $"{prefix}-owned-target-matches-resolved-path: "
+                    + GetYesNo(ecosystemResult.OwnedTargetMatchesResolvedPath)
             );
             lines.Add(
                 $"{prefix}-ownership-manifest: "
@@ -4165,6 +4529,7 @@ internal static class CliApplication
         if (doctorResult.Scope == ConfigurationPhase14Scope.CiTemporary)
         {
             return doctorResult.ConfigurationPlanValid
+                && doctorResult.ConfigureOperationValid
                 && (
                     (
                         !doctorResult.OwnershipManifestPresent
@@ -4174,17 +4539,20 @@ internal static class CliApplication
                     || (
                         doctorResult.OwnershipManifestPresent
                         && doctorResult.OwnedTargetPresent
+                        && doctorResult.OwnedTargetMatchesResolvedPath
                         && IsAcceptableLifecycleState(doctorResult.LifecycleState)
                     )
                 );
         }
 
         return doctorResult.ConfigurationPlanValid
+            && doctorResult.ConfigureOperationValid
             && (
                 ConfigurationPhase14DoctorStateAbsent(doctorResult)
                 || (
                     doctorResult.OwnershipManifestPresent
                     && doctorResult.OwnedTargetPresent
+                    && doctorResult.OwnedTargetMatchesResolvedPath
                     && (
                         !IsPackageRegistryEcosystem(doctorResult.Ecosystem)
                         || IsAcceptableLifecycleState(doctorResult.LifecycleState)
@@ -4314,6 +4682,29 @@ internal static class CliApplication
         }
 
         string ecosystem = GetEcosystemText(doctorResult.Ecosystem);
+        if (!doctorResult.ConfigurationPlanValid)
+        {
+            return "manual action required: inspect the product-owned configuration state "
+                + "and ownership manifest, then rerun doctor";
+        }
+
+        if (
+            !doctorResult.ConfigureOperationValid
+            && doctorResult.OwnershipManifestPresent
+            && doctorResult.OwnedTargetPresent
+            && !doctorResult.OwnedTargetMatchesResolvedPath
+        )
+        {
+            return "manual action required: reconcile the owned target with the resolved "
+                + "configuration path, then rerun doctor before configure or refresh";
+        }
+
+        if (!doctorResult.ConfigureOperationValid)
+        {
+            return "manual action required: resolve conflicting package-manager configuration "
+                + "or access conditions, then rerun doctor";
+        }
+
         if (
             doctorResult.LifecycleState
             is RegistryCredentialLifecycleState.RefreshRecommended

--- a/src/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform/Composition/CredentialProviderCompositionRoot.cs
+++ b/src/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform/Composition/CredentialProviderCompositionRoot.cs
@@ -352,7 +352,11 @@ public sealed class CredentialProviderCompositionRoot
         CredentialProviderCapabilityReadiness interactive = prerequisite is null
             ? Ready(
                 "AzureAuthInteractiveReady",
-                "AzureAuth interactive acquisition is ready and may reuse the host MSAL cache."
+                installation.HostPlatform == AzureAuthHostPlatform.NativeLinux
+                    ? "AzureAuth native Linux interaction-allowed acquisition is ready."
+                    : "AzureAuth Windows/WSL interaction-allowed acquisition uses the Windows "
+                        + "Web Account Manager (WAM)-first flow and may prompt; current account "
+                        + "and cache state are not probed."
             )
             : Unavailable(prerequisite.Code, prerequisite.SafeMessage);
         return new CredentialProviderReadiness
@@ -370,8 +374,9 @@ public sealed class CredentialProviderCompositionRoot
                 : config.Selection == AzureAuthProviderSelection.AzureAuth
                     ? Unavailable(
                         "SilentAcquisitionUnavailable",
-                        "AzureAuth 0.9.5 has no cache-only command mode on Windows or WSL; "
-                            + "silent acquisition is unavailable."
+                        "AzureAuth 0.9.5 has no cache-only command mode on Windows or WSL. "
+                            + "A WAM cache may satisfy an interaction-allowed request without "
+                            + "prompting, but silent-only readiness is unavailable."
                     )
                 : interactive,
         };

--- a/src/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform/VerticalSlice/ConfigurationPhase14VerticalSliceService.cs
+++ b/src/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform/VerticalSlice/ConfigurationPhase14VerticalSliceService.cs
@@ -115,9 +115,13 @@ public sealed record ConfigurationPhase14EcosystemDoctorResult
 
     public required bool ConfigurationPlanValid { get; init; }
 
+    public required bool ConfigureOperationValid { get; init; }
+
     public required bool OwnershipManifestPresent { get; init; }
 
     public required bool OwnedTargetPresent { get; init; }
+
+    public required bool OwnedTargetMatchesResolvedPath { get; init; }
 
     public required bool TemporaryContainerPresent { get; init; }
 
@@ -546,15 +550,15 @@ public sealed class ConfigurationPhase14VerticalSliceService
             }
         }
 
-        EnsureRecognizedPythonManifestIfPresent(scope, ownershipManifestPath);
-        IReadOnlyList<ConfigurationChangePlan> plans = CreatePythonPlans(scope);
-        List<ConfigurationPlanResult> previewResults = [];
-        foreach (ConfigurationChangePlan plan in plans)
-        {
-            previewResults.Add(
-                await CreateManager(ownershipManifestPath).DryRunAsync(plan, cancellationToken)
-            );
-        }
+        (
+            IReadOnlyList<ConfigurationChangePlan> plans,
+            List<ConfigurationPlanResult> previewResults
+        ) = await PreviewPythonConfigurationAsync(
+                scope,
+                ownershipManifestPath,
+                cancellationToken
+            )
+            .ConfigureAwait(false);
 
         if (!execute)
         {
@@ -630,14 +634,16 @@ public sealed class ConfigurationPhase14VerticalSliceService
         ConfigurationPhase14Scope scope,
         bool execute,
         bool forceRefresh,
-        CancellationToken cancellationToken
+        CancellationToken cancellationToken,
+        Uri? registryUrlOverride = null
     )
     {
         string ownershipManifestPath = GetOwnershipManifestPath(ecosystem, scope);
         ConfigurationChangePlan requestedDryRunPlan = CreateApplyPlans(
                 ecosystem,
                 scope,
-                CreateDryRunCredential(scope)
+                CreateDryRunCredential(scope),
+                registryUrlOverride
             )
             .Single();
         ExistingOwnershipManifest? existing = LoadRecognizedPackageManifest(
@@ -677,7 +683,13 @@ public sealed class ConfigurationPhase14VerticalSliceService
         CredentialResult credential = execute
             ? GetPackageCredential(ecosystem, scope, cancellationToken)
             : CreateDryRunCredential(scope);
-        ConfigurationChangePlan applyPlan = CreateApplyPlans(ecosystem, scope, credential).Single();
+        ConfigurationChangePlan applyPlan = CreateApplyPlans(
+                ecosystem,
+                scope,
+                credential,
+                registryUrlOverride
+            )
+            .Single();
         bool replaceExisting =
             existing is not null
             && !ManifestMatchesRequestedConfiguration(existing.Manifest, applyPlan);
@@ -1108,7 +1120,8 @@ public sealed class ConfigurationPhase14VerticalSliceService
     private IReadOnlyList<ConfigurationChangePlan> CreateApplyPlans(
         CredentialEcosystem ecosystem,
         ConfigurationPhase14Scope scope,
-        CredentialResult? credential
+        CredentialResult? credential,
+        Uri? registryUrlOverride = null
     ) =>
         ecosystem switch
         {
@@ -1119,7 +1132,8 @@ public sealed class ConfigurationPhase14VerticalSliceService
                     ecosystem,
                     scope,
                     credential
-                        ?? throw new InvalidOperationException("Package credential is required.")
+                        ?? throw new InvalidOperationException("Package credential is required."),
+                    registryUrlOverride
                 ),
             ],
             CredentialEcosystem.Yarn =>
@@ -1127,7 +1141,8 @@ public sealed class ConfigurationPhase14VerticalSliceService
                 CreateYarnPlan(
                     scope,
                     credential
-                        ?? throw new InvalidOperationException("Package credential is required.")
+                        ?? throw new InvalidOperationException("Package credential is required."),
+                    registryUrlOverride
                 ),
             ],
             _ => throw new NotSupportedException(
@@ -1384,7 +1399,8 @@ public sealed class ConfigurationPhase14VerticalSliceService
     private ConfigurationChangePlan CreateNpmCompatiblePlan(
         CredentialEcosystem ecosystem,
         ConfigurationPhase14Scope scope,
-        CredentialResult credential
+        CredentialResult credential,
+        Uri? registryUrlOverride
     )
     {
         var service = new NpmPhase12VerticalSliceService(
@@ -1399,7 +1415,10 @@ public sealed class ConfigurationPhase14VerticalSliceService
                         : paths.NpmUserNpmrcPath,
             }
         );
-        NpmPhase12RegistryDeclaration declaration = CreateNpmDeclaration(ecosystem);
+        NpmPhase12RegistryDeclaration declaration = CreateNpmDeclaration(
+            ecosystem,
+            registryUrlOverride
+        );
         var request = new NpmPhase12CredentialPlanRequest
         {
             Declaration = declaration,
@@ -1439,7 +1458,8 @@ public sealed class ConfigurationPhase14VerticalSliceService
 
     private ConfigurationChangePlan CreateYarnPlan(
         ConfigurationPhase14Scope scope,
-        CredentialResult credential
+        CredentialResult credential,
+        Uri? registryUrlOverride
     )
     {
         var service = new YarnPhase13VerticalSliceService(
@@ -1451,7 +1471,7 @@ public sealed class ConfigurationPhase14VerticalSliceService
                 UserYarnrcPath = paths.YarnUserYarnrcPath,
             }
         );
-        YarnPhase13RegistryDeclaration declaration = CreateYarnDeclaration();
+        YarnPhase13RegistryDeclaration declaration = CreateYarnDeclaration(registryUrlOverride);
         var request = new YarnPhase13CredentialPlanRequest
         {
             Declaration = declaration,
@@ -1608,7 +1628,7 @@ public sealed class ConfigurationPhase14VerticalSliceService
         };
     }
 
-    private ValueTask<ConfigurationPhase14EcosystemDoctorResult> InspectDoctorAsync(
+    private async ValueTask<ConfigurationPhase14EcosystemDoctorResult> InspectDoctorAsync(
         CredentialEcosystem ecosystem,
         ConfigurationPhase14Scope scope,
         CancellationToken cancellationToken
@@ -1622,6 +1642,11 @@ public sealed class ConfigurationPhase14VerticalSliceService
             scope,
             ownershipManifestPath,
             cancellationToken
+        );
+        bool ownedTargetMatchesResolvedPath = TryInspectOwnedTargetMatchesResolvedPath(
+            ecosystem,
+            scope,
+            ownershipManifestPath
         );
         bool temporaryContainerPresent = TemporaryContainerExists(ecosystem, scope);
         bool configurationPlanValid = !ownershipManifestPresent
@@ -1658,21 +1683,116 @@ public sealed class ConfigurationPhase14VerticalSliceService
                 || !lifecycleMetadataPresent;
             registryUrl = TryGetManifestRegistryUrl(ownershipManifestPath);
         }
+        bool configureOperationValid =
+            configurationPlanValid
+            && (
+                ecosystem == CredentialEcosystem.Python
+                    ? await TryValidatePythonConfigureOperationAsync(
+                            scope,
+                            ownershipManifestPath,
+                            cancellationToken
+                        )
+                        .ConfigureAwait(false)
+                    : (
+                        !registryUrls.ContainsKey(ecosystem)
+                        && registryUrl is null
+                        && !ownershipManifestPresent
+                    )
+                        || await TryValidateConfigureOperationAsync(
+                                ecosystem,
+                                scope,
+                                registryUrl,
+                                cancellationToken
+                            )
+                            .ConfigureAwait(false)
+            );
 
-        return ValueTask.FromResult(
-            new ConfigurationPhase14EcosystemDoctorResult
-            {
-                Ecosystem = ecosystem,
-                Scope = scope,
-                ConfigurationPlanValid = configurationPlanValid,
-                OwnershipManifestPresent = ownershipManifestPresent,
-                OwnedTargetPresent = ownedTargetPresent,
-                TemporaryContainerPresent = temporaryContainerPresent,
-                LifecycleState = lifecycleState,
-                CredentialExpiresAt = lifecycle?.ExpiresAt,
-                RegistryUrl = registryUrl,
-            }
-        );
+        return new ConfigurationPhase14EcosystemDoctorResult
+        {
+            Ecosystem = ecosystem,
+            Scope = scope,
+            ConfigurationPlanValid = configurationPlanValid,
+            ConfigureOperationValid = configureOperationValid,
+            OwnershipManifestPresent = ownershipManifestPresent,
+            OwnedTargetPresent = ownedTargetPresent,
+            OwnedTargetMatchesResolvedPath = ownedTargetMatchesResolvedPath,
+            TemporaryContainerPresent = temporaryContainerPresent,
+            LifecycleState = lifecycleState,
+            CredentialExpiresAt = lifecycle?.ExpiresAt,
+            RegistryUrl = registryUrl,
+        };
+    }
+
+    private async ValueTask<bool> TryValidateConfigureOperationAsync(
+        CredentialEcosystem ecosystem,
+        ConfigurationPhase14Scope scope,
+        Uri? registryUrlOverride,
+        CancellationToken cancellationToken
+    )
+    {
+        try
+        {
+            _ = await ConfigurePackageCoreAsync(
+                    ecosystem,
+                    scope,
+                    execute: false,
+                    forceRefresh: false,
+                    cancellationToken,
+                    registryUrlOverride
+                )
+                .ConfigureAwait(false);
+            return true;
+        }
+        catch (Exception exception) when (IsExpectedDoctorCheckFailure(exception))
+        {
+            return false;
+        }
+    }
+
+    private async ValueTask<bool> TryValidatePythonConfigureOperationAsync(
+        ConfigurationPhase14Scope scope,
+        string ownershipManifestPath,
+        CancellationToken cancellationToken
+    )
+    {
+        try
+        {
+            _ = await PreviewPythonConfigurationAsync(
+                    scope,
+                    ownershipManifestPath,
+                    cancellationToken
+                )
+                .ConfigureAwait(false);
+            return true;
+        }
+        catch (Exception exception) when (IsExpectedDoctorCheckFailure(exception))
+        {
+            return false;
+        }
+    }
+
+    private async ValueTask<(
+        IReadOnlyList<ConfigurationChangePlan> Plans,
+        List<ConfigurationPlanResult> PreviewResults
+    )> PreviewPythonConfigurationAsync(
+        ConfigurationPhase14Scope scope,
+        string ownershipManifestPath,
+        CancellationToken cancellationToken
+    )
+    {
+        EnsureRecognizedPythonManifestIfPresent(scope, ownershipManifestPath);
+        IReadOnlyList<ConfigurationChangePlan> plans = CreatePythonPlans(scope);
+        List<ConfigurationPlanResult> previewResults = [];
+        foreach (ConfigurationChangePlan plan in plans)
+        {
+            previewResults.Add(
+                await CreateManager(ownershipManifestPath)
+                    .DryRunAsync(plan, cancellationToken)
+                    .ConfigureAwait(false)
+            );
+        }
+
+        return (plans, previewResults);
     }
 
     // editorconfig-checker-disable
@@ -2582,6 +2702,69 @@ public sealed class ConfigurationPhase14VerticalSliceService
         }
     }
 
+    private bool TryInspectOwnedTargetMatchesResolvedPath(
+        CredentialEcosystem ecosystem,
+        ConfigurationPhase14Scope scope,
+        string ownershipManifestPath
+    )
+    {
+        try
+        {
+            if (
+                !TryLoadOwnershipManifest(
+                    ownershipManifestPath,
+                    out ConfigurationOwnershipManifest? manifest
+                )
+                || !OwnershipManifestMatchesExpectedState(manifest, ecosystem, scope)
+            )
+            {
+                return false;
+            }
+
+            if (ecosystem == CredentialEcosystem.Python)
+            {
+                return true;
+            }
+
+            (ConfigurationTargetKind targetKind, string expectedPath) = ecosystem switch
+            {
+                CredentialEcosystem.Npm or CredentialEcosystem.Pnpm =>
+                    (ConfigurationTargetKind.Npmrc, GetNpmTargetPath(ecosystem, scope)),
+                CredentialEcosystem.Yarn =>
+                    (
+                        ConfigurationTargetKind.Yarnrc,
+                        scope == ConfigurationPhase14Scope.User
+                            ? paths.YarnUserYarnrcPath
+                            : FileSystemPathSemantics.Combine(
+                                fileSystem,
+                                paths.YarnCiTemporaryHomePath,
+                                ".yarnrc.yml"
+                            )
+                    ),
+                _ => throw new NotSupportedException("Unsupported configuration ecosystem."),
+            };
+            string normalizedExpectedPath = NormalizePath(expectedPath);
+            ConfigurationOwnershipManifestEntry[] entries = manifest
+                .Entries.Where(entry =>
+                    EntryMatchesEcosystem(entry, ecosystem)
+                    && entry.TargetKind == targetKind
+                )
+                .ToArray();
+            return entries.Length > 0
+                && entries.All(entry =>
+                    string.Equals(
+                        NormalizePath(entry.TargetPathOrName),
+                        normalizedExpectedPath,
+                        FileSystemPathSemantics.GetComparison(fileSystem)
+                    )
+                );
+        }
+        catch (Exception exception) when (IsExpectedDoctorCheckFailure(exception))
+        {
+            return false;
+        }
+    }
+
     private ConfigurationChangePlan CreatePythonPresencePlan(
         ConfigurationOwnershipManifestEntry entry
     )
@@ -3219,9 +3402,12 @@ public sealed class ConfigurationPhase14VerticalSliceService
             : null;
     }
 
-    private NpmPhase12RegistryDeclaration CreateNpmDeclaration(CredentialEcosystem ecosystem)
+    private NpmPhase12RegistryDeclaration CreateNpmDeclaration(
+        CredentialEcosystem ecosystem,
+        Uri? registryUrlOverride = null
+    )
     {
-        Uri registryUrl = GetRequiredRegistryUrl(ecosystem);
+        Uri registryUrl = registryUrlOverride ?? GetRequiredRegistryUrl(ecosystem);
         if (
             !NpmPhase12VerticalSliceService.TryCreateAzureArtifactsNpmResourceIdentity(
                 registryUrl,
@@ -3258,9 +3444,12 @@ public sealed class ConfigurationPhase14VerticalSliceService
         };
     }
 
-    private YarnPhase13RegistryDeclaration CreateYarnDeclaration()
+    private YarnPhase13RegistryDeclaration CreateYarnDeclaration(
+        Uri? registryUrlOverride = null
+    )
     {
-        Uri registryUrl = GetRequiredRegistryUrl(CredentialEcosystem.Yarn);
+        Uri registryUrl =
+            registryUrlOverride ?? GetRequiredRegistryUrl(CredentialEcosystem.Yarn);
         if (
             !NpmPhase12VerticalSliceService.TryCreateAzureArtifactsNpmResourceIdentity(
                 registryUrl,

--- a/src/private/app/azureauth-credprovider/docs/high-level-design.md
+++ b/src/private/app/azureauth-credprovider/docs/high-level-design.md
@@ -111,6 +111,13 @@ an explicitly accepted provider-cache behavior; product-owned derived
 credentials remain non-persistent with no plaintext fallback. Direct MSAL is
 not implemented.
 
+Windows and WSL interaction readiness means that the WAM-first launch path is
+available and may prompt. A WAM cache can satisfy that interaction-allowed
+request without prompting, but AzureAuth 0.9.5 exposes no cache-only command
+mode on those hosts. Status therefore reports Windows and WSL silent-only
+readiness as unavailable without claiming that the provider cache or account is
+absent.
+
 The core must not assume a single protocol output format. Protocol adapters are responsible for host-tool input and output.
 
 ## Machine-Facing Entrypoints
@@ -337,16 +344,30 @@ CI behavior must:
 
 ## Diagnostics
 
-`<primary-cli> doctor` should validate:
+`<primary-cli> status` reports interactive and silent-only provider readiness
+separately. It replaces broad ecosystem support claims with per-ecosystem
+`configurable` and `currently-usable` assessments. `not-assessed` and
+`selection-deferred-not-probed` are valid results when status or a lower-layer
+client cannot establish the stronger claim from local evidence.
+
+`<primary-cli> doctor` should validate bounded local evidence:
 
 - Git helper executable discovery and `credential.https://dev.azure.com.useHttpPath` behavior for Azure Repos hosts,
 - NuGet plugin discovery and runtime compatibility,
 - Python keyring backend discovery,
 - `keyring` shim availability for uv,
 - npm and Yarn registry configuration format and required entries,
-- identity-provider readiness, silent-cache availability, and account selection,
+- identity-provider installation and interaction-mode readiness,
 - host/feed canonicalization,
 - CI mode and secret handling.
+
+Capability reporting distinguishes structural local readiness from remote
+authorization. It does not contact package feeds, prove NuGet's runtime plugin
+selection, directly read or enumerate provider-managed cache storage, or verify
+the configured account preference. `status` performs no live authentication
+probe. Existing bounded Git `doctor` checks may invoke the provider in
+`SilentOnly` mode (cache-only on native Linux) and do not turn other ecosystem
+rows into live-authentication claims.
 
 Diagnostics should never print access tokens, refresh tokens, PATs, Basic auth headers, npm tokens, NuGet API keys, or generated passwords.
 

--- a/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Cli.Tests/CliApplicationTests.cs
+++ b/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Cli.Tests/CliApplicationTests.cs
@@ -181,6 +181,11 @@ public sealed class CliApplicationTests
         );
         AssertDoctorCheck(
             doctor.StdOut,
+            "ecosystem-nuget-currently-usable",
+            expectedSuccess ? "selection-deferred-not-probed" : "blocked"
+        );
+        AssertDoctorCheck(
+            doctor.StdOut,
             "nuget-operational-plugin-selection",
             "deferred-not-probed"
         );
@@ -455,7 +460,7 @@ public sealed class CliApplicationTests
     [Fact]
     public void StatusWritesDeterministicShellOutput()
     {
-        CommandResult result = Invoke("status");
+        CommandResult result = InvokeIsolatedStatus("status");
 
         Assert.Equal(0, result.ExitCode);
         // editorconfig-checker-disable
@@ -465,26 +470,42 @@ public sealed class CliApplicationTests
                 command: status
                 product: azureauth-credprovider
                 phase: 15-end-to-end-hardening
+                capability-schema: azureauth-credprovider-capabilities-v1
                 ci-mode: none
                 composition-mode: Production
                 provider: Unspecified
                 interactive-readiness: interactive-unavailable
                 interactive-readiness-code: ProviderNotConfigured
                 interactive-blocker: Provider configuration is missing.
-                silent-readiness: silent-unavailable
-                silent-readiness-code: ProviderNotConfigured
-                silent-remediation: Provider configuration is missing.
+                silent-only-readiness: silent-unavailable
+                silent-only-readiness-code: ProviderNotConfigured
+                silent-only-remediation: Provider configuration is missing.
+                interactive-mechanism: unavailable
+                silent-only-mechanism: unavailable
                 status-shell: ready
-                environment-probing: disabled
-                persistent-cache: disabled
-                persistent-derived-credentials: disabled
+                live-auth-probing: disabled
+                live-feed-probing: disabled
+                provider-cache: provider-managed-not-probed
+                product-token-cache: disabled
+                registry-derived-credentials: lifecycle-reported-per-ecosystem
                 accepted-identity-flows: browser, azure-pipelines
                 unavailable-identity-flows: device-code
                 deferred-identity-flows: pat-compatibility, service-principal, managed-identity, workload-identity
                 pat-compatibility: deferred-disabled
                 dry-run-rendering: enabled
                 mutating-commands: identity-configuration, host-tool-configuration, auth, cleanup
-                supported-ecosystems: git, nuget, python, npm, pnpm, yarn
+                ecosystem-git-configurable: not-assessed
+                ecosystem-git-currently-usable: not-assessed
+                ecosystem-nuget-configurable: not-assessed
+                ecosystem-nuget-currently-usable: not-assessed
+                ecosystem-python-configurable: yes
+                ecosystem-python-currently-usable: not-configured
+                ecosystem-npm-configurable: not-assessed
+                ecosystem-npm-currently-usable: not-configured
+                ecosystem-pnpm-configurable: not-assessed
+                ecosystem-pnpm-currently-usable: not-configured
+                ecosystem-yarn-configurable: yes
+                ecosystem-yarn-currently-usable: not-configured
                 npm-user-lifecycle: missing
                 pnpm-user-lifecycle: missing
                 yarn-user-lifecycle: missing
@@ -571,7 +592,7 @@ public sealed class CliApplicationTests
     {
         string[] args = ciValue is null ? ["status", ciToken] : ["status", ciToken, ciValue];
 
-        CommandResult result = Invoke(args);
+        CommandResult result = InvokeIsolatedStatus(args);
 
         Assert.Equal(0, result.ExitCode);
         // editorconfig-checker-disable
@@ -581,26 +602,42 @@ public sealed class CliApplicationTests
                 command: status
                 product: azureauth-credprovider
                 phase: 15-end-to-end-hardening
+                capability-schema: azureauth-credprovider-capabilities-v1
                 ci-mode: azure-pipelines
                 composition-mode: Production
                 provider: Unspecified
                 interactive-readiness: interactive-unavailable
                 interactive-readiness-code: ProviderNotConfigured
                 interactive-blocker: Provider configuration is missing.
-                silent-readiness: silent-unavailable
-                silent-readiness-code: ProviderNotConfigured
-                silent-remediation: Provider configuration is missing.
+                silent-only-readiness: silent-unavailable
+                silent-only-readiness-code: ProviderNotConfigured
+                silent-only-remediation: Provider configuration is missing.
+                interactive-mechanism: unavailable
+                silent-only-mechanism: unavailable
                 status-shell: ready
-                environment-probing: disabled
-                persistent-cache: disabled
-                persistent-derived-credentials: disabled
+                live-auth-probing: disabled
+                live-feed-probing: disabled
+                provider-cache: provider-managed-not-probed
+                product-token-cache: disabled
+                registry-derived-credentials: lifecycle-reported-per-ecosystem
                 accepted-identity-flows: browser, azure-pipelines
                 unavailable-identity-flows: device-code
                 deferred-identity-flows: pat-compatibility, service-principal, managed-identity, workload-identity
                 pat-compatibility: deferred-disabled
                 dry-run-rendering: enabled
                 mutating-commands: identity-configuration, host-tool-configuration, auth, cleanup
-                supported-ecosystems: git, nuget, python, npm, pnpm, yarn
+                ecosystem-git-configurable: no
+                ecosystem-git-currently-usable: not-assessed
+                ecosystem-nuget-configurable: no
+                ecosystem-nuget-currently-usable: not-assessed
+                ecosystem-python-configurable: no
+                ecosystem-python-currently-usable: not-assessed
+                ecosystem-npm-configurable: not-assessed
+                ecosystem-npm-currently-usable: not-configured
+                ecosystem-pnpm-configurable: not-assessed
+                ecosystem-pnpm-currently-usable: not-configured
+                ecosystem-yarn-configurable: not-assessed
+                ecosystem-yarn-currently-usable: not-configured
                 npm-user-lifecycle: missing
                 pnpm-user-lifecycle: missing
                 yarn-user-lifecycle: missing
@@ -1966,6 +2003,8 @@ public sealed class CliApplicationTests
 
         Assert.Equal(1, doctor.ExitCode);
         AssertDoctorCheck(doctor.StdOut, "nuget-configuration-state", "unrecognized");
+        AssertDoctorCheck(doctor.StdOut, "ecosystem-nuget-configurable", "no");
+        AssertDoctorCheck(doctor.StdOut, "ecosystem-nuget-currently-usable", "blocked");
         Assert.Contains(
             "nuget-configuration-plan-remediation: manually inspect and restore "
                 + "the product-owned NuGet plugin layout",
@@ -3415,6 +3454,20 @@ public sealed class CliApplicationTests
                 "azure-pipelines"
             );
             Assert.Equal(0, configure.ExitCode);
+            CommandResult status = InvokeWithRuntime(
+                runtimeOptions,
+                "status",
+                "--ci",
+                "azure-pipelines"
+            );
+            Assert.Contains(
+                "ecosystem-npm-configurable: not-assessed\n",
+                status.StdOut
+            );
+            Assert.Contains(
+                "ecosystem-npm-currently-usable: not-assessed\n",
+                status.StdOut
+            );
             string npmrcBefore = File.ReadAllText(npmrcPath);
             string manifestBefore = File.ReadAllText(manifestPath);
 
@@ -3432,6 +3485,19 @@ public sealed class CliApplicationTests
             Assert.Equal(string.Empty, dryRun.StdErr);
             Assert.Equal(npmrcBefore, File.ReadAllText(npmrcPath));
             Assert.Equal(manifestBefore, File.ReadAllText(manifestPath));
+
+            File.Delete(manifestPath);
+            CommandResult orphanedStatus = InvokeWithRuntime(
+                runtimeOptions,
+                "status",
+                "--ci",
+                "azure-pipelines"
+            );
+            Assert.Contains("ecosystem-npm-configurable: no\n", orphanedStatus.StdOut);
+            Assert.Contains(
+                "ecosystem-npm-currently-usable: blocked\n",
+                orphanedStatus.StdOut
+            );
         }
         finally
         {
@@ -3544,6 +3610,55 @@ public sealed class CliApplicationTests
             Assert.Equal(string.Empty, missing.StdOut);
             Assert.Equal(string.Empty, nonAzure.StdOut);
             Assert.False(File.Exists(Path.Combine(stateDirectory, "npm", "user.npmrc")));
+        }
+        finally
+        {
+            DeleteDirectoryIfExists(stateDirectory);
+        }
+    }
+
+    [Fact]
+    public void StatusKeepsUnconfiguredPackageCapabilitiesConservativeWithoutRegistryContext()
+    {
+        string stateDirectory = CreateTestDirectory();
+        try
+        {
+            CliRuntimeOptions localRuntime = CreateConfigurationRuntimeWithoutRegistries(
+                stateDirectory
+            );
+            var ciRuntime = new CliRuntimeOptions
+            {
+                CompositionRoot = CreateTestCompositionRoot(),
+                ConfigurationPhase14Options = new ConfigurationPhase14VerticalSliceOptions
+                {
+                    StateDirectoryPath = stateDirectory,
+                    EnvironmentVariableReader = name =>
+                        ReadConfigurationEnvironment(stateDirectory, name),
+                },
+            };
+
+            CommandResult local = InvokeWithRuntime(localRuntime, "status");
+            CommandResult ci = InvokeWithRuntime(
+                ciRuntime,
+                "status",
+                "--ci",
+                "azure-pipelines"
+            );
+
+            Assert.Equal(0, local.ExitCode);
+            Assert.Contains("ecosystem-npm-configurable: not-assessed\n", local.StdOut);
+            Assert.Contains("ecosystem-pnpm-configurable: not-assessed\n", local.StdOut);
+            Assert.Contains("ecosystem-yarn-configurable: yes\n", local.StdOut);
+            Assert.Contains("ecosystem-npm-currently-usable: not-configured\n", local.StdOut);
+            Assert.Contains("ecosystem-pnpm-currently-usable: not-configured\n", local.StdOut);
+            Assert.Contains("ecosystem-yarn-currently-usable: not-configured\n", local.StdOut);
+            Assert.Equal(0, ci.ExitCode);
+            Assert.Contains("ecosystem-npm-configurable: not-assessed\n", ci.StdOut);
+            Assert.Contains("ecosystem-pnpm-configurable: not-assessed\n", ci.StdOut);
+            Assert.Contains("ecosystem-yarn-configurable: not-assessed\n", ci.StdOut);
+            Assert.Contains("ecosystem-npm-currently-usable: not-configured\n", ci.StdOut);
+            Assert.Contains("ecosystem-pnpm-currently-usable: not-configured\n", ci.StdOut);
+            Assert.Contains("ecosystem-yarn-currently-usable: not-configured\n", ci.StdOut);
         }
         finally
         {
@@ -3862,8 +3977,22 @@ public sealed class CliApplicationTests
 
             Assert.NotEqual(70, status.ExitCode);
             Assert.Contains("yarn-user-lifecycle: invalid\n", status.StdOut);
+            Assert.Contains("ecosystem-yarn-configurable: no\n", status.StdOut);
+            Assert.Contains("ecosystem-yarn-currently-usable: blocked\n", status.StdOut);
             Assert.NotEqual(70, doctor.ExitCode);
             Assert.Contains("yarn-user-lifecycle: invalid\n", doctor.StdOut);
+            Assert.Contains("ecosystem-yarn-configurable: no\n", doctor.StdOut);
+            Assert.Contains("ecosystem-yarn-currently-usable: blocked\n", doctor.StdOut);
+            Assert.Contains(
+                "yarn-user-remediation: manual action required: inspect the product-owned "
+                    + "configuration state and ownership manifest, then rerun doctor\n",
+                doctor.StdOut
+            );
+            Assert.DoesNotContain(
+                "reconcile the owned target with the resolved configuration path",
+                doctor.StdOut,
+                StringComparison.Ordinal
+            );
         }
         finally
         {
@@ -3883,6 +4012,12 @@ public sealed class CliApplicationTests
             CliRuntimeOptions baseline = CreateConfigurationRuntime(stateDirectory);
             CliRuntimeOptions runtimeOptions = baseline with
             {
+                NpmPhase12Options = CreateIsolatedNpmPhase12Options(stateDirectory) with
+                {
+                    UserNpmrcPath = Path.Combine(stateDirectory, "npm", "user.npmrc"),
+                    EnvironmentVariableReader = name =>
+                        ReadConfigurationEnvironment(stateDirectory, name),
+                },
                 ConfigurationPhase14Options = baseline.ConfigurationPhase14Options! with
                 {
                     TimeProvider = time,
@@ -3898,15 +4033,184 @@ public sealed class CliApplicationTests
             Assert.Equal(0, configured.ExitCode);
             time.Now = new DateTimeOffset(2029, 12, 31, 23, 50, 0, TimeSpan.Zero);
 
+            CommandResult status = InvokeWithRuntime(runtimeOptions, "status");
             CommandResult doctor = InvokeWithRuntime(runtimeOptions, "doctor");
 
+            Assert.Contains(
+                "ecosystem-npm-currently-usable: not-assessed\n",
+                status.StdOut
+            );
             Assert.Contains("configuration-aggregation: pass\n", doctor.StdOut);
             Assert.Contains("npm-user-lifecycle: refresh-recommended\n", doctor.StdOut);
+            Assert.Contains("ecosystem-npm-configurable: yes\n", doctor.StdOut);
+            Assert.Contains(
+                "ecosystem-npm-currently-usable: ready-local-evidence\n",
+                doctor.StdOut
+            );
             Assert.Contains(
                 "npm-user-remediation: azureauth-credprovider refresh npm",
                 doctor.StdOut
             );
             Assert.DoesNotContain("fake-token-test", doctor.StdOut, StringComparison.Ordinal);
+
+            time.Now = new DateTimeOffset(2030, 1, 1, 0, 0, 1, TimeSpan.Zero);
+            CommandResult expiredStatus = InvokeWithRuntime(runtimeOptions, "status");
+            CommandResult expiredDoctor = InvokeWithRuntime(runtimeOptions, "doctor");
+
+            Assert.Contains("npm-user-lifecycle: expired\n", expiredStatus.StdOut);
+            Assert.Contains(
+                "ecosystem-npm-currently-usable: blocked\n",
+                expiredStatus.StdOut
+            );
+            Assert.Contains("npm-user-lifecycle: expired\n", expiredDoctor.StdOut);
+            Assert.Contains(
+                "ecosystem-npm-currently-usable: blocked\n",
+                expiredDoctor.StdOut
+            );
+            Assert.Equal(1, expiredDoctor.ExitCode);
+
+            string alternateNpmrcPath = Path.Combine(
+                stateDirectory,
+                "alternate",
+                "user.npmrc"
+            );
+            Directory.CreateDirectory(Path.GetDirectoryName(alternateNpmrcPath)!);
+            string ownedNpmrcPath = new ConfigurationPhase14VerticalSliceService(
+                runtimeOptions.ConfigurationPhase14Options
+            ).Paths.NpmUserNpmrcPath;
+            File.WriteAllText(alternateNpmrcPath, File.ReadAllText(ownedNpmrcPath));
+            CliRuntimeOptions shadowedRuntime = runtimeOptions with
+            {
+                NpmPhase12Options = runtimeOptions.NpmPhase12Options! with
+                {
+                    UserNpmrcPath = alternateNpmrcPath,
+                    EnvironmentVariableReader = name =>
+                        string.Equals(
+                            name,
+                            "NPM_CONFIG_USERCONFIG",
+                            StringComparison.Ordinal
+                        )
+                            ? alternateNpmrcPath
+                            : null,
+                },
+                ConfigurationPhase14Options = runtimeOptions.ConfigurationPhase14Options! with
+                {
+                    EnvironmentVariableReader = name =>
+                        string.Equals(
+                            name,
+                            "NPM_CONFIG_USERCONFIG",
+                            StringComparison.Ordinal
+                        )
+                            ? alternateNpmrcPath
+                            : ReadConfigurationEnvironment(stateDirectory, name),
+                },
+            };
+
+            CommandResult shadowedStatus = InvokeWithRuntime(shadowedRuntime, "status");
+            CommandResult shadowedDoctor = InvokeWithRuntime(shadowedRuntime, "doctor");
+
+            Assert.Contains("ecosystem-npm-configurable: no\n", shadowedStatus.StdOut);
+            Assert.Contains(
+                "ecosystem-npm-currently-usable: blocked\n",
+                shadowedStatus.StdOut
+            );
+            Assert.Contains(
+                "npm-user-owned-target-matches-resolved-path: no\n",
+                shadowedDoctor.StdOut
+            );
+            Assert.Contains(
+                "ecosystem-npm-currently-usable: blocked\n",
+                shadowedDoctor.StdOut
+            );
+            Assert.Contains("ecosystem-npm-configurable: no\n", shadowedDoctor.StdOut);
+            Assert.Contains(
+                "npm-user-remediation: manual action required: reconcile the owned target "
+                    + "with the resolved configuration path, then rerun doctor before "
+                    + "configure or refresh\n",
+                shadowedDoctor.StdOut
+            );
+            Assert.DoesNotContain(
+                "npm-user-remediation: azureauth-credprovider refresh",
+                shadowedDoctor.StdOut,
+                StringComparison.Ordinal
+            );
+            Assert.Contains("configuration-aggregation: fail\n", shadowedDoctor.StdOut);
+            Assert.Contains("doctor-aggregation: fail\n", shadowedDoctor.StdOut);
+            Assert.Equal(1, shadowedDoctor.ExitCode);
+        }
+        finally
+        {
+            DeleteDirectoryIfExists(stateDirectory);
+        }
+    }
+
+    [Fact]
+    public void YarnUnownedReplacementBlocksStatusAndDoctorConfigurability()
+    {
+        string stateDirectory = CreateTestDirectory();
+        try
+        {
+            CliRuntimeOptions runtimeOptions = CreateConfigurationRuntime(stateDirectory);
+            CommandResult configured = InvokeWithRuntime(
+                runtimeOptions,
+                "configure",
+                "yarn",
+                "--registry-url",
+                TestRegistryUrl
+            );
+            Assert.Equal(0, configured.ExitCode);
+
+            var configuredService = new ConfigurationPhase14VerticalSliceService(
+                runtimeOptions.ConfigurationPhase14Options
+            );
+            string alternateHomePath = Path.Combine(stateDirectory, "alternate-yarn-home");
+            string alternateYarnrcPath = Path.Combine(alternateHomePath, ".yarnrc.yml");
+            Directory.CreateDirectory(alternateHomePath);
+            File.WriteAllText(
+                alternateYarnrcPath,
+                File.ReadAllText(configuredService.Paths.YarnUserYarnrcPath)
+            );
+            CliRuntimeOptions shadowedRuntime = runtimeOptions with
+            {
+                YarnPhase13Options = new YarnPhase13VerticalSliceOptions
+                {
+                    WorkspaceDirectoryPath = stateDirectory,
+                    UserHomeDirectoryPath = alternateHomePath,
+                    UserYarnrcPath = alternateYarnrcPath,
+                    EnvironmentVariableReader = name =>
+                        string.Equals(name, "HOME", StringComparison.Ordinal)
+                            ? alternateHomePath
+                            : null,
+                },
+                ConfigurationPhase14Options = runtimeOptions.ConfigurationPhase14Options! with
+                {
+                    EnvironmentVariableReader = name =>
+                        string.Equals(name, "HOME", StringComparison.Ordinal)
+                            ? alternateHomePath
+                            : ReadConfigurationEnvironment(stateDirectory, name),
+                },
+            };
+
+            CommandResult status = InvokeWithRuntime(shadowedRuntime, "status");
+            CommandResult doctor = InvokeWithRuntime(shadowedRuntime, "doctor");
+
+            Assert.Contains("ecosystem-yarn-configurable: no\n", status.StdOut);
+            Assert.Contains("ecosystem-yarn-currently-usable: blocked\n", status.StdOut);
+            Assert.Contains("yarn-user-configuration-plan: pass\n", doctor.StdOut);
+            Assert.Contains("yarn-user-configure-operation: fail\n", doctor.StdOut);
+            Assert.Contains("ecosystem-yarn-configurable: no\n", doctor.StdOut);
+            Assert.Contains("ecosystem-yarn-currently-usable: blocked\n", doctor.StdOut);
+            Assert.Contains(
+                "yarn-user-remediation: manual action required: reconcile the owned target "
+                    + "with the resolved configuration path, then rerun doctor before "
+                    + "configure or refresh\n",
+                doctor.StdOut
+            );
+            Assert.DoesNotContain(
+                "yarn-user-remediation: azureauth-credprovider configure",
+                doctor.StdOut,
+                StringComparison.Ordinal
+            );
         }
         finally
         {
@@ -5027,22 +5331,39 @@ public sealed class CliApplicationTests
         bool useHttpPathPresent = devAzureUseHttpPathPresent ?? ownedGitEntriesPresent;
         bool localShellSuccess = localShellHelperShorthandSuccess ?? ownedGitEntriesPresent;
         bool effectiveProductHelperActive = productHelperActive ?? ownedGitEntriesPresent;
+        bool gitAbsent =
+            !ownedGitEntriesPresent
+            && !ownershipManifestPresent
+            && !useHttpPathPresent
+            && !effectiveProductHelperActive;
+        bool gitStructurallyReady =
+            configurationPlanValid
+            && ownedGitEntriesPresent
+            && ownershipManifestPresent
+            && useHttpPathPresent
+            && localShellSuccess
+            && effectiveProductHelperActive;
         return Normalize(
             string.Join(
                 "\n",
                 [
                     "command: doctor",
                     "phase: 15-end-to-end-hardening",
+                    "capability-schema: azureauth-credprovider-capabilities-v1",
                     "composition-mode: TestScaffold",
                     "provider: DirectMsal",
                     "interactive-readiness: unavailable",
                     "interactive-readiness-code: TestScaffold",
                     "interactive-blocker: Explicit deterministic test scaffold; "
                         + "not production-ready.",
-                    "silent-readiness: silent-unavailable",
-                    "silent-readiness-code: TestScaffold",
-                    "silent-remediation: Explicit deterministic test scaffold; "
+                    "silent-only-readiness: silent-unavailable",
+                    "silent-only-readiness-code: TestScaffold",
+                    "silent-only-remediation: Explicit deterministic test scaffold; "
                         + "not production-ready.",
+                    "interactive-mechanism: unavailable",
+                    "silent-only-mechanism: unavailable",
+                    "live-auth-probing: git-doctor-silent-only",
+                    "live-feed-probing: disabled",
                     "azureauth-version-probe: not-required",
                     "azureauth-version-probe-code: AzureAuthVersionProbeNotRequired",
                     $"configuration-plan: {(configurationPlanValid ? "pass" : "fail")}",
@@ -5076,6 +5397,25 @@ public sealed class CliApplicationTests
                     "auth-pat-compatibility: deferred-disabled",
                     "auth-persistent-derived-credentials: disabled",
                     "auth-product-plaintext-fallback: disabled",
+                    $"ecosystem-git-configurable: {(configurationPlanValid ? "yes" : "no")}",
+                    "ecosystem-git-currently-usable: "
+                        + (
+                            gitAbsent
+                                ? "not-configured"
+                                : gitStructurallyReady
+                                    ? "ready-local-evidence"
+                                    : "blocked"
+                        ),
+                    "ecosystem-nuget-configurable: yes",
+                    "ecosystem-nuget-currently-usable: not-configured",
+                    "ecosystem-python-configurable: no",
+                    "ecosystem-python-currently-usable: not-configured",
+                    "ecosystem-npm-configurable: yes",
+                    "ecosystem-npm-currently-usable: not-configured",
+                    "ecosystem-pnpm-configurable: yes",
+                    "ecosystem-pnpm-currently-usable: not-configured",
+                    "ecosystem-yarn-configurable: yes",
+                    "ecosystem-yarn-currently-usable: not-configured",
                     "nuget-configuration-plan: pass",
                     "nuget-configuration-state: valid",
                     "nuget-plugin-layout-marker: absent",
@@ -5125,23 +5465,31 @@ public sealed class CliApplicationTests
                         + "phase-1.4-accepted; writes-supported-by-phase-13b",
                     "configuration-aggregation: pass",
                     "npm-user-configuration-plan: pass",
+                    "npm-user-configure-operation: pass",
                     "npm-user-owned-targets: absent",
+                    "npm-user-owned-target-matches-resolved-path: no",
                     "npm-user-ownership-manifest: absent",
                     "npm-user-lifecycle: missing",
                     "npm-user-remediation: azureauth-credprovider configure npm --registry-url "
                         + "<azure-artifacts-npm-registry-url>",
                     "pnpm-user-configuration-plan: pass",
+                    "pnpm-user-configure-operation: pass",
                     "pnpm-user-owned-targets: absent",
+                    "pnpm-user-owned-target-matches-resolved-path: no",
                     "pnpm-user-ownership-manifest: absent",
                     "pnpm-user-lifecycle: missing",
                     "pnpm-user-remediation: azureauth-credprovider configure pnpm --registry-url "
                         + "<azure-artifacts-npm-registry-url>",
                     "python-user-configuration-plan: pass",
+                    "python-user-configure-operation: pass",
                     "python-user-owned-targets: absent",
+                    "python-user-owned-target-matches-resolved-path: no",
                     "python-user-ownership-manifest: absent",
                     "python-user-remediation: azureauth-credprovider configure python",
                     "yarn-user-configuration-plan: pass",
+                    "yarn-user-configure-operation: pass",
                     "yarn-user-owned-targets: absent",
+                    "yarn-user-owned-target-matches-resolved-path: no",
                     "yarn-user-ownership-manifest: absent",
                     "yarn-user-lifecycle: missing",
                     "yarn-user-remediation: azureauth-credprovider configure yarn --registry-url "
@@ -5167,6 +5515,31 @@ public sealed class CliApplicationTests
     private static CommandResult Invoke(params string[] args)
     {
         return InvokeWithRuntime(runtimeOptions: null, args: args);
+    }
+
+    private static CommandResult InvokeIsolatedStatus(params string[] args)
+    {
+        string stateDirectory = CreateTestDirectory();
+        try
+        {
+            var runtimeOptions = new CliRuntimeOptions
+            {
+                CompositionRootFactory = () =>
+                    CredentialProviderCompositionRoot.CreateProduction(
+                        new CredentialProviderProductionOptions
+                        {
+                            SecureStoreRootPath = stateDirectory,
+                            EnvironmentVariableReader = _ => null,
+                        }
+                    ),
+                ConfigurationPhase14Options = CreateConfigurationPhase14Options(stateDirectory),
+            };
+            return InvokeWithRuntime(runtimeOptions, args);
+        }
+        finally
+        {
+            DeleteDirectoryIfExists(stateDirectory);
+        }
     }
 
     private static CommandResult InvokeWithRuntime(
@@ -5230,6 +5603,7 @@ public sealed class CliApplicationTests
                 AzurePipelinesJobScopeId = "cli-test-job",
                 EnvironmentVariableReader = name =>
                     ReadConfigurationEnvironment(stateDirectoryPath, name),
+                ProductExecutablePath = GetTestProductExecutablePath(),
                 RegistryUrls = CreateTestRegistryUrls(),
             },
         };
@@ -5247,6 +5621,7 @@ public sealed class CliApplicationTests
                 AzurePipelinesJobScopeId = "cli-test-job",
                 EnvironmentVariableReader = name =>
                     ReadConfigurationEnvironment(stateDirectoryPath, name),
+                ProductExecutablePath = GetTestProductExecutablePath(),
             },
         };
 
@@ -5266,6 +5641,7 @@ public sealed class CliApplicationTests
                     string.Equals(name, "SYSTEM_ACCESSTOKEN", StringComparison.Ordinal)
                         ? token
                         : ReadConfigurationEnvironment(stateDirectoryPath, name),
+                ProductExecutablePath = GetTestProductExecutablePath(),
                 RegistryUrls = CreateTestRegistryUrls(),
             },
         };
@@ -6381,7 +6757,17 @@ public sealed class CliApplicationTests
                 StringComparison.Ordinal
             );
             Assert.Contains(
-                "silent-readiness: silent-ready\n",
+                "silent-only-readiness: silent-ready\n",
+                result.StdOut,
+                StringComparison.Ordinal
+            );
+            Assert.Contains(
+                "interactive-mechanism: native-linux-web\n",
+                result.StdOut,
+                StringComparison.Ordinal
+            );
+            Assert.Contains(
+                "silent-only-mechanism: native-linux-cache-only\n",
                 result.StdOut,
                 StringComparison.Ordinal
             );
@@ -6452,7 +6838,18 @@ public sealed class CliApplicationTests
             );
             Assert.Equal(string.Empty, result.StdErr);
             Assert.Equal(0, runner.InvocationCount);
-            if (!installationReady)
+            if (
+                installationReady
+                && hostPlatform is AzureAuthHostPlatform.Windows or AzureAuthHostPlatform.Wsl
+            )
+            {
+                Assert.Contains(
+                    "interactive-mechanism: windows-wam-then-web\n",
+                    result.StdOut,
+                    StringComparison.Ordinal
+                );
+            }
+            else if (!installationReady)
             {
                 Assert.Contains(
                     "interactive-readiness: interactive-unavailable\n",
@@ -6846,22 +7243,66 @@ public sealed class CliApplicationTests
             gitDiscoveryRunner.ExpectedHelperCommand = OperatingSystem.IsWindows()
                 ? expectedHelperCommand.Replace('\\', '/')
                 : expectedHelperCommand;
+            ConfigurationPhase14VerticalSliceOptions configurationOptions =
+                CreateConfigurationPhase14Options(rootPath) with
+                {
+                    EnvironmentVariableReader = name =>
+                        name switch
+                        {
+                            "HOME" => rootPath,
+                            "NPM_CONFIG_USERCONFIG" => Path.Combine(rootPath, "user.npmrc"),
+                            "XDG_CONFIG_HOME" => Path.Combine(rootPath, ".config"),
+                            _ => ReadConfigurationPhase14Environment(rootPath, name),
+                        },
+                };
+            ConfigurationPhase14ResolvedPaths configurationPaths =
+                new ConfigurationPhase14VerticalSliceService(configurationOptions).Paths;
             var runtime = new CliRuntimeOptions
             {
                 CompositionRoot = root,
                 GitPhase8Options = gitOptions,
                 NuGetPhase10Options = CreateIsolatedNuGetPhase10Options(),
-                NpmPhase12Options = CreateIsolatedNpmPhase12Options(rootPath),
-                YarnPhase13Options = CreateIsolatedYarnPhase13Options(rootPath),
+                NpmPhase12Options = CreateIsolatedNpmPhase12Options(rootPath) with
+                {
+                    UserNpmrcPath = configurationPaths.PnpmUserNpmrcPath,
+                },
+                YarnPhase13Options = CreateIsolatedYarnPhase13Options(rootPath) with
+                {
+                    UserHomeDirectoryPath = rootPath,
+                    UserYarnrcPath = configurationPaths.YarnUserYarnrcPath,
+                },
                 PythonPhase11Options = pythonFixture.Options,
-                ConfigurationPhase14Options = CreateConfigurationPhase14Options(rootPath),
+                ConfigurationPhase14Options = configurationOptions,
             };
             CommandResult configureGit = InvokeWithRuntime(runtime, "configure", "git");
+            CommandResult configurePython = InvokeWithRuntime(
+                runtime,
+                "configure",
+                "python"
+            );
+            CommandResult configurePnpm = InvokeWithRuntime(
+                runtime,
+                "configure",
+                "pnpm",
+                "--registry-url",
+                TestRegistryUrl
+            );
+            CommandResult configureYarn = InvokeWithRuntime(
+                runtime,
+                "configure",
+                "yarn",
+                "--registry-url",
+                TestRegistryUrl
+            );
+            acquisitionService.Requests.Clear();
 
             CommandResult doctor = InvokeWithRuntime(runtime, "doctor");
 
             Assert.Equal(0, configureGit.ExitCode);
             Assert.Equal(string.Empty, configureGit.StdErr);
+            Assert.Equal(0, configurePython.ExitCode);
+            Assert.Equal(0, configurePnpm.ExitCode);
+            Assert.Equal(0, configureYarn.ExitCode);
             Assert.Equal(0, doctor.ExitCode);
             Assert.True(pythonFixture.PathWasRequested);
             Assert.Contains(
@@ -6875,7 +7316,22 @@ public sealed class CliApplicationTests
                 StringComparison.Ordinal
             );
             Assert.Contains(
-                "silent-readiness: silent-ready\n",
+                "silent-only-readiness: silent-ready\n",
+                doctor.StdOut,
+                StringComparison.Ordinal
+            );
+            Assert.Contains(
+                "live-feed-probing: disabled\n",
+                doctor.StdOut,
+                StringComparison.Ordinal
+            );
+            Assert.Contains(
+                "ecosystem-git-currently-usable: ready-local-evidence\n",
+                doctor.StdOut,
+                StringComparison.Ordinal
+            );
+            Assert.Contains(
+                "ecosystem-nuget-currently-usable: not-configured\n",
                 doctor.StdOut,
                 StringComparison.Ordinal
             );
@@ -6997,6 +7453,18 @@ public sealed class CliApplicationTests
                 doctor.StdOut,
                 StringComparison.Ordinal
             );
+            Assert.Contains(
+                "ecosystem-python-currently-usable: ready-local-evidence\n",
+                doctor.StdOut
+            );
+            Assert.Contains(
+                "ecosystem-pnpm-currently-usable: ready-local-evidence\n",
+                doctor.StdOut
+            );
+            Assert.Contains(
+                "ecosystem-yarn-currently-usable: ready-local-evidence\n",
+                doctor.StdOut
+            );
             Assert.Equal(string.Empty, doctor.StdErr);
             Assert.Equal(1, authenticationRunner.InvocationCount);
             ProcessStartSpec healthProbe = Assert.Single(authenticationRunner.StartSpecs);
@@ -7006,10 +7474,15 @@ public sealed class CliApplicationTests
             Assert.Equal(TimeSpan.FromSeconds(10), healthProbe.Timeout);
             Assert.Empty(healthProbe.Environment);
             Assert.Null(healthProbe.StandardErrorTee);
-            Assert.NotEmpty(acquisitionService.Requests);
+            Assert.Equal(2, acquisitionService.Requests.Count);
             Assert.All(
                 acquisitionService.Requests,
-                request => Assert.NotEqual(InteractivePolicy.UserAllowed, request.InteractivePolicy)
+                request =>
+                {
+                    Assert.Equal(CredentialEcosystem.Git, request.Ecosystem);
+                    Assert.Equal(AcquisitionMode.SilentOnly, request.AcquisitionMode);
+                    Assert.Equal(InteractivePolicy.Never, request.InteractivePolicy);
+                }
             );
             Assert.Equal(2, gitDiscoveryRunner.StartSpecs.Count);
             ProcessStartSpec gitDiscovery = gitDiscoveryRunner.StartSpecs[0];
@@ -7025,8 +7498,53 @@ public sealed class CliApplicationTests
                 ],
                 gitDiscovery.Arguments
             );
+            Assert.Equal(rootPath, gitDiscovery.WorkingDirectory);
+            Assert.Equal(TimeSpan.FromSeconds(10), gitDiscovery.Timeout);
+            Assert.Equal(
+                64 * 1024,
+                gitDiscovery.OutputCaptureOptions.StandardOutputByteLimit
+            );
+            Assert.Equal(
+                64 * 1024,
+                gitDiscovery.OutputCaptureOptions.StandardErrorByteLimit
+            );
             Assert.False(gitDiscovery.Environment.ContainsKey("GIT_CONFIG_GLOBAL"));
             Assert.Null(gitDiscovery.StandardErrorTee);
+            ProcessStartSpec useHttpPathProbe = gitDiscoveryRunner.StartSpecs[1];
+            Assert.Equal("fake-git", useHttpPathProbe.FileName);
+            Assert.Equal(
+                [
+                    "-c",
+                    "credential.helper=",
+                    "-c",
+                    "credential.helper=!f() { p=absent; while IFS= read -r line; do "
+                        + "case \"$line\" in path=*) p=present;; esac; done; "
+                        + "echo username=azureauth-use-http-path-$p; "
+                        + "echo password=azureauth-use-http-path-probe; }; f",
+                    "credential",
+                    "fill",
+                ],
+                useHttpPathProbe.Arguments
+            );
+            Assert.Equal(rootPath, useHttpPathProbe.WorkingDirectory);
+            Assert.Equal(
+                "protocol=https\nhost=dev.azure.com\npath=org/project/_git/repository\n\n",
+                useHttpPathProbe.StandardInput
+            );
+            Assert.Equal(TimeSpan.FromSeconds(10), useHttpPathProbe.Timeout);
+            Assert.Equal(
+                64 * 1024,
+                useHttpPathProbe.OutputCaptureOptions.StandardOutputByteLimit
+            );
+            Assert.Equal(
+                64 * 1024,
+                useHttpPathProbe.OutputCaptureOptions.StandardErrorByteLimit
+            );
+            Assert.Equal(
+                ["HOME", "XDG_CONFIG_HOME"],
+                useHttpPathProbe.Environment.Keys.Order(StringComparer.Ordinal)
+            );
+            Assert.Null(useHttpPathProbe.StandardErrorTee);
             Assert.Equal(string.Empty, promptWriter.ToString());
             Assert.DoesNotContain(PrivateToken, doctor.StdOut, StringComparison.Ordinal);
             Assert.DoesNotContain(PrivateToken, doctor.StdErr, StringComparison.Ordinal);
@@ -7084,6 +7602,13 @@ public sealed class CliApplicationTests
                         request.Ecosystem == CredentialEcosystem.NuGet
                             ? "opaque-session-token-healthy-doctor"
                             : "fake-secret-healthy-doctor",
+                    BearerToken =
+                        request.Ecosystem
+                            is CredentialEcosystem.Npm
+                                or CredentialEcosystem.Pnpm
+                                or CredentialEcosystem.Yarn
+                            ? "fake-bearer-token-healthy-doctor"
+                            : null,
                     Account = request.AccountHint ?? "unbound",
                     Tenant = request.TenantHint ?? "unbound",
                     DiagnosticsCorrelationId = "healthy-doctor-success",
@@ -7139,7 +7664,58 @@ public sealed class CliApplicationTests
         Assert.Equal(1, doctor.ExitCode);
         AssertDoctorCheck(doctor.StdOut, "npm-ci-temporary-credential-plan", "fail");
         AssertDoctorCheck(doctor.StdOut, "yarn-forbidden-auth-ident-conflict", "present");
+        AssertDoctorCheck(doctor.StdOut, "ecosystem-yarn-configurable", "no");
         AssertDoctorCheck(doctor.StdOut, "doctor-aggregation", "fail");
+    }
+
+    [Fact]
+    public async Task PythonUnownedTargetBlocksStatusAndDoctorConfigurability()
+    {
+        using var pythonFixture = new PythonDoctorFixture(PythonDoctorFixtureMode.Healthy);
+        CliRuntimeOptions baseline = CreateHealthyDoctorRuntimeOptions(pythonFixture);
+        ConfigurationPhase14VerticalSliceOptions configurationOptions =
+            baseline.ConfigurationPhase14Options! with
+            {
+                EnvironmentVariableReader = name =>
+                    name switch
+                    {
+                        "HOME" => pythonFixture.RootPath,
+                        "XDG_CONFIG_HOME" => Path.Combine(
+                            pythonFixture.RootPath,
+                            "configuration-home"
+                        ),
+                        _ => ReadConfigurationPhase14Environment(
+                            pythonFixture.RootPath,
+                            name
+                        ),
+                    },
+            };
+        var service = new ConfigurationPhase14VerticalSliceService(configurationOptions);
+        ConfigurationPhase14PlanResult preview = await service.DryRunConfigureAsync(
+            CredentialEcosystem.Python,
+            ConfigurationPhase14Scope.User,
+            TestContext.Current.CancellationToken
+        );
+        var backend = Assert.Single(
+            preview.PlanResults.SelectMany(static result => result.Changes),
+            change => change.TargetKind == ConfigurationTargetKind.PythonKeyringBackend
+        );
+        Directory.CreateDirectory(Path.GetDirectoryName(backend.TargetPathOrName)!);
+        File.WriteAllText(backend.TargetPathOrName, "unowned-python-backend");
+        CliRuntimeOptions runtime = baseline with
+        {
+            ConfigurationPhase14Options = configurationOptions,
+        };
+
+        CommandResult status = InvokeWithRuntime(runtime, "status");
+        CommandResult doctor = InvokeWithRuntime(runtime, "doctor");
+
+        Assert.Contains("ecosystem-python-configurable: no\n", status.StdOut);
+        Assert.Contains("ecosystem-python-currently-usable: blocked\n", status.StdOut);
+        AssertDoctorCheck(doctor.StdOut, "python-user-configuration-plan", "pass");
+        AssertDoctorCheck(doctor.StdOut, "python-user-configure-operation", "fail");
+        AssertDoctorCheck(doctor.StdOut, "ecosystem-python-configurable", "no");
+        AssertDoctorCheck(doctor.StdOut, "ecosystem-python-currently-usable", "blocked");
     }
 
     private static void AssertDoctorAzureAuthProbeFailure(

--- a/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform.Tests/ConfigurationPhase14VerticalSliceServiceTests.cs
+++ b/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform.Tests/ConfigurationPhase14VerticalSliceServiceTests.cs
@@ -411,9 +411,27 @@ public sealed class ConfigurationPhase14VerticalSliceServiceTests
             fileSystem,
             environmentVariableReader: CreatePackagePathEnvironmentReader(ecosystem, "new")
         );
+        ConfigurationPhase14VerticalSliceService doctorService = CreateService(
+            fileSystem,
+            environmentVariableReader: CreatePackagePathEnvironmentReader(ecosystem, "new"),
+            includeRegistryUrls: false
+        );
         string destinationPath = GetPackageConfigurationPath(replacement, ecosystem);
         fileSystem.CreateDirectory(Path.GetDirectoryName(destinationPath)!);
         fileSystem.WriteAllText(destinationPath, oldContents);
+
+        ConfigurationPhase14DoctorResult doctor = await doctorService.DoctorAsync(
+            TestContext.Current.CancellationToken
+        );
+        ConfigurationPhase14EcosystemDoctorResult ecosystemDoctor = Assert.Single(
+            doctor.Ecosystems,
+            result =>
+                result.Ecosystem == ecosystem
+                && result.Scope == ConfigurationPhase14Scope.User
+        );
+        Assert.False(ecosystemDoctor.ConfigureOperationValid);
+        Assert.True(ecosystemDoctor.OwnedTargetPresent);
+        Assert.False(ecosystemDoctor.OwnedTargetMatchesResolvedPath);
 
         InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(
             async () =>
@@ -432,6 +450,118 @@ public sealed class ConfigurationPhase14VerticalSliceServiceTests
         Assert.Equal(oldContents, fileSystem.ReadAllText(oldPath));
         Assert.Equal(manifestContents, fileSystem.ReadAllText(manifestPath));
         Assert.Equal(oldContents, fileSystem.ReadAllText(destinationPath));
+    }
+
+    [Fact]
+    public async Task DoctorTreatsCleanPackageAbsenceWithoutRegistryContextAsNeutral()
+    {
+        var fileSystem = new InMemoryFileSystem(InMemoryPathSemantics.Posix);
+        ConfigurationPhase14VerticalSliceService service = CreateService(
+            fileSystem,
+            includeRegistryUrls: false
+        );
+
+        ConfigurationPhase14DoctorResult doctor = await service.DoctorAsync(
+            TestContext.Current.CancellationToken
+        );
+
+        ConfigurationPhase14EcosystemDoctorResult[] packageResults = doctor
+            .Ecosystems.Where(result =>
+                result.Scope == ConfigurationPhase14Scope.User
+                && result.Ecosystem
+                    is CredentialEcosystem.Npm
+                        or CredentialEcosystem.Pnpm
+                        or CredentialEcosystem.Yarn
+            )
+            .ToArray();
+        Assert.Equal(3, packageResults.Length);
+        Assert.All(
+            packageResults,
+            result =>
+            {
+                Assert.True(result.ConfigurationPlanValid);
+                Assert.True(result.ConfigureOperationValid);
+                Assert.False(result.OwnershipManifestPresent);
+                Assert.False(result.OwnedTargetPresent);
+            }
+        );
+    }
+
+    [Theory]
+    [InlineData(CredentialEcosystem.Npm)]
+    [InlineData(CredentialEcosystem.Pnpm)]
+    [InlineData(CredentialEcosystem.Yarn)]
+    public async Task DoctorUsesPersistedRegistryWithoutConfiguredRegistryUrls(
+        CredentialEcosystem ecosystem
+    )
+    {
+        var fileSystem = new InMemoryFileSystem(InMemoryPathSemantics.Posix);
+        await CreateService(fileSystem)
+            .ConfigureAsync(
+                ecosystem,
+                ConfigurationPhase14Scope.User,
+                TestContext.Current.CancellationToken
+            );
+        ConfigurationPhase14VerticalSliceService doctorService = CreateService(
+            fileSystem,
+            includeRegistryUrls: false
+        );
+
+        ConfigurationPhase14DoctorResult doctor = await doctorService.DoctorAsync(
+            TestContext.Current.CancellationToken
+        );
+
+        ConfigurationPhase14EcosystemDoctorResult result = Assert.Single(
+            doctor.Ecosystems,
+            item =>
+                item.Ecosystem == ecosystem
+                && item.Scope == ConfigurationPhase14Scope.User
+        );
+        Assert.Equal(new Uri(TestRegistryUrl), result.RegistryUrl);
+        Assert.True(result.ConfigurationPlanValid);
+        Assert.True(result.ConfigureOperationValid);
+        Assert.True(result.OwnershipManifestPresent);
+        Assert.True(result.OwnedTargetPresent);
+        Assert.True(result.OwnedTargetMatchesResolvedPath);
+    }
+
+    [Theory]
+    [InlineData(ConfigurationTargetKind.PythonKeyringBackend)]
+    [InlineData(ConfigurationTargetKind.KeyringShim)]
+    public async Task PythonDoctorRejectsUnownedConfigureTarget(
+        ConfigurationTargetKind targetKind
+    )
+    {
+        var fileSystem = new InMemoryFileSystem(InMemoryPathSemantics.Posix);
+        ConfigurationPhase14VerticalSliceService service = CreateService(fileSystem);
+        ConfigurationPhase14PlanResult preview = await service.DryRunConfigureAsync(
+            CredentialEcosystem.Python,
+            ConfigurationPhase14Scope.User,
+            TestContext.Current.CancellationToken
+        );
+        ConfigurationPlannedChange target = Assert.Single(
+            preview.PlanResults.SelectMany(static result => result.Changes),
+            change => change.TargetKind == targetKind
+        );
+        fileSystem.CreateDirectory(Path.GetDirectoryName(target.TargetPathOrName)!);
+        fileSystem.WriteAllText(target.TargetPathOrName, "unowned-python-target");
+
+        ConfigurationPhase14DoctorResult doctor = await service.DoctorAsync(
+            TestContext.Current.CancellationToken
+        );
+
+        ConfigurationPhase14EcosystemDoctorResult python = GetPythonDoctorResult(doctor);
+        Assert.True(python.ConfigurationPlanValid);
+        Assert.False(python.ConfigureOperationValid);
+        Assert.False(python.OwnershipManifestPresent);
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            async () =>
+                await service.DryRunConfigureAsync(
+                    CredentialEcosystem.Python,
+                    ConfigurationPhase14Scope.User,
+                    TestContext.Current.CancellationToken
+                )
+        );
     }
 
     [Theory]
@@ -4218,7 +4348,8 @@ public sealed class ConfigurationPhase14VerticalSliceServiceTests
         Uri? registryUrl = null,
         ICredentialAcquisitionService? credentialAcquisition = null,
         string? workspaceDirectoryPath = null,
-        string? ciTemporaryProductRootPath = null
+        string? ciTemporaryProductRootPath = null,
+        bool includeRegistryUrls = true
     ) =>
         new(
             new ConfigurationPhase14VerticalSliceOptions
@@ -4244,12 +4375,14 @@ public sealed class ConfigurationPhase14VerticalSliceServiceTests
                 ProductExecutablePath = GetTestProductExecutablePath(fileSystem),
                 WorkspaceDirectoryPath = workspaceDirectoryPath,
                 TimeProvider = timeProvider,
-                RegistryUrls = new Dictionary<CredentialEcosystem, Uri>
-                {
-                    [CredentialEcosystem.Npm] = registryUrl ?? new(TestRegistryUrl),
-                    [CredentialEcosystem.Pnpm] = registryUrl ?? new(TestRegistryUrl),
-                    [CredentialEcosystem.Yarn] = registryUrl ?? new(TestRegistryUrl),
-                },
+                RegistryUrls = includeRegistryUrls
+                    ? new Dictionary<CredentialEcosystem, Uri>
+                    {
+                        [CredentialEcosystem.Npm] = registryUrl ?? new(TestRegistryUrl),
+                        [CredentialEcosystem.Pnpm] = registryUrl ?? new(TestRegistryUrl),
+                        [CredentialEcosystem.Yarn] = registryUrl ?? new(TestRegistryUrl),
+                    }
+                    : null,
             }
         );
 

--- a/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform.Tests/CredentialProviderCompositionRootWp6Tests.cs
+++ b/tests/private/app/azureauth-credprovider/Hcoona.AzureAuth.CredProvider.Platform.Tests/CredentialProviderCompositionRootWp6Tests.cs
@@ -75,8 +75,28 @@ public sealed class CredentialProviderCompositionRootWp6Tests
 
             Assert.True(root.Readiness.Interactive.IsReady);
             Assert.True(root.Readiness.IsReady);
+            Assert.Contains(
+                "Web Account Manager (WAM)-first",
+                root.Readiness.Interactive.SafeMessage,
+                StringComparison.Ordinal
+            );
+            Assert.Contains(
+                "may prompt",
+                root.Readiness.Interactive.SafeMessage,
+                StringComparison.Ordinal
+            );
             Assert.False(root.Readiness.Silent.IsReady);
             Assert.Equal("SilentAcquisitionUnavailable", root.Readiness.Silent.Code);
+            Assert.Contains(
+                "WAM cache may satisfy an interaction-allowed request",
+                root.Readiness.Silent.SafeMessage,
+                StringComparison.Ordinal
+            );
+            Assert.Contains(
+                "silent-only readiness is unavailable",
+                root.Readiness.Silent.SafeMessage,
+                StringComparison.Ordinal
+            );
             Assert.Equal(1, discovery.CallCount);
             _ = root.GetReadiness(TestContext.Current.CancellationToken);
             _ = root.RunProviderDoctor(TestContext.Current.CancellationToken);
@@ -122,6 +142,10 @@ public sealed class CredentialProviderCompositionRootWp6Tests
                 );
 
             Assert.True(root.Readiness.Interactive.IsReady);
+            Assert.Equal(
+                "AzureAuth native Linux interaction-allowed acquisition is ready.",
+                root.Readiness.Interactive.SafeMessage
+            );
             Assert.True(root.Readiness.Silent.IsReady);
             Assert.Equal("AzureAuthSilentReady", root.Readiness.Silent.Code);
         }


### PR DESCRIPTION
## Summary

- replace blanket ecosystem support claims with conservative per-ecosystem `configurable` and `currently-usable` assessments
- distinguish WAM-first interaction-allowed acquisition from true silent-only readiness on Windows, WSL, and native Linux
- validate package and Python configure applicability through bounded, non-mutating local previews while preserving clean absence and persisted registry context
- disclose existing Git silent-only probes, avoid remote feed claims, and provide failure-specific remediation

## Validation

- CLI tests: 351 passed
- Platform tests: 1,447 passed, 2 skipped
- `hk check --unstaged --check --no-progress`
- terminal OCR: UX, architecture, and test reviewers returned no findings